### PR TITLE
exposes object_type function to look up type of object by object id

### DIFF
--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -238,6 +238,14 @@ public class Document {
         self.doc.wrapErrors { $0.lengthAt(obj: obj.bytes, heads: heads.map(\.bytes)) }
     }
 
+    /// Returns the object type for the object Id that you provide.
+    /// - Parameter obj: The object Id to inspect.
+    public func objectType(obj: ObjId) -> ObjType {
+        self.doc.wrapErrors {
+            ObjType.fromFfi(ty: $0.objectType(obj: obj.bytes))
+        }
+    }
+
     /// Get the value of the text object `obj`
     public func text(obj: ObjId) throws -> String {
         try self.doc.wrapErrors { try $0.text(obj: obj.bytes) }

--- a/Tests/AutomergeTests/TestObjectType.swift
+++ b/Tests/AutomergeTests/TestObjectType.swift
@@ -1,0 +1,27 @@
+import Automerge
+import XCTest
+
+class ObjectTypeTestCase: XCTestCase {
+    func testRootObjectType() {
+        let doc = Document()
+        XCTAssertEqual(doc.objectType(obj: ObjId.ROOT), .Map)
+    }
+
+    func testCheckingListObjectType() {
+        let doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        XCTAssertEqual(doc.objectType(obj: list), .List)
+    }
+
+    func testCheckingMapObjectType() {
+        let doc = Document()
+        let map = try! doc.putObject(obj: ObjId.ROOT, key: "map", ty: .Map)
+        XCTAssertEqual(doc.objectType(obj: map), .Map)
+    }
+
+    func testCheckingTextObjectType() {
+        let doc = Document()
+        let text = try! doc.putObject(obj: ObjId.ROOT, key: "map", ty: .Text)
+        XCTAssertEqual(doc.objectType(obj: text), .Text)
+    }
+}

--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -41,9 +41,9 @@ class TextTestCase: XCTestCase {
         for _ in 0 ... 5000 {
             let stringToInsert = characterCollection.randomElement() ?? " "
             stringLength = doc.length(obj: text)
-            //print("Adding '\(stringToInsert)' at \(stringLength)")
+            // print("Adding '\(stringToInsert)' at \(stringLength)")
             try! doc.spliceText(obj: text, start: stringLength, delete: 0, value: stringToInsert)
-            //print("Combined text: \(try! doc.text(obj: text))")
+            // print("Combined text: \(try! doc.text(obj: text))")
         }
 
         // flaky assertion, don't do it :: because length is in UTF-8 codepoints, not!!! grapheme clusters.

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -185,6 +185,8 @@ interface Doc {
     u64 length(ObjId obj);
     u64 length_at(ObjId obj, sequence<ChangeHash> heads);
 
+    ObjType object_type(ObjId obj);
+
     [Throws=DocError]
     sequence<PathElement> path(ObjId obj);
 

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -321,6 +321,12 @@ impl Doc {
         doc.length_at(obj, &heads) as u64
     }
 
+    pub fn object_type(&self, obj: ObjId) -> ObjType {
+        let obj = am::ObjId::from(obj);
+        let doc = self.0.read().unwrap();
+        doc.object_type(obj).unwrap().into()
+    }
+
     pub fn text(&self, obj: ObjId) -> Result<String, DocError> {
         let obj = am::ObjId::from(obj);
         let doc = self.0.read().unwrap();


### PR DESCRIPTION
exposes a new function - object_type - to the Swift language bindings that allow for looking up a specific type based on an ObjId