### PR TITLE
Scalar value rep extension

### DIFF
--- a/Sources/Automerge/Counter.swift
+++ b/Sources/Automerge/Counter.swift
@@ -18,12 +18,15 @@ public struct Counter: Equatable, Hashable {
 
 /// A failure to convert an Automerge scalar value to or from a signer integer counter representation.
 public enum CounterScalarConversionError: LocalizedError {
-    case notCounter(_ val: Value)
+    case notCounterValue(_ val: Value)
+    case notCounterScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notCounter(val):
+        case let .notCounterValue(val):
+            return "Failed to read the value \(val) as a signed integer counter."
+        case let .notCounterScalarValue(val):
             return "Failed to read the scalar value \(val) as a signed integer counter."
         }
     }
@@ -34,12 +37,22 @@ public enum CounterScalarConversionError: LocalizedError {
 
 extension Counter: ScalarValueRepresentable {
     public typealias ConvertError = CounterScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Counter, CounterScalarConversionError> {
         switch val {
         case let .Scalar(.Counter(d)):
             return .success(Counter(d))
         default:
-            return .failure(CounterScalarConversionError.notCounter(val))
+            return .failure(CounterScalarConversionError.notCounterValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Counter, CounterScalarConversionError> {
+        switch val {
+        case let .Counter(d):
+            return .success(Counter(d))
+        default:
+            return .failure(CounterScalarConversionError.notCounterScalarValue(val))
         }
     }
 

--- a/Sources/Automerge/ScalarValueRepresentable.swift
+++ b/Sources/Automerge/ScalarValueRepresentable.swift
@@ -13,14 +13,20 @@ public protocol ScalarValueRepresentable {
     /// The error type associated with failed attempted conversion into or out of Automerge representation.
     associatedtype ConvertError: LocalizedError
 
-    /// Converts the Automerge representation to a local type, or returns a failure
+    /// Converts the Automerge representation to a local type, or returns a failure.
     /// - Parameter val: The Automerge ``Value`` to be converted as a scalar value into a local type.
     /// - Returns: The type, converted to a local type, or an error indicating the reason for the failure to convert.
     ///
     /// The protocol accepts defines a function to accept a ``Value`` primarily for convenience.
-    /// ``Value`` is a higher level enumeration that can include object types such as ``ObjType/List``, ``ObjType/Map``,
+    /// ``Value`` is a higher level enumeration that also includes object types such as ``ObjType/List``,
+    /// ``ObjType/Map``,
     /// and ``ObjType/Text``.
     static func fromValue(_ val: Value) -> Result<Self, ConvertError>
+
+    /// Converts the Automerge representation to a local type, or returns a failure.
+    /// - Parameter val: The Automerge ``ScalarValue`` to be converted into a local type.
+    /// - Returns: The local type, or an error indicating the reason for the failure to convert.
+    static func fromScalarValue(_ val: ScalarValue) -> Result<Self, ConvertError>
 
     /// Converts a local type into an Automerge scalar value.
     /// - Returns: The ``ScalarValue`` that aligns with the provided type
@@ -31,12 +37,15 @@ public protocol ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a Boolean representation.
 public enum BooleanScalarConversionError: LocalizedError {
-    case notbool(_ val: Value)
+    case notboolValue(_ val: Value)
+    case notboolScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notbool(val):
+        case let .notboolValue(val):
+            return "Failed to read the value \(val) as a Boolean."
+        case let .notboolScalarValue(val):
             return "Failed to read the scalar value \(val) as a Boolean."
         }
     }
@@ -47,12 +56,22 @@ public enum BooleanScalarConversionError: LocalizedError {
 
 extension Bool: ScalarValueRepresentable {
     public typealias ConvertError = BooleanScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Self, BooleanScalarConversionError> {
         switch val {
         case let .Scalar(.Boolean(b)):
             return .success(b)
         default:
-            return .failure(BooleanScalarConversionError.notbool(val))
+            return .failure(BooleanScalarConversionError.notboolValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Bool, BooleanScalarConversionError> {
+        switch val {
+        case let .Boolean(b):
+            return .success(b)
+        default:
+            return .failure(BooleanScalarConversionError.notboolScalarValue(val))
         }
     }
 
@@ -65,12 +84,15 @@ extension Bool: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a String representation.
 public enum StringScalarConversionError: LocalizedError {
-    case notstring(_ val: Value)
+    case notstringValue(_ val: Value)
+    case notstringScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notstring(val):
+        case let .notstringValue(val):
+            return "Failed to read the value \(val) as a String."
+        case let .notstringScalarValue(val):
             return "Failed to read the scalar value \(val) as a String."
         }
     }
@@ -81,12 +103,22 @@ public enum StringScalarConversionError: LocalizedError {
 
 extension String: ScalarValueRepresentable {
     public typealias ConvertError = StringScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<String, StringScalarConversionError> {
         switch val {
         case let .Scalar(.String(s)):
             return .success(s)
         default:
-            return .failure(StringScalarConversionError.notstring(val))
+            return .failure(StringScalarConversionError.notstringValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<String, StringScalarConversionError> {
+        switch val {
+        case let .String(s):
+            return .success(s)
+        default:
+            return .failure(StringScalarConversionError.notstringScalarValue(val))
         }
     }
 
@@ -99,12 +131,15 @@ extension String: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a byte representation.
 public enum BytesScalarConversionError: LocalizedError {
-    case notbytes(_ val: Value)
+    case notbytesValue(_ val: Value)
+    case notbytesScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notbytes(val):
+        case let .notbytesValue(val):
+            return "Failed to read the value \(val) as a bytes."
+        case let .notbytesScalarValue(val):
             return "Failed to read the scalar value \(val) as a bytes."
         }
     }
@@ -115,12 +150,22 @@ public enum BytesScalarConversionError: LocalizedError {
 
 extension Data: ScalarValueRepresentable {
     public typealias ConvertError = BytesScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Data, BytesScalarConversionError> {
         switch val {
         case let .Scalar(.Bytes(d)):
             return .success(d)
         default:
-            return .failure(BytesScalarConversionError.notbytes(val))
+            return .failure(BytesScalarConversionError.notbytesValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Data, BytesScalarConversionError> {
+        switch val {
+        case let .Bytes(d):
+            return .success(d)
+        default:
+            return .failure(BytesScalarConversionError.notbytesScalarValue(val))
         }
     }
 
@@ -133,12 +178,15 @@ extension Data: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from an unsigned integer representation.
 public enum UIntScalarConversionError: LocalizedError {
-    case notUInt(_ val: Value)
+    case notUIntValue(_ val: Value)
+    case notUIntScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notUInt(val):
+        case let .notUIntValue(val):
+            return "Failed to read the value \(val) as an unsigned integer."
+        case let .notUIntScalarValue(val):
             return "Failed to read the scalar value \(val) as an unsigned integer."
         }
     }
@@ -149,12 +197,22 @@ public enum UIntScalarConversionError: LocalizedError {
 
 extension UInt: ScalarValueRepresentable {
     public typealias ConvertError = UIntScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<UInt, UIntScalarConversionError> {
         switch val {
         case let .Scalar(.Uint(d)):
             return .success(UInt(d))
         default:
-            return .failure(UIntScalarConversionError.notUInt(val))
+            return .failure(UIntScalarConversionError.notUIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt, UIntScalarConversionError> {
+        switch val {
+        case let .Uint(d):
+            return .success(UInt(d))
+        default:
+            return .failure(UIntScalarConversionError.notUIntScalarValue(val))
         }
     }
 
@@ -167,12 +225,15 @@ extension UInt: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a signed integer representation.
 public enum IntScalarConversionError: LocalizedError {
-    case notInt(_ val: Value)
+    case notIntValue(_ val: Value)
+    case notIntScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notInt(val):
+        case let .notIntValue(val):
+            return "Failed to read the value \(val) as a signed integer."
+        case let .notIntScalarValue(val):
             return "Failed to read the scalar value \(val) as a signed integer."
         }
     }
@@ -183,12 +244,22 @@ public enum IntScalarConversionError: LocalizedError {
 
 extension Int: ScalarValueRepresentable {
     public typealias ConvertError = IntScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Int, IntScalarConversionError> {
         switch val {
         case let .Scalar(.Int(d)):
             return .success(Int(d))
         default:
-            return .failure(IntScalarConversionError.notInt(val))
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Int, IntScalarConversionError> {
+        switch val {
+        case let .Int(d):
+            return .success(Int(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
         }
     }
 
@@ -201,12 +272,15 @@ extension Int: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a 64-bit floating-point value representation.
 public enum DoubleScalarConversionError: LocalizedError {
-    case notDouble(_ val: Value)
+    case notDoubleValue(_ val: Value)
+    case notDoubleScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notDouble(val):
+        case let .notDoubleValue(val):
+            return "Failed to read the value \(val) as a 64-bit floating-point value."
+        case let .notDoubleScalarValue(val):
             return "Failed to read the scalar value \(val) as a 64-bit floating-point value."
         }
     }
@@ -217,12 +291,22 @@ public enum DoubleScalarConversionError: LocalizedError {
 
 extension Double: ScalarValueRepresentable {
     public typealias ConvertError = DoubleScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Double, DoubleScalarConversionError> {
         switch val {
         case let .Scalar(.F64(d)):
             return .success(Double(d))
         default:
-            return .failure(DoubleScalarConversionError.notDouble(val))
+            return .failure(DoubleScalarConversionError.notDoubleValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Double, DoubleScalarConversionError> {
+        switch val {
+        case let .F64(d):
+            return .success(Double(d))
+        default:
+            return .failure(DoubleScalarConversionError.notDoubleScalarValue(val))
         }
     }
 
@@ -235,12 +319,15 @@ extension Double: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a timestamp representation.
 public enum TimestampScalarConversionError: LocalizedError {
-    case notTimetamp(_ val: Value)
+    case notTimetampValue(_ val: Value)
+    case notTimetampScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notTimetamp(val):
+        case let .notTimetampValue(val):
+            return "Failed to read the value \(val) as a timestamp value."
+        case let .notTimetampScalarValue(val):
             return "Failed to read the scalar value \(val) as a timestamp value."
         }
     }
@@ -251,12 +338,22 @@ public enum TimestampScalarConversionError: LocalizedError {
 
 extension Date: ScalarValueRepresentable {
     public typealias ConvertError = TimestampScalarConversionError
+
     public static func fromValue(_ val: Value) -> Result<Date, TimestampScalarConversionError> {
         switch val {
         case let .Scalar(.Timestamp(d)):
             return .success(Date(timeIntervalSince1970: TimeInterval(d)))
         default:
-            return .failure(TimestampScalarConversionError.notTimetamp(val))
+            return .failure(TimestampScalarConversionError.notTimetampValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Date, TimestampScalarConversionError> {
+        switch val {
+        case let .Timestamp(d):
+            return .success(Date(timeIntervalSince1970: TimeInterval(d)))
+        default:
+            return .failure(TimestampScalarConversionError.notTimetampScalarValue(val))
         }
     }
 

--- a/Sources/Automerge/ScalarValueRepresentable.swift
+++ b/Sources/Automerge/ScalarValueRepresentable.swift
@@ -268,19 +268,229 @@ extension Int: ScalarValueRepresentable {
     }
 }
 
+extension Int8: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<Int8, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Int(d)):
+            return .success(Int8(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Int8, IntScalarConversionError> {
+        switch val {
+        case let .Int(d):
+            return .success(Int8(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Int(Int64(self))
+    }
+}
+
+extension Int16: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<Int16, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Int(d)):
+            return .success(Int16(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Int16, IntScalarConversionError> {
+        switch val {
+        case let .Int(d):
+            return .success(Int16(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Int(Int64(self))
+    }
+}
+
+extension Int32: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<Int32, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Int(d)):
+            return .success(Int32(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Int32, IntScalarConversionError> {
+        switch val {
+        case let .Int(d):
+            return .success(Int32(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Int(Int64(self))
+    }
+}
+
+extension Int64: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<Int64, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Int(d)):
+            return .success(Int64(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Int64, IntScalarConversionError> {
+        switch val {
+        case let .Int(d):
+            return .success(Int64(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Int(Int64(self))
+    }
+}
+
+// MARK: UInt types
+
+extension UInt8: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<UInt8, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Uint(d)):
+            return .success(UInt8(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt8, IntScalarConversionError> {
+        switch val {
+        case let .Uint(d):
+            return .success(UInt8(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Uint(UInt64(self))
+    }
+}
+
+extension UInt16: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<UInt16, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Uint(d)):
+            return .success(UInt16(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt16, IntScalarConversionError> {
+        switch val {
+        case let .Uint(d):
+            return .success(UInt16(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Uint(UInt64(self))
+    }
+}
+
+extension UInt32: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<UInt32, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Uint(d)):
+            return .success(UInt32(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt32, IntScalarConversionError> {
+        switch val {
+        case let .Uint(d):
+            return .success(UInt32(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Uint(UInt64(self))
+    }
+}
+
+extension UInt64: ScalarValueRepresentable {
+    public typealias ConvertError = IntScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<UInt64, IntScalarConversionError> {
+        switch val {
+        case let .Scalar(.Int(d)):
+            return .success(UInt64(d))
+        default:
+            return .failure(IntScalarConversionError.notIntValue(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt64, IntScalarConversionError> {
+        switch val {
+        case let .Uint(d):
+            return .success(UInt64(d))
+        default:
+            return .failure(IntScalarConversionError.notIntScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .Uint(self)
+    }
+}
+
 // MARK: Double Conversions
 
 /// A failure to convert an Automerge scalar value to or from a 64-bit floating-point value representation.
-public enum DoubleScalarConversionError: LocalizedError {
-    case notDoubleValue(_ val: Value)
-    case notDoubleScalarValue(_ val: ScalarValue)
+public enum FloatingPointScalarConversionError: LocalizedError {
+    case notF64Value(_ val: Value)
+    case notF64ScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notDoubleValue(val):
+        case let .notF64Value(val):
             return "Failed to read the value \(val) as a 64-bit floating-point value."
-        case let .notDoubleScalarValue(val):
+        case let .notF64ScalarValue(val):
             return "Failed to read the scalar value \(val) as a 64-bit floating-point value."
         }
     }
@@ -290,28 +500,54 @@ public enum DoubleScalarConversionError: LocalizedError {
 }
 
 extension Double: ScalarValueRepresentable {
-    public typealias ConvertError = DoubleScalarConversionError
+    public typealias ConvertError = FloatingPointScalarConversionError
 
-    public static func fromValue(_ val: Value) -> Result<Double, DoubleScalarConversionError> {
+    public static func fromValue(_ val: Value) -> Result<Double, FloatingPointScalarConversionError> {
         switch val {
         case let .Scalar(.F64(d)):
             return .success(Double(d))
         default:
-            return .failure(DoubleScalarConversionError.notDoubleValue(val))
+            return .failure(FloatingPointScalarConversionError.notF64Value(val))
         }
     }
 
-    public static func fromScalarValue(_ val: ScalarValue) -> Result<Double, DoubleScalarConversionError> {
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Double, FloatingPointScalarConversionError> {
         switch val {
         case let .F64(d):
             return .success(Double(d))
         default:
-            return .failure(DoubleScalarConversionError.notDoubleScalarValue(val))
+            return .failure(FloatingPointScalarConversionError.notF64ScalarValue(val))
         }
     }
 
     public func toScalarValue() -> ScalarValue {
         .F64(self)
+    }
+}
+
+extension Float: ScalarValueRepresentable {
+    public typealias ConvertError = FloatingPointScalarConversionError
+
+    public static func fromValue(_ val: Value) -> Result<Float, FloatingPointScalarConversionError> {
+        switch val {
+        case let .Scalar(.F64(d)):
+            return .success(Float(d))
+        default:
+            return .failure(FloatingPointScalarConversionError.notF64Value(val))
+        }
+    }
+
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<Float, FloatingPointScalarConversionError> {
+        switch val {
+        case let .F64(d):
+            return .success(Float(d))
+        default:
+            return .failure(FloatingPointScalarConversionError.notF64ScalarValue(val))
+        }
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        .F64(Double(self))
     }
 }
 


### PR DESCRIPTION
The ScalarValueRepresentable protocol provides a generic interface for converting from Swift language types into values that can be stored into ScalarValue fields within an AutomergeDocument. In the original version, it translated in and out of Automerge Value enum, which can also represent objects (Map, Object, Text). 

This extends it to support converted from conforming types directly into an Automerge ScalarValue enum as well, to support encoding and decoding from an Automerge document. It also expands that types that have conformance to all the types supported by Swift `Codable`.