### PR TITLE
doc: Adds documentation abstracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automerge-swifter
 
-An automerge implementation for swift.
+An Automerge implementation for swift.
 
 This is a reasonably low-level library with relatively few concessions to ergonomics, nicer APIs should be built on top of this work.
 
@@ -30,7 +30,7 @@ let package = Package(
 )
 ```
 
-Now you can create a document and do all sorts of automerge things with it
+Now you can create a document and do all sorts of Automerge things with it
 
 ```swift
 let doc = Document()
@@ -61,7 +61,7 @@ The moving parts here then are:
 
 * The `rust/src/automerge.udl` file which describes the FFI interface
 * The `rust/build.rs` build script, which uses Uniffi to generate the boilerplate parts of the rust side of the interface
-* The `rust/src/*`files which implement the automerge specific parts of the rust binding
+* The `rust/src/*`files which implement the Automerge specific parts of the rust binding
 * The `rust/uniffi-bindgen.rs` script, which uses Uniffi to output a Swift wrapper around the interface
 * The source files in `./Sources` and `./Tests` which implement the handwritten swift wrappers
 * The `./scripts/build-xcframework.sh` script, which builds the rust project and packages it into an XCFramework

--- a/Sources/Automerge/Automerge.docc/AddressBookExample.md
+++ b/Sources/Automerge/Automerge.docc/AddressBookExample.md
@@ -1,6 +1,6 @@
 # Address Book Example
 
-Building a CLI address book application using automerge. 
+Building a CLI address book application using Automerge. 
 
 ## Overview
 
