### PR TITLE
hiding unsafe flags behind an environment variable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,29 @@
 // swift-tools-version:5.6
 
 import PackageDescription
+import Foundation
 
 var globalSwiftSettings: [PackageDescription.SwiftSetting] = []
 #if swift(>=5.7)
-globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
-/*
- Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
- Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
- checks in your code. This explicitly verifies that `Sendable` constraints are
- met when you mark one of your types as `Sendable`.
+// Only enable these additional checker settings if the environment variable `CI` is set.
+// (Typically set through GitHub actions)
+if ProcessInfo.processInfo.environment["CI"] != nil {
+    globalSwiftSettings.append(.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"]))
+    /*
+     Summation from https://www.donnywals.com/enabling-concurrency-warnings-in-xcode-14/
+     Set `strict-concurrency` to `targeted` to enforce Sendable and actor-isolation
+     checks in your code. This explicitly verifies that `Sendable` constraints are
+     met when you mark one of your types as `Sendable`.
 
- This mode is essentially a bit of a hybrid between the behavior that's intended
- in Swift 6, and the default in Swift 5.7. Use this mode to have a bit of
- checking on your code that uses Swift concurrency without too many warnings
- and / or errors in your current codebase.
+     This mode is essentially a bit of a hybrid between the behavior that's intended
+     in Swift 6, and the default in Swift 5.7. Use this mode to have a bit of
+     checking on your code that uses Swift concurrency without too many warnings
+     and / or errors in your current codebase.
 
- Set `strict-concurrency` to `complete` to get the full suite of concurrency
- constraints, essentially as they will work in Swift 6.
- */
+     Set `strict-concurrency` to `complete` to get the full suite of concurrency
+     constraints, essentially as they will work in Swift 6.
+     */
+}
 #endif
 
 let package = Package(


### PR DESCRIPTION
I recently learned that having a package with "unsafe" compiler flags (which I added to enable fully concurrency checking) results in a Swift package not being directly consumable by regular iOS and macOS projects in Xcode. As such, this PR sets those additional checking flags behind a local environment variable (`CI`) being set to any value. I chose `CI` because [it is always set on GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables). This way we still get the additional checking through GitHub CI, but the package isn't invalidated for external use in iOS and macOS apps.