### PR TITLE
Strict concurrency checks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,25 @@
 
 import PackageDescription
 
+var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
+#if swift(>=5.7)
+    globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
+    /*
+     Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
+     Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
+     checks in your code. This explicitly verifies that `Sendable` constraints are
+     met when you mark one of your types as `Sendable`.
+
+     This mode is essentially a bit of a hybrid between the behavior that's intended
+     in Swift 6, and the default in Swift 5.7. Use this mode to have a bit of
+     checking on your code that uses Swift concurrency without too many warnings
+     and / or errors in your current codebase.
+
+     Set `strict-concurrency` to `complete` to get the full suite of concurrency
+     constraints, essentially as they will work in Swift 6.
+     */
+#endif
+
 let package = Package(
     name: "Automerge",
     platforms: [.iOS(.v13), .macOS(.v10_15)],
@@ -32,7 +51,8 @@ let package = Package(
         ),
         .target(
             name: "Automerge",
-            dependencies: ["AutomergeUniffi"]
+            dependencies: ["AutomergeUniffi"],
+            swiftSettings: globalSwiftSettings
         ),
         .testTarget(
             name: "AutomergeTests",

--- a/Sources/Automerge/ObjId.swift
+++ b/Sources/Automerge/ObjId.swift
@@ -1,7 +1,7 @@
 import AutomergeUniffi
 
 /// The unique internal identifier for an object stored in an Automerge document.
-public struct ObjId: Equatable, Hashable {
+public struct ObjId: Equatable, Hashable, Sendable {
     internal var bytes: [UInt8]
     /// The root identifier for an Automerge document.
     public static let ROOT = ObjId(bytes: AutomergeUniffi.root())

--- a/Sources/Automerge/ObjType.swift
+++ b/Sources/Automerge/ObjType.swift
@@ -3,7 +3,7 @@ import enum AutomergeUniffi.ObjType
 typealias FfiObjtype = AutomergeUniffi.ObjType
 
 /// A type that represents an Automerge object.
-public enum ObjType {
+public enum ObjType: Sendable {
     /// A type that represents a map that uses String as keys.
     case Map
     /// A type that represents a sequence of arbitrary Automerge values.

--- a/Sources/Automerge/ScalarValue.swift
+++ b/Sources/Automerge/ScalarValue.swift
@@ -4,7 +4,7 @@ import Foundation
 typealias FFIScalar = AutomergeUniffi.ScalarValue
 
 /// A type that represents a primitive Automerge value.
-public enum ScalarValue: Equatable, Hashable {
+public enum ScalarValue: Equatable, Hashable, Sendable {
     /// A byte buffer.
     case Bytes(Data)
     /// A string.

--- a/Sources/Automerge/Value.swift
+++ b/Sources/Automerge/Value.swift
@@ -3,7 +3,7 @@ import enum AutomergeUniffi.Value
 typealias FfiValue = AutomergeUniffi.Value
 
 /// A type that represents a value or object managed by Automerge.
-public enum Value: Equatable, Hashable {
+public enum Value: Equatable, Hashable, Sendable {
     /// An object type
     case Object(ObjId, ObjType)
     /// A scalar value

--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -41,9 +41,9 @@ class TextTestCase: XCTestCase {
         for _ in 0 ... 5000 {
             let stringToInsert = characterCollection.randomElement() ?? " "
             stringLength = doc.length(obj: text)
-            print("Adding '\(stringToInsert)' at \(stringLength)")
+            //print("Adding '\(stringToInsert)' at \(stringLength)")
             try! doc.spliceText(obj: text, start: stringLength, delete: 0, value: stringToInsert)
-            print("Combined text: \(try! doc.text(obj: text))")
+            //print("Combined text: \(try! doc.text(obj: text))")
         }
 
         // flaky assertion, don't do it :: because length is in UTF-8 codepoints, not!!! grapheme clusters.


### PR DESCRIPTION
- adds strict Swift6-style concurrency checking to the builds
- adds sendable conformance for Value and constructed sub-types that can be passed safely
- quiets a noisy unit test