@@ -102,19 +102,19 @@ func sync(server: String) {
 
 ## Creating the address book 
 
-To create an address book we just need to create an automerge document with an empty `contacts` array in it. This is conceptually simple but there's a wrinkle, which we refer to as the "initial data" problem. Once we've explained the problem, the approach we take will make more sense.
+To create an address book we just need to create an Automerge document with an empty `contacts` array in it. This is conceptually simple but there's a wrinkle, which we refer to as the "initial data" problem. Once we've explained the problem, the approach we take will make more sense.
 
 ### The "initial data" problem
 
-Automerge documents contain "objects", which are maps, lists, or text objects. These objects have an ID (``ObjId``). Every automerge document contains a "root" ID (``ObjId/ROOT``)which is a map, any time you create a new object in an automerge document the new object has an ID you use to refer to it. The reason you need to know this is because the IDs which automerge generates are used to determine how to merge documents, this means that for two documents with similar structure to merge in the way we expect, they need to share a history. 
+Automerge documents contain "objects", which are maps, lists, or text objects. These objects have an ID (``ObjId``). Every Automerge document contains a "root" ID (``ObjId/ROOT``)which is a map, any time you create a new object in an Automerge document the new object has an ID you use to refer to it. The reason you need to know this is because the IDs which Automerge generates are used to determine how to merge documents, this means that for two documents with similar structure to merge in the way we expect, they need to share a history. 
 
-Let's make this a bit more concrete. We are building a contact book application, the core data structure is a list of contacts under the `contacts` key in the document. The merge behaviour we want is that when two nodes concurrently add contacts to the contact book, they end up in the same sequence. In terms of the automerge data model then, the `contacts` key is a property in the root object which contains a list object. The list has an ID - obtained by calling ``Document/putObject(obj:key:ty:)`` with ``ObjId/ROOT``, `"contacts"`, and ``ObjType/List``. For concurrent insertions into this list to merge, we want all insertions to reference the same ``ObjId`` for the list, but every time you call `putObject` you get a new object ID. What this means is that every node needs to share a basic skeleton document which already has an empty `"contacts"` list in it.
+Let's make this a bit more concrete. We are building a contact book application, the core data structure is a list of contacts under the `contacts` key in the document. The merge behaviour we want is that when two nodes concurrently add contacts to the contact book, they end up in the same sequence. In terms of the Automerge data model then, the `contacts` key is a property in the root object which contains a list object. The list has an ID - obtained by calling ``Document/putObject(obj:key:ty:)`` with ``ObjId/ROOT``, `"contacts"`, and ``ObjType/List``. For concurrent insertions into this list to merge, we want all insertions to reference the same ``ObjId`` for the list, but every time you call `putObject` you get a new object ID. What this means is that every node needs to share a basic skeleton document which already has an empty `"contacts"` list in it.
 
 > Note: We are very much aware that this is not a good developer experience and we are thinking about ways to make this easier. See [this issue](https://github.com/automerge/automerge/issues/528)
 
 ### Generating a skeleton document
 
-The easiest way to have every peer start from a shared history is to use the automerge command line tools (installable by using `cargo install automerge-cli`) to generate an automerge document from a JSON skeleton, and then including the bytes of this document as a resource in the application bundle.
+The easiest way to have every peer start from a shared history is to use the Automerge command line tools (installable by using `cargo install automerge-cli`) to generate an Automerge document from a JSON skeleton, and then including the bytes of this document as a resource in the application bundle.
 
 ```
 # generate the skeleton  document

--- a/Sources/Automerge/Automerge.docc/Automerge.md
+++ b/Sources/Automerge/Automerge.docc/Automerge.md
@@ -2,9 +2,12 @@
 
 A library which provides fast implementations of several different CRDTs, a compact compression format for these CRDTs, and a sync protocol for efficiently transmitting those changes over the network.
 
-The central data type of automerge is a ``Document`` which presents a data model somewhat similar to JSON, with string keyed maps and sequences which can be nested within one another. Unlike JSON a ``Document`` is a CRDT which means it can be merged with any other ``Document`` in a manner which preserves user intent as much as possible. This means that when you have multiple users (or even just multiple devices for one user) working on the same data you can synchronise their changes without necessarily needing a central server.
+The central data type of Automerge is a ``Document`` which presents a data model somewhat similar to JSON, with string keyed maps and sequences which can be nested within one another. 
+Unlike JSON a ``Document`` is a CRDT which means it can be merged with any other ``Document`` in a manner which preserves user intent as much as possible. 
+This means that when you have multiple users (or even just multiple devices for one user) working on the same data you can synchronise their changes without necessarily needing a central server.
 
-Being able to merge changes is not much use without some way to transfer changes to other peers. You can send the entire document to other devices (and this will be compact and often a good workflow), but automerge also provides a sync protocol for efficiently getting in sync and staying in sync, which may be more appropriate for real-time collaborative applications and/or applications with very large data sets.
+Being able to merge changes is not much use without some way to transfer changes to other peers. 
+You can send the entire document to other devices (and this will be compact and often a good workflow), but Automerge also provides a sync protocol for efficiently getting in sync and staying in sync, which may be more appropriate for real-time collaborative applications and/or applications with very large data sets.
 
 As a developer then you will likely have two concerns:
 
@@ -13,15 +16,20 @@ As a developer then you will likely have two concerns:
 
 We'll get to those in a second, but first let's introduce the data model.
 
-> Note: This library provides a fairly low level interface to automerge documents. There are no mappings from complex swift datatypes like structs or classees to the structure of the automerge document. It is intended that such higher level wrappers be built on top of this one as separate libraries.
+> Note: This library provides a fairly low level interface to Automerge documents. 
+There are no mappings from complex swift datatypes like structs or classees to the structure of the Automerge document. 
+It is intended that such higher level wrappers be built on top of this one as separate libraries.
 
 ## Data Model
 
-Automerge documents are composed of "objects" - which are composite data structures like a map or a list - and primitive values like booleans and numbers. Objects have an ``ObjId``, which is used to refer to them when making changes to them. Every automerge document starts with the "root" object, which is a map identified by ``ObjId/ROOT``. The data model (which is represeented in this library by the ``Value`` enum), is the following:
+Automerge documents are composed of "objects" - which are composite data structures like a map or a list - and primitive values like booleans and numbers. 
+Objects have an ``ObjId``, which is used to refer to them when making changes to them. 
+Every Automerge document starts with the "root" object, which is a map identified by ``ObjId/ROOT``. 
+The data model (which is represeented in this library by the ``Value`` enum), is the following:
 
 * Objects (``ObjType``):
     * Maps (``ObjType/Map``): string keyed maps
-    * Lists (``ObjType/List``): sequences of other automerge values
+    * Lists (``ObjType/List``): sequences of other Automerge values
     * Text (``ObjType/Text``): sequences of unicode characters
 * Primitive values (``ScalarValue``)
     * byte arrays (``ScalarValue/Bytes(_:)``)
@@ -36,25 +44,39 @@ Automerge documents are composed of "objects" - which are composite data structu
 
 ## Reading and writing from a document
 
-Most operations you perform on a document require that you identify a property of an object. This is either a key of a map, or an index in a sequence. This is represented by overloaded functions which accept either a `key:` paramter or an `index:` parameter. For example, ``Document/get(obj:key:)`` to get a value out of a map and ``Document/get(obj:index:)`` to get a value out of a list. 
+Most operations you perform on a document require that you identify a property of an object. 
+This is either a key of a map, or an index in a sequence. 
+This is represented by overloaded functions which accept either a `key:` parameter or an `index:` parameter. 
+For example, ``Document/get(obj:key:)`` to get a value out of a map and ``Document/get(obj:index:)`` to get a value out of a list. 
 
-Methods which insert an object into the document are separate to those which insert primitive values (see ``Document/put(obj:key:value:)`` vs ``Document/putObject(obj:key:ty:)``). This is because methods which insert an object return the ``ObjId`` of the newly created object which can then be used to modify the contents of the new object. See the documentation of ``Document`` for more details on the individual methods.
+Methods which insert an object into the document are separate to those which insert primitive values (see ``Document/put(obj:key:value:)`` vs ``Document/putObject(obj:key:ty:)``). 
+This is because methods which insert an object return the ``ObjId`` of the newly created object which can then be used to modify the contents of the new object. 
+See the documentation of ``Document`` for more details on the individual methods.
 
 ## Saving, loading, and syncing
 
-An automerge document can be saved using ``Document/save()``. This will produce a compressed encoding of the document which is extremely efficient and which can be loaded using ``Document/init(_:)``. In many cases you know that the other end already has some set of changes and you just want to send "new" changes. You can obtain these changes using ``Document/encodeNewChanges()`` and ``Document/encodeChangesSince(heads:)``. On the other end of the wire you can apply changes using ``Document/applyEncodedChanges(encoded:)``.
+An Automerge document can be saved using ``Document/save()``. 
+This will produce a compressed encoding of the document which is extremely efficient and which can be loaded using ``Document/init(_:)``. 
+In many cases you know that the other end already has some set of changes and you just want to send "new" changes. 
+You can obtain these changes using ``Document/encodeNewChanges()`` and ``Document/encodeChangesSince(heads:)``. 
+On the other end of the wire you can apply changes using ``Document/applyEncodedChanges(encoded:)``.
 
-As well as these options automerge also offers a sync protocol. The sync protocol is intended to be run over a reliable in-order connection between two peers. To use the sync protocol you instantiate a ``SyncState`` representing the peer you are connecting with and then generate messages to send to them using ``Document/generateSyncMessage(state:)`` and receive messages from them using ``Document/receiveSyncMessage(state:message:)``.
+As well as these options Automerge also offers a sync protocol. 
+The sync protocol is intended to be run over a reliable in-order connection between two peers. 
+To use the sync protocol you instantiate a ``SyncState`` representing the peer you are connecting with and then generate messages to send to them using ``Document/generateSyncMessage(state:)`` and receive messages from them using ``Document/receiveSyncMessage(state:message:)``.
 
 ## Heads and change hashes
 
-An automerge document is a little like a git repository in that it is composed of a graph of changes which are identified by a hash. This means that like a git repository a point in the history of an automerge document can be referenced by its hash. _unlike_ a git repository an automerge document can have multiple heads for a given point in time, representing a merge of concurrent changes. 
+An Automerge document is a little like a git repository in that it is composed of a graph of changes which are identified by a hash. 
+This means that like a git repository a point in the history of an Automerge document can be referenced by its hash. _unlike_ a git repository an Automerge document can have multiple heads for a given point in time, representing a merge of concurrent changes. 
 
-From time to time you may want to refer to a particular point in the document history - to read values as at that point, or to get the changes since that time. ``Document/heads()`` can be used to obtain the current heads of the document, and there are families of methods on document which accept `Array[ChangeHash]` (which is returned by ``Document/heads()``).
+From time to time you may want to refer to a particular point in the document history - to read values as at that point, or to get the changes since that time. 
+``Document/heads()`` can be used to obtain the current heads of the document, and there are families of methods on document which accept `Array[ChangeHash]` (which is returned by ``Document/heads()``).
 
 ## Getting notified of remote changes
 
-When you apply changes received from a remote document (or merged from a separate local document) you may need to know what changed as a result of those changes so that you can update your UI. Any document method which accepts remote changes has a `*WithPatches` variant which returns an array of ``Patch``es, representing the change.
+When you apply changes received from a remote document (or merged from a separate local document) you may need to know what changed as a result of those changes so that you can update your UI. 
+Any document method which accepts remote changes has a `*WithPatches` variant which returns an array of ``Patch``es, representing the change.
 
 ## Topics
 

--- a/Sources/Automerge/actor_id.swift
+++ b/Sources/Automerge/actor_id.swift
@@ -1,5 +1,6 @@
 import AutomergeUniffi
 
+/// A type that represents a collaboration instance for managing replication within an Automerge document.
 public struct ActorId: Equatable, Hashable {
     internal var bytes: [UInt8]
 }

--- a/Sources/Automerge/actor_id.swift
+++ b/Sources/Automerge/actor_id.swift
@@ -1,6 +1,6 @@
 import AutomergeUniffi
 
-/// A type that represents an identifier for a collaborator that makes changes within an Automerge document.
+/// The identifier for collaborators contributing to an Automerge document.
 ///
 /// Each separate instance of an Automerge document should have it's own, unique, `ActorId`.
 /// If you create your own `ActorId`, no concurrent changes should ever be made with the same `ActorId`.

--- a/Sources/Automerge/actor_id.swift
+++ b/Sources/Automerge/actor_id.swift
@@ -1,6 +1,9 @@
 import AutomergeUniffi
 
-/// A type that represents a collaboration instance for managing replication within an Automerge document.
+/// A type that represents an identifier for a collaborator that makes changes within an Automerge document.
+///
+/// Each separate instance of an Automerge document should have it's own, unique, `ActorId`.
+/// If you create your own `ActorId`, no concurrent changes should ever be made with the same `ActorId`.
 public struct ActorId: Equatable, Hashable {
     internal var bytes: [UInt8]
 }

--- a/Sources/Automerge/changehash.swift
+++ b/Sources/Automerge/changehash.swift
@@ -1,8 +1,10 @@
 import AutomergeUniffi
 
+/// An opaque hash that represents a change within an Automerge document.
 public struct ChangeHash: Equatable, Hashable, CustomDebugStringConvertible {
     internal var bytes: [UInt8]
 
+    /// The hex value of the change hash.
     public var debugDescription: String {
         bytes.map { String(format: "%02hhx", $0) }.joined()
     }

--- a/Sources/Automerge/document.swift
+++ b/Sources/Automerge/document.swift
@@ -164,7 +164,7 @@ public class Document {
         return val.map(Value.fromFfi)
     }
 
-    /// Get all the possibly vonflicting values for `key` in map `obj` as at `heads`
+    /// Get all the possibly conflicting values for `key` in map `obj` as at `heads`
     public func getAllAt<Heads: Collection<ChangeHash>>(obj: ObjId, key: String, heads: Heads) throws
         -> Set<Value>
     {
@@ -174,7 +174,7 @@ public class Document {
         return Set(vals.map { Value.fromFfi(value: $0) })
     }
 
-    /// Get all the possibly vonflicting values for `index` in list `obj` as at `heads`
+    /// Get all the possibly conflicting values for `index` in list `obj` as at `heads`
     public func getAllAt<Heads: Collection<ChangeHash>>(obj: ObjId, index: UInt64, heads: Heads)
         throws -> Set<Value>
     {

--- a/Sources/Automerge/document.swift
+++ b/Sources/Automerge/document.swift
@@ -344,7 +344,7 @@ public class Document {
         return patches.map { Patch($0) }
     }
 
-    /// Returns: a sequence of ``Patch`` representing the changes which were
+    /// Returns: a sequence of ``ChangeHash`` representing the changes which were
     /// made to the document as a result of the merge
     public func heads() -> Set<ChangeHash> {
         Set(self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } })

--- a/Sources/Automerge/error.swift
+++ b/Sources/Automerge/error.swift
@@ -13,6 +13,9 @@ typealias FfiReceiveSyncError = AutomergeUniffi.ReceiveSyncError
 // binding generator and we would rather not couple our public API to the
 // specific binding generator tech we're using
 
+/// An general document error.
+///
+/// The error is specific to the Rust language binding infrastructure.
 public struct DocError: Error {
     let inner: FfiDocError
 
@@ -21,6 +24,9 @@ public struct DocError: Error {
     }
 }
 
+/// An error that indicates the synchronisation state could not be decoded.
+///
+/// The error is specific to the Rust language binding infrastructure.
 public struct DecodeSyncStateError: Error {
     let inner: FfiDecodeSyncStateError
 
@@ -29,6 +35,9 @@ public struct DecodeSyncStateError: Error {
     }
 }
 
+/// An error that indicates a problem loading the document.
+///
+/// The error is specific to the Rust language binding infrastructure.
 public struct LoadError: Error {
     let inner: FfiLoadError
 
@@ -37,6 +46,9 @@ public struct LoadError: Error {
     }
 }
 
+/// An error that indicates the received synchornisation could not be applied.
+///
+/// The error is specific to the Rust language binding infrastructure.
 public struct ReceiveSyncError: Error {
     let inner: FfiReceiveSyncError
 

--- a/Sources/Automerge/objid.swift
+++ b/Sources/Automerge/objid.swift
@@ -1,6 +1,8 @@
 import AutomergeUniffi
 
+/// The unique internal identifier for an object stored in an Automerge document.
 public struct ObjId: Equatable, Hashable {
     internal var bytes: [UInt8]
+    /// The root identifier for an Automerge document.
     public static let ROOT = ObjId(bytes: AutomergeUniffi.root())
 }

--- a/Sources/Automerge/objtype.swift
+++ b/Sources/Automerge/objtype.swift
@@ -2,9 +2,13 @@ import enum AutomergeUniffi.ObjType
 
 typealias FfiObjtype = AutomergeUniffi.ObjType
 
+/// A type that represents an Automerge object.
 public enum ObjType {
+    /// A type that represents a map that uses String as keys.
     case Map
+    /// A type that represents a sequence of arbitrary Automerge values.
     case List
+    /// A type that represents sequence of unicode characters.
     case Text
 
     func toFfi() -> FfiObjtype {

--- a/Sources/Automerge/patch.swift
+++ b/Sources/Automerge/patch.swift
@@ -4,18 +4,18 @@ import enum AutomergeUniffi.PatchAction
 typealias FfiPatchAction = AutomergeUniffi.PatchAction
 typealias FfiPatch = AutomergeUniffi.Patch
 
-/// A collection of changes to an Automerge document.
+/// A collection of updates to the current state of an Automerge document.
 public struct Patch: Equatable {
-    /// The type change
+    /// The kind of update to apply.
     public let action: PatchAction
 
-    /// The path to the object identifier the action effects.
+    /// The path to the object identifier the update effects.
     public let path: [PathElement]
 
     /// Creates a new patch
     /// - Parameters:
-    ///   - action: The type of change
-    ///   - path: A collection of the paths to apply the change.
+    ///   - action: The kind of update to apply.
+    ///   - path: The path to the object identifier the update effects.
     public init(action: PatchAction, path: [PathElement]) {
         self.action = action
         self.path = path
@@ -27,13 +27,17 @@ public struct Patch: Equatable {
     }
 }
 
-/// The type of change to apply along with the data to change.
+/// The type of change the library applied to an Automerge document, along with the data that changed.
 public enum PatchAction: Equatable {
     /// Put a new value at the property for the identified object.
+    ///
+    /// The property included within the `Put` can be either an index to a sequence, or a key into a map.
     case Put(ObjId, Prop, Value)
     /// Insert a collection of values at the index you provide for the identified object.
     case Insert(ObjId, UInt64, [Value])
     /// Splices characters into and/or removes characters from the identified object at a given position within it.
+    ///
+    /// The unsigned 64bit integer is the index to a UTF-8 code point, and not a grapheme cluster index.
     case SpliceText(ObjId, UInt64, String)
     /// Increment the property of the identified object by the value you provide.
     case Increment(ObjId, Prop, Int64)

--- a/Sources/Automerge/patch.swift
+++ b/Sources/Automerge/patch.swift
@@ -14,10 +14,12 @@ typealias FfiPatch = AutomergeUniffi.Patch
 /// You can inspect these patches to identify the objects updated within the Automerge document, in order to react accordingly within your code.
 /// A common use case for inspecting patches is to recalculate derived data that is using Automerge as an authoritative source.
 public struct Patch: Equatable {
-    /// The kind of update to apply.
+    /// The the type of change, and the value that patch updated, if relevant to the change.
     public let action: PatchAction
 
-    /// The path to the object identifier the update effects.
+    /// The path to the object that the update effects.
+    ///
+    /// The path doesn't identify the property or index being updated on that object, that information is contained with the associated `action`.
     public let path: [PathElement]
 
     /// Creates a new patch
@@ -27,7 +29,7 @@ public struct Patch: Equatable {
     ///
     ///   The `path` does not identify the property on an object, or index in a sequence, that is updated, only the object that is effected.
     ///   The `action` includes the type of change, and the value being updated, if relevant to the change.
-    public init(action: PatchAction, path: [PathElement]) {
+    init(action: PatchAction, path: [PathElement]) {
         self.action = action
         self.path = path
     }

--- a/Sources/Automerge/patch.swift
+++ b/Sources/Automerge/patch.swift
@@ -4,10 +4,18 @@ import enum AutomergeUniffi.PatchAction
 typealias FfiPatchAction = AutomergeUniffi.PatchAction
 typealias FfiPatch = AutomergeUniffi.Patch
 
+/// A collection of changes to an Automerge document.
 public struct Patch: Equatable {
+    /// The type change
     public let action: PatchAction
+
+    /// The path to the object identifier the action effects.
     public let path: [PathElement]
 
+    /// Creates a new patch
+    /// - Parameters:
+    ///   - action: The type of change
+    ///   - path: A collection of the paths to apply the change.
     public init(action: PatchAction, path: [PathElement]) {
         self.action = action
         self.path = path
@@ -19,12 +27,19 @@ public struct Patch: Equatable {
     }
 }
 
+/// The type of change to apply along with the data to change.
 public enum PatchAction: Equatable {
+    /// Put a new value at the property for the identified object.
     case Put(ObjId, Prop, Value)
+    /// Insert a collection of values at the index you provide for the identified object.
     case Insert(ObjId, UInt64, [Value])
+    /// Splices characters into and/or removes characters from the identified object at a given position within it.
     case SpliceText(ObjId, UInt64, String)
+    /// Increment the property of the identified object by the value you provide.
     case Increment(ObjId, Prop, Int64)
+    /// Delete a key from a identified object.
     case DeleteMap(ObjId, String)
+    /// Delete a sequence from the identified object starting at the index you provide for the length you provide.
     case DeleteSeq(DeleteSeq)
 
     static func fromFfi(_ ffi: FfiPatchAction) -> Self {
@@ -45,9 +60,13 @@ public enum PatchAction: Equatable {
     }
 }
 
+/// A sequence of deletions.
 public struct DeleteSeq: Equatable {
+    /// The object to which the delete applies.
     public let obj: ObjId
+    /// The index location of the start of the deletion.
     public let index: UInt64
+    /// The number of elements to delete.
     public let length: UInt64
 
     public init(obj: ObjId, index: UInt64, length: UInt64) {

--- a/Sources/Automerge/patch.swift
+++ b/Sources/Automerge/patch.swift
@@ -4,7 +4,15 @@ import enum AutomergeUniffi.PatchAction
 typealias FfiPatchAction = AutomergeUniffi.PatchAction
 typealias FfiPatch = AutomergeUniffi.Patch
 
-/// A collection of updates to the current state of an Automerge document.
+/// A collection of updates applied to an Automerge document.
+///
+/// A patch can be received from applying updates to an Automerge document with one of the following methods:
+/// -  ``Document/applyEncodedChangesWithPatches(encoded:)``
+/// - ``Document/receiveSyncMessageWithPatches(state:message:)``
+/// - ``Document/mergeWithPatches(other:)``.
+///
+/// You can inspect these patches to identify the objects updated within the Automerge document, in order to react accordingly within your code.
+/// A common use case for inspecting patches is to recalculate derived data that is using Automerge as an authoritative source.
 public struct Patch: Equatable {
     /// The kind of update to apply.
     public let action: PatchAction
@@ -15,7 +23,10 @@ public struct Patch: Equatable {
     /// Creates a new patch
     /// - Parameters:
     ///   - action: The kind of update to apply.
-    ///   - path: The path to the object identifier the update effects.
+    ///   - path: The path to the object identifier that the action effects.
+    ///
+    ///   The `path` does not identify the property on an object, or index in a sequence, that is updated, only the object that is effected.
+    ///   The `action` includes the type of change, and the value being updated, if relevant to the change.
     public init(action: PatchAction, path: [PathElement]) {
         self.action = action
         self.path = path
@@ -37,9 +48,10 @@ public enum PatchAction: Equatable {
     case Insert(ObjId, UInt64, [Value])
     /// Splices characters into and/or removes characters from the identified object at a given position within it.
     ///
-    /// The unsigned 64bit integer is the index to a UTF-8 code point, and not a grapheme cluster index.
+    /// > Note: The unsigned 64bit integer is the index to a UTF-8 code point, and not a grapheme cluster index.
+    /// If you are working with `Characters` from a `String`, you will need to calculate the offset to insert it correctly.
     case SpliceText(ObjId, UInt64, String)
-    /// Increment the property of the identified object by the value you provide.
+    /// Increment the property of the identified object, typically a Counter.
     case Increment(ObjId, Prop, Int64)
     /// Delete a key from a identified object.
     case DeleteMap(ObjId, String)

--- a/Sources/Automerge/path.swift
+++ b/Sources/Automerge/path.swift
@@ -4,6 +4,7 @@ import enum AutomergeUniffi.Prop
 typealias FfiPathElem = AutomergeUniffi.PathElement
 typealias FfiProp = AutomergeUniffi.Prop
 
+/// The path to a specific object identifier within an Automerge document.
 public struct PathElement: Equatable {
     let prop: Prop
     let obj: ObjId
@@ -21,8 +22,11 @@ public struct PathElement: Equatable {
     }
 }
 
+/// A type that represents a property on an object within an Automerge document.
 public enum Prop: Equatable {
+    /// A string-based key
     case Key(String)
+    /// In index or cursor position.
     case Index(UInt64)
 
     static func fromFfi(_ ffi: FfiProp) -> Self {

--- a/Sources/Automerge/path.swift
+++ b/Sources/Automerge/path.swift
@@ -4,7 +4,7 @@ import enum AutomergeUniffi.Prop
 typealias FfiPathElem = AutomergeUniffi.PathElement
 typealias FfiProp = AutomergeUniffi.Prop
 
-/// The path to a specific object identifier within an Automerge document.
+/// The path to a property within an object.
 public struct PathElement: Equatable {
     let prop: Prop
     let obj: ObjId
@@ -24,9 +24,9 @@ public struct PathElement: Equatable {
 
 /// A type that represents a property on an object within an Automerge document.
 public enum Prop: Equatable {
-    /// A string-based key
+    /// A property in a map.
     case Key(String)
-    /// In index or cursor position.
+    /// An index into a sequence.
     case Index(UInt64)
 
     static func fromFfi(_ ffi: FfiProp) -> Self {

--- a/Sources/Automerge/path.swift
+++ b/Sources/Automerge/path.swift
@@ -4,11 +4,19 @@ import enum AutomergeUniffi.Prop
 typealias FfiPathElem = AutomergeUniffi.PathElement
 typealias FfiProp = AutomergeUniffi.Prop
 
-/// The path to a property within an object.
+/// A component of the path to an object within a document.
+///
+/// A path constructed of `PathElement` instances represents the sequence of navigating through a hierarchical structure of objects within an Automerge document.
+/// The base of this tree structure is  ``ObjId/ROOT``.
 public struct PathElement: Equatable {
     let prop: Prop
     let obj: ObjId
 
+    
+    /// Creates a new path element.
+    /// - Parameters:
+    ///   - obj: The object Id of the path element.
+    ///   - prop: The property on the object, either a key on a map, or index position in a list.
     public init(obj: ObjId, prop: Prop) {
         self.prop = prop
         self.obj = obj
@@ -23,6 +31,9 @@ public struct PathElement: Equatable {
 }
 
 /// A type that represents a property on an object within an Automerge document.
+///
+/// The property is either a ``Prop/Key(_:)``, in the from of a `String` to a map,
+/// or a ``Prop/Index(_:)`` with the index position represented as a 64-bit unsigned integer.
 public enum Prop: Equatable {
     /// A property in a map.
     case Key(String)

--- a/Sources/Automerge/scalar.swift
+++ b/Sources/Automerge/scalar.swift
@@ -2,27 +2,29 @@ import enum AutomergeUniffi.ScalarValue
 
 typealias FFIScalar = AutomergeUniffi.ScalarValue
 
-/// A type that represents a primitive Automerge value
+/// A type that represents a primitive Automerge value.
 public enum ScalarValue: Equatable, Hashable {
-    /// A byte buffer
+    /// A byte buffer.
     case Bytes([UInt8])
-    /// A string
+    /// A string.
     case String(String)
-    /// An unsigned integer
+    /// An unsigned integer.
     case Uint(UInt64)
-    /// A signed integer
+    /// A signed integer.
     case Int(Int64)
-    /// A floating point number
+    /// A floating point number.
     case F64(Double)
-    /// An integer counter
+    /// An integer counter.
     case Counter(Int64)
-    /// A timestamp
+    /// A timestamp represented by the milliseconds since UNIX epoch.
     case Timestamp(Int64)
-    /// A Boolean value
+    /// A Boolean value.
     case Boolean(Bool)
     /// An unknown, raw scalar type.
+    ///
+    /// This type is reserved for forward compatibility, and is not expected to be created directly.
     case Unknown(typeCode: UInt8, data: [UInt8])
-    /// A null
+    /// A null.
     case Null
 
     internal func toFfi() -> FFIScalar {

--- a/Sources/Automerge/scalar.swift
+++ b/Sources/Automerge/scalar.swift
@@ -2,16 +2,27 @@ import enum AutomergeUniffi.ScalarValue
 
 typealias FFIScalar = AutomergeUniffi.ScalarValue
 
+/// A type that represents a primitive Automerge value
 public enum ScalarValue: Equatable, Hashable {
+    /// A byte buffer
     case Bytes([UInt8])
+    /// A string
     case String(String)
+    /// An unsigned integer
     case Uint(UInt64)
+    /// A signed integer
     case Int(Int64)
+    /// A floating point number
     case F64(Double)
+    /// An integer counter
     case Counter(Int64)
+    /// A timestamp
     case Timestamp(Int64)
+    /// A Boolean value
     case Boolean(Bool)
+    /// An unknown, raw scalar type.
     case Unknown(typeCode: UInt8, data: [UInt8])
+    /// A null
     case Null
 
     internal func toFfi() -> FFIScalar {

--- a/Sources/Automerge/value.swift
+++ b/Sources/Automerge/value.swift
@@ -2,8 +2,11 @@ import enum AutomergeUniffi.Value
 
 typealias FfiValue = AutomergeUniffi.Value
 
+/// A type that represents a value or object managed by Automerge.
 public enum Value: Equatable, Hashable {
+    /// An object type
     case Object(ObjId, ObjType)
+    /// A scalar value
     case Scalar(ScalarValue)
 
     static func fromFfi(value: FfiValue) -> Self {

--- a/Tests/AutomergeTests/TestPatches.swift
+++ b/Tests/AutomergeTests/TestPatches.swift
@@ -1,4 +1,4 @@
-import Automerge
+@testable import Automerge
 import XCTest
 
 class PatchesTestCase: XCTestCase {

--- a/scripts/build-ghpages-docs.sh
+++ b/scripts/build-ghpages-docs.sh
@@ -21,10 +21,6 @@ $(xcrun --find swift) build --target Automerge \
    -Xswiftc -emit-symbol-graph \
    -Xswiftc -emit-symbol-graph-dir -Xswiftc "${BUILD_DIR}/symbol-graphs"
 
-# Enables deterministic output from DocC
-# - useful when you're committing the results to host on github pages
-export DOCC_JSON_PRETTYPRINT=YES
-
 $(xcrun --find docc) convert Sources/Automerge/Automerge.docc \
     --output-path ./docs \
     --fallback-display-name Automerge \
@@ -42,7 +38,11 @@ $(xcrun --find docc) convert Sources/Automerge/Automerge.docc \
 #    --checkout-path ${PACKAGE_PATH}
 
 # Swift package plugin for hosted content - this _should_ work, but it's not generating
-# any symbols in the resulting documentation.
+# any symbols in the resulting documentation. Swift 5.6 to 5.8 don't support the plugin
+# with a _local_ XCFframework reference.
+#   Bug filed: https://github.com/apple/swift-docc-plugin/issues/52
+# The workaround is to buld and extract the symbols to generate the documentation
+# manually.
 #
 # $(xcrun --find swift) package \
 #     --allow-writing-to-directory ./docs \


### PR DESCRIPTION
- also updated any references of `automerge` to `Automerge` in the narrative to reflect it being a proper noun in other Automerge documentation.
- removed a redundancy in the doc build script, and documented an upstream bug with swift-docc-tools and using a local XCFramework reference (as this project does)