### PR TITLE
replace [UInt8] in public API with Data

### DIFF
--- a/CollectionBenchmarks/Package.swift
+++ b/CollectionBenchmarks/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v10_15)],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.1"),
-        .package(path: "../")
+        .package(path: "../"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -16,8 +16,11 @@ let package = Package(
             name: "CollectionBenchmarks",
             dependencies: [
                 .product(name: "Automerge", package: "automerge-swifter"),
-                .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark"
-),
-            ]),
+                .product(
+                    name: "CollectionsBenchmark",
+                    package: "swift-collections-benchmark"
+                ),
+            ]
+        ),
     ]
 )

--- a/CollectionBenchmarks/Sources/CollectionBenchmarks/main.swift
+++ b/CollectionBenchmarks/Sources/CollectionBenchmarks/main.swift
@@ -36,13 +36,13 @@ import Foundation
 // the type you defined in the `for:` parameter to be returned for that instance of size.
 //
 // For example, the definition of the `[Int].self` generator is:
-// 
+//
 // ```swift
 // registerInputGenerator(for: [Int].self) { size in
 //     (0 ..< size).shuffled()
 // }
 // ```
-// The above generator creates a range of values from 0 to the size provided and returns 
+// The above generator creates a range of values from 0 to the size provided and returns
 // them as an array of integers, shuffled.
 
 var benchmark = Benchmark(title: "Automerge")
