### PR TITLE
Path element access

### DIFF
--- a/Sources/Automerge/PathElement.swift
+++ b/Sources/Automerge/PathElement.swift
@@ -10,8 +10,8 @@ typealias FfiProp = AutomergeUniffi.Prop
 /// of objects within an Automerge document.
 /// The base of this tree structure is  ``ObjId/ROOT``.
 public struct PathElement: Equatable {
-    let prop: Prop
-    let obj: ObjId
+    public let prop: Prop
+    public let obj: ObjId
 
     /// Creates a new path element.
     /// - Parameters:


### PR DESCRIPTION
makes the internals of PathElement more accessible

This is totally a convenience to make it easier to experiment with different API in sample code prior to bringing it back into Automerge Swift. Once a concept of Automerge.Document "path" is exposed for creation and verification on a document, we can drop this back to internal or even private, as external access *shouldn't* be required when we have a means to specify a schema path publicly.