### PR TITLE
adds ObjId debugging string representation

### DIFF
--- a/Sources/Automerge/ObjId.swift
+++ b/Sources/Automerge/ObjId.swift
@@ -6,3 +6,13 @@ public struct ObjId: Equatable, Hashable {
     /// The root identifier for an Automerge document.
     public static let ROOT = ObjId(bytes: AutomergeUniffi.root())
 }
+
+extension ObjId: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        if bytes == AutomergeUniffi.root() {
+            return "ObjId.ROOT"
+        } else {
+            return "ObjId(\(bytes.map { Swift.String(format: "%02hhx", $0) }.joined())"
+        }
+    }
+}


### PR DESCRIPTION
for more compact debugging output when exploring path and [PathElement] structures