@@ -54,9 +54,9 @@ let stringCharacters = "a bcdef ghijk lmnop qrstu vwxyz ABCD EFGHI JKLMN OPQRS T
 // benchmark returns type of [String], but is essentially a large array of random characters.
 benchmark.registerInputGenerator(for: [String].self) { size in
     (0 ..< size)
-    .map { _ in
-        stringCharacters.randomElement() ?? " "
-    }
+        .map { _ in
+            stringCharacters.randomElement() ?? " "
+        }
 }
 
 benchmark.addSimple(
@@ -69,9 +69,10 @@ benchmark.addSimple(
     var stringLength = doc.length(obj: text)
     for strChar in input {
         try! doc.spliceText(obj: text, start: stringLength, delete: 0, value: strChar)
-        stringLength = doc.length(obj: text)        
+        stringLength = doc.length(obj: text)
     }
-    //precondition(stringLength == input.count) // NOT VALID - difference in UTF-8 codepoints and how strings represent lengths
+    // precondition(stringLength == input.count) // NOT VALID - difference in UTF-8 codepoints and how strings represent
+    // lengths
     blackHole(doc)
 }
 
@@ -85,10 +86,11 @@ benchmark.addSimple(
     var stringLength = doc.length(obj: text)
     for strChar in input {
         try! doc.spliceText(obj: text, start: stringLength, delete: 0, value: strChar)
-        stringLength = doc.length(obj: text)        
+        stringLength = doc.length(obj: text)
     }
     let resultingString = try! doc.text(obj: text)
-    //precondition(stringLength == input.count) // NOT VALID - difference in UTF-8 codepoints and how strings represent lengths
+    // precondition(stringLength == input.count) // NOT VALID - difference in UTF-8 codepoints and how strings represent
+    // lengths
     blackHole(resultingString)
 }
 

--- a/CollectionBenchmarks/Tests/CollectionBenchmarksTests/CollectionBenchmarksTests.swift
+++ b/CollectionBenchmarks/Tests/CollectionBenchmarksTests/CollectionBenchmarksTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import CollectionBenchmarks
+import XCTest
 
 final class CollectionBenchmarksTests: XCTestCase {
     func testExample() throws {

--- a/Sources/Automerge/Automerge.docc/AddressBookExample.md
+++ b/Sources/Automerge/Automerge.docc/AddressBookExample.md
@@ -147,7 +147,7 @@ func add(filename: String, name: String, email: String) {
 
     // Load the data from the filesyste
     let bytes = try! Data(contentsOf: URL(fileURLWithPath: filename))
-    let document = try! Document([UInt8](bytes))
+    let document = try! Document(bytes)
     
     // Find the contacts list in the document
     let contacts: ObjId
@@ -186,7 +186,7 @@ To list contacts we iterate over each value in the contacts list, printing them 
 ```
 func list(filename: String) {
     let bytes = try! Data(contentsOf: URL(fileURLWithPath: filename))
-    let document = try! Document([UInt8](bytes))
+    let document = try! Document(bytes)
     let contacts: ObjId
     switch try! document.get(obj: ObjId.ROOT, key: "contacts")! {
     case .Object(let id, _):
@@ -231,7 +231,7 @@ Here we load the document, loop over the contacts in the `contacts` list, and if
 ```
 func update(filename: String, contact: String, newEmail: String) {
     let bytes = try! Data(contentsOf: URL(fileURLWithPath: filename))
-    let document = try! Document([UInt8](bytes))
+    let document = try! Document(bytes)
     let contacts: ObjId
     switch try! document.get(obj: ObjId.ROOT, key: "contacts")! {
     case .Object(let id, _):
@@ -279,10 +279,10 @@ func update(filename: String, contact: String, newEmail: String) {
 ```
 func merge(filename1: String, filename2: String, out: String) {
     let leftBytes = try! Data(contentsOf: URL(fileURLWithPath: filename1))
-    let left = try! Document([UInt8](leftBytes))
+    let left = try! Document(leftBytes)
 
     let rightBytes = try! Data(contentsOf: URL(fileURLWithPath: filename2))
-    let right = try! Document([UInt8](rightBytes))
+    let right = try! Document(rightBytes)
 
     try! left.merge(other: right)
     let savedBytes = left.save()

--- a/Sources/Automerge/document.swift
+++ b/Sources/Automerge/document.swift
@@ -1,3 +1,4 @@
+import Foundation
 import class AutomergeUniffi.Doc
 import protocol AutomergeUniffi.DocProtocol
 
@@ -38,8 +39,8 @@ public class Document {
     /// concatenation of many calls to ``encodeChangesSince(heads:)``, or
     /// ``encodeNewChanges()`` or the concatenation of any of those, or really
     /// any sequence of bytes containing valid encodings of automerge changes.
-    public init(_ bytes: [UInt8]) throws {
-        doc = try WrappedDoc { try Doc.load(bytes: bytes) }
+    public init(_ bytes: Data) throws {
+        doc = try WrappedDoc { try Doc.load(bytes: Array(bytes)) }
     }
 
     private init(doc: Doc) {
@@ -283,32 +284,39 @@ public class Document {
     }
 
     /// Encode this document in a compressed binary format
-    public func save() -> [UInt8] {
-        self.doc.wrapErrors { $0.save() }
+    public func save() -> Data {
+        self.doc.wrapErrors { Data($0.save()) }
     }
 
     /// Generate a sync message to send to the peer represented by `state`
     ///
     /// - Returns: A message to send to the peer, or `nil` if we are in sync
-    public func generateSyncMessage(state: SyncState) -> [UInt8]? {
-        self.doc.wrapErrors { $0.generateSyncMessage(state: state.ffi_state) }
+    public func generateSyncMessage(state: SyncState) -> Data? {
+        self.doc.wrapErrors {
+            if let tempArr = $0.generateSyncMessage(state: state.ffi_state) {
+                return Data(tempArr)
+            }
+            return nil
+        }
     }
 
     /// Receive a sync message from the peer represented by `state`
     ///
     /// > Tip: if you need to know what changed in the document as a result of
     /// the message try using ``receiveSyncMessageWithPatches(state:message:)``
-    public func receiveSyncMessage(state: SyncState, message: [UInt8]) throws {
-        try self.doc.wrapErrors { try $0.receiveSyncMessage(state: state.ffi_state, msg: message) }
+    public func receiveSyncMessage(state: SyncState, message: Data) throws {
+        try self.doc.wrapErrors {
+            try $0.receiveSyncMessage(state: state.ffi_state, msg: Array(message))
+        }
     }
 
     /// Receive a sync message from the peer represented by `state`, returning patches
     ///
     /// Returns: a sequence of ``Patch`` representing the changes which were
     /// made to the document as a result of the message.
-    public func receiveSyncMessageWithPatches(state: SyncState, message: [UInt8]) throws -> [Patch] {
+    public func receiveSyncMessageWithPatches(state: SyncState, message: Data) throws -> [Patch] {
         let patches = try self.doc.wrapErrors {
-            try $0.receiveSyncMessageWithPatches(state: state.ffi_state, msg: message)
+            try $0.receiveSyncMessageWithPatches(state: state.ffi_state, msg: Array(message))
         }
         return patches.map { Patch($0) }
     }
@@ -360,16 +368,16 @@ public class Document {
     ///
     /// Returns: encoded changes suitable for sending over the network and
     /// applying to another document using ``applyEncodedChanges(encoded:)``
-    public func encodeNewChanges() -> [UInt8] {
-        self.doc.wrapErrors { $0.encodeNewChanges() }
+    public func encodeNewChanges() -> Data {
+        self.doc.wrapErrors { Data($0.encodeNewChanges()) }
     }
 
     /// Encode any changes made since `heads`
     ///
     /// Returns: encoded changes suitable for sending over the network and
     /// applying to another document using ``applyEncodedChanges(encoded:)``
-    public func encodeChangesSince<Heads: Collection<ChangeHash>>(heads: Heads) throws -> [UInt8] {
-        try self.doc.wrapErrors { try $0.encodeChangesSince(heads: heads.map(\.bytes)) }
+    public func encodeChangesSince<Heads: Collection<ChangeHash>>(heads: Heads) throws -> Data {
+        try self.doc.wrapErrors { try Data($0.encodeChangesSince(heads: heads.map(\.bytes))) }
     }
 
     /// Apply encoded changes to this document
@@ -380,8 +388,8 @@ public class Document {
     ///
     /// > Tip: if you need to know what changed in the document as a result of
     /// the applied changes try using ``applyEncodedChangesWithPatches(encoded:)``
-    public func applyEncodedChanges(encoded: [UInt8]) throws {
-        try self.doc.wrapErrors { try $0.applyEncodedChanges(changes: encoded) }
+    public func applyEncodedChanges(encoded: Data) throws {
+        try self.doc.wrapErrors { try $0.applyEncodedChanges(changes: Array(encoded)) }
     }
 
     /// Apply encoded changes to this document
@@ -389,9 +397,9 @@ public class Document {
     /// The input to this function can be anything returned by ``save()``,
     /// ``encodeNewChanges()``, ``encodeChangesSince(heads:)`` or any
     /// concatenation of those.
-    public func applyEncodedChangesWithPatches(encoded: [UInt8]) throws -> [Patch] {
+    public func applyEncodedChangesWithPatches(encoded: Data) throws -> [Patch] {
         let patches = try self.doc.wrapErrors {
-            try $0.applyEncodedChangesWithPatches(changes: encoded)
+            try $0.applyEncodedChangesWithPatches(changes: Array(encoded))
         }
         return patches.map { Patch($0) }
     }

--- a/Sources/Automerge/document.swift
+++ b/Sources/Automerge/document.swift
@@ -1,6 +1,6 @@
-import Foundation
 import class AutomergeUniffi.Doc
 import protocol AutomergeUniffi.DocProtocol
+import Foundation
 
 /// The entry point to automerge, a ``Document`` presents a key/value interface to
 /// the data it contains; as well as methods for loading and saving documents, and

--- a/Sources/Automerge/patch.swift
+++ b/Sources/Automerge/patch.swift
@@ -11,15 +11,18 @@ typealias FfiPatch = AutomergeUniffi.Patch
 /// - ``Document/receiveSyncMessageWithPatches(state:message:)``
 /// - ``Document/mergeWithPatches(other:)``.
 ///
-/// You can inspect these patches to identify the objects updated within the Automerge document, in order to react accordingly within your code.
-/// A common use case for inspecting patches is to recalculate derived data that is using Automerge as an authoritative source.
+/// You can inspect these patches to identify the objects updated within the Automerge document, in order to react
+/// accordingly within your code.
+/// A common use case for inspecting patches is to recalculate derived data that is using Automerge as an authoritative
+/// source.
 public struct Patch: Equatable {
     /// The the type of change, and the value that patch updated, if relevant to the change.
     public let action: PatchAction
 
     /// The path to the object that the update effects.
     ///
-    /// The path doesn't identify the property or index being updated on that object, that information is contained with the associated `action`.
+    /// The path doesn't identify the property or index being updated on that object, that information is contained with
+    /// the associated `action`.
     public let path: [PathElement]
 
     /// Creates a new patch
@@ -27,7 +30,8 @@ public struct Patch: Equatable {
     ///   - action: The kind of update to apply.
     ///   - path: The path to the object identifier that the action effects.
     ///
-    ///   The `path` does not identify the property on an object, or index in a sequence, that is updated, only the object that is effected.
+    ///   The `path` does not identify the property on an object, or index in a sequence, that is updated, only the
+    /// object that is effected.
     ///   The `action` includes the type of change, and the value being updated, if relevant to the change.
     init(action: PatchAction, path: [PathElement]) {
         self.action = action
@@ -51,7 +55,8 @@ public enum PatchAction: Equatable {
     /// Splices characters into and/or removes characters from the identified object at a given position within it.
     ///
     /// > Note: The unsigned 64bit integer is the index to a UTF-8 code point, and not a grapheme cluster index.
-    /// If you are working with `Characters` from a `String`, you will need to calculate the offset to insert it correctly.
+    /// If you are working with `Characters` from a `String`, you will need to calculate the offset to insert it
+    /// correctly.
     case SpliceText(ObjId, UInt64, String)
     /// Increment the property of the identified object, typically a Counter.
     case Increment(ObjId, Prop, Int64)

--- a/Sources/Automerge/path.swift
+++ b/Sources/Automerge/path.swift
@@ -6,13 +6,13 @@ typealias FfiProp = AutomergeUniffi.Prop
 
 /// A component of the path to an object within a document.
 ///
-/// A path constructed of `PathElement` instances represents the sequence of navigating through a hierarchical structure of objects within an Automerge document.
+/// A path constructed of `PathElement` instances represents the sequence of navigating through a hierarchical structure
+/// of objects within an Automerge document.
 /// The base of this tree structure is  ``ObjId/ROOT``.
 public struct PathElement: Equatable {
     let prop: Prop
     let obj: ObjId
 
-    
     /// Creates a new path element.
     /// - Parameters:
     ///   - obj: The object Id of the path element.

--- a/Sources/Automerge/scalar.swift
+++ b/Sources/Automerge/scalar.swift
@@ -24,7 +24,7 @@ public enum ScalarValue: Equatable, Hashable {
     /// An unknown, raw scalar type.
     ///
     /// This type is reserved for forward compatibility, and is not expected to be created directly.
-    case Unknown(typeCode: UInt8, data: [UInt8])
+    case Unknown(typeCode: UInt8, data: Data)
     /// A null.
     case Null
 
@@ -47,7 +47,7 @@ public enum ScalarValue: Equatable, Hashable {
         case let .Boolean(v):
             return .boolean(value: v)
         case let .Unknown(t, d):
-            return .unknown(typeCode: t, data: d)
+            return .unknown(typeCode: t, data: Array(d))
         case .Null:
             return .null
         }
@@ -72,7 +72,7 @@ public enum ScalarValue: Equatable, Hashable {
         case let .boolean(value):
             return .Boolean(value)
         case let .unknown(typeCode, data):
-            return .Unknown(typeCode: typeCode, data: data)
+            return .Unknown(typeCode: typeCode, data: Data(data))
         case .null:
             return .Null
         }

--- a/Sources/Automerge/scalar.swift
+++ b/Sources/Automerge/scalar.swift
@@ -1,5 +1,5 @@
-import Foundation
 import enum AutomergeUniffi.ScalarValue
+import Foundation
 
 typealias FFIScalar = AutomergeUniffi.ScalarValue
 

--- a/Sources/Automerge/scalar.swift
+++ b/Sources/Automerge/scalar.swift
@@ -1,3 +1,4 @@
+import Foundation
 import enum AutomergeUniffi.ScalarValue
 
 typealias FFIScalar = AutomergeUniffi.ScalarValue
@@ -5,7 +6,7 @@ typealias FFIScalar = AutomergeUniffi.ScalarValue
 /// A type that represents a primitive Automerge value.
 public enum ScalarValue: Equatable, Hashable {
     /// A byte buffer.
-    case Bytes([UInt8])
+    case Bytes(Data)
     /// A string.
     case String(String)
     /// An unsigned integer.
@@ -30,7 +31,7 @@ public enum ScalarValue: Equatable, Hashable {
     internal func toFfi() -> FFIScalar {
         switch self {
         case let .Bytes(b):
-            return .bytes(value: b)
+            return .bytes(value: Array(b))
         case let .String(s):
             return .string(value: s)
         case let .Uint(i):
@@ -55,7 +56,7 @@ public enum ScalarValue: Equatable, Hashable {
     static func fromFfi(value: FFIScalar) -> Self {
         switch value {
         case let .bytes(value):
-            return .Bytes(value)
+            return .Bytes(Data(value))
         case let .string(value):
             return .String(value)
         case let .uint(value):

--- a/Sources/Automerge/sync_state.swift
+++ b/Sources/Automerge/sync_state.swift
@@ -58,7 +58,7 @@ public struct SyncState {
     /// The serialized representation does not include session data which
     /// depends on reliable in-order delivery. I.e. you do not need to call
     /// ``reset()`` on a decoded sync state.
-    public func encode() -> [UInt8] {
-        self.ffi_state.encode()
+    public func encode() -> Data {
+        Data(self.ffi_state.encode())
     }
 }

--- a/Sources/Automerge/sync_state.swift
+++ b/Sources/Automerge/sync_state.swift
@@ -1,3 +1,4 @@
+import Foundation
 import class AutomergeUniffi.SyncState
 
 typealias FfiSyncState = AutomergeUniffi.SyncState
@@ -38,8 +39,8 @@ public struct SyncState {
         ffi_state = FfiSyncState()
     }
 
-    public init(bytes: [UInt8]) throws {
-        self.ffi_state = try wrappedErrors { try FfiSyncState.decode(bytes: bytes) }
+    public init(bytes: Data) throws {
+        self.ffi_state = try wrappedErrors { try FfiSyncState.decode(bytes: Array(bytes)) }
     }
 
     /// Reset the state if the connection is interrupted

--- a/Sources/Automerge/sync_state.swift
+++ b/Sources/Automerge/sync_state.swift
@@ -1,5 +1,5 @@
-import Foundation
 import class AutomergeUniffi.SyncState
+import Foundation
 
 typealias FfiSyncState = AutomergeUniffi.SyncState
 

--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -26,25 +26,26 @@ class TextTestCase: XCTestCase {
         XCTAssertEqual(try! doc.text(obj: text), "Greetings wonderful world!")
         XCTAssertEqual(try! doc.textAt(obj: text, heads: heads), "hello world!")
     }
-    
+
     func testRepeatedTextInsertion() throws {
-        let characterCollection: [String] = "a bcdef ghijk lmnop qrstu vwxyz ABCD EFGHI JKLMN OPQRS TUVWX YZ😀😎🤓⚁ ♛⛺︎🕰️⏰⏲️ ⏱️🧭".map { char in
-            String(char)
-        }
+        let characterCollection: [String] =
+            "a bcdef ghijk lmnop qrstu vwxyz ABCD EFGHI JKLMN OPQRS TUVWX YZ😀😎🤓⚁ ♛⛺︎🕰️⏰⏲️ ⏱️🧭".map { char in
+                String(char)
+            }
 
         let doc = Automerge.Document()
         let text = try! doc.putObject(obj: ObjId.ROOT, key: "text", ty: .Text)
         var stringLength = doc.length(obj: text)
         XCTAssertEqual(stringLength, 0)
-        
-        for _ in 0...5000 {
+
+        for _ in 0 ... 5000 {
             let stringToInsert = characterCollection.randomElement() ?? " "
             stringLength = doc.length(obj: text)
             print("Adding '\(stringToInsert)' at \(stringLength)")
             try! doc.spliceText(obj: text, start: stringLength, delete: 0, value: stringToInsert)
             print("Combined text: \(try! doc.text(obj: text))")
         }
-        
+
         // flaky assertion, don't do it :: because length is in UTF-8 codepoints, not!!! grapheme clusters.
         // XCTAssertEqual(stringLength, 5)
     }


### PR DESCRIPTION
The API transformation is quite direct, and primarily ergonomic - tests pass, but the API has changed with this.

One thing I noticed (and updated) was example code in the article `AddressBookExample.md`, which could easily get missed. They did get simpler with this update, but I'm thinking it might be a good idea to explicitly encapsulate some of those bits into "Snippets" - which are a relatively new Swift feature, specifically for Documentation, that provide tiny executables that can be referenced in articles and reference docs. They have the notable benefit of being explicitly compiled, so if there's an API change that would break a snippet that included in Documentation, this would flag it.

It's not quite as advanced as Rust (or Python)'s concept of DocTests - it doesn't check the output right now by running anything, only that it compiles - but still might be useful in these contexts, and it was pretty much made with the idea of mixing in pieces from a bit of example code into narrative just like the `AddressBookExample.md` articles does currently.