### PR TITLE
Repo updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Issues for this library are tracked on GitHub: [https://github.com/automerge/automerge-swifter/issues](https://github.com/automerge/automerge-swifter/issues)
+
+There is a hosted [Automerge Slack](https://automerge.slack.com/join/shared_invite/zt-e4p3760n-kKh7r3KRH1YwwNfiZM8ktw#/shared-invite/email) that includes the channel `#automerge-swift`. 
+
+## Building and Developing
+
+This package is implemented by wrapping the Rust library. 
+There are two problems to solve to make this possible:
+
+1. Writing and/or generating a bunch of code to cross the FFI bridge from Rust to Swift
+2. Distributing the compiled Rust in a way that Swift understands
+
+We use the [Uniffi](https://mozilla.github.io/uniffi-rs/) framework from Mozilla. 
+Uniffi takes in an IDL file describing the FFI interface and some rust source code which implements the Rust side of the interface. 
+Given this IDL Uniffi generates a swift package providing the swift side of the interface. 
+However, the generated code is not very idiomatic Swift, so we wrap it in a handwritten Swift wrapper of our own. 
+Finally, we distribute the compiled Rust code in the form of a binary XCFramework. 
+
+The moving parts here then are:
+
+* The `rust/src/automerge.udl` file which describes the FFI interface.
+* The `rust/build.rs` build script, which uses Uniffi to generate the boilerplate parts of the rust side of the interface.
+* The `rust/src/*`files which implement the Automerge specific parts of the rust binding.
+* The `rust/uniffi-bindgen.rs` script, which uses Uniffi to output a Swift wrapper around the interface.
+* The source files in `./Sources` and `./Tests` which implement the handwritten swift wrappers.
+* The `./scripts/build-xcframework.sh` script, which builds the rust project and packages it into an XCFramework.
+Actually, the `build-xcframework.sh` script does a bit more than this. 
+It builds the rust framework, generates the swift package and copies it into `./AutomergeUniffi`, and generates the XCFramework and places it in `automergeFFI.xcframework.zip`.
+
+The default Package.swift uses the latest, pre-compiled version of the XCFramework to make it easy to directly use this package.
+If you are developing at the Rust or FFI interface level, set the environment variable `LOCAL_BUILD` to any value, and use the script `./scripts/build-xcframework.sh` to compile the Rust, regenerate the associated Swift wrappers, and recreate a local copy of the XCFramework file.
+For example:
+
+```bash
+export LOCAL_BUILD=true
+./scripts/build-xcframework
+```
+
+What this means is that the typical development cycle usually looks like this:
+
+* Write a failing test in `Tests/*.swift`.
+* Modify the `rust/src/automerge.udl` file to expose the additional methods or data you need from the rust side.
+* In the rust project write rust code to implement the IDL. The build script generates the new code Uniffi needs and will produce compile errors until you implement the required parts. This means you just run `cargo build` in `./rust` and modify code until cargo is happy.
+* Set the environment variable `LOCAL_BUILD` to `true`. 
+* Run `./scripts/build-xcframework.sh` to generate the new xcframework based on the new bindings you've implemented.
+* Wire up the swift side of the wrappers in `./Sources/*`.
+* Run tests on the swift side with `swift test`.
+
+## Benchmarking
+
+The repository has two-dimensional benchmarking as a seperate project in the directory `CollectionBenchmarks`.
+It uses the library [swift-collections-benchmarks](https://github.com/apple/swift-collections-benchmark) to run benchmarks that are relevant over the size of the collection.
+The benchmark baselines were built on an Apple M1 MacBook Pro.
+
+## Building the docs
+
+The script `./scripts/preview-docs.sh` will run a web server previewing the docs. 
+This does not pick up all source code changes so you may need to restart it occasionally.
+
+## Releasing Updates
+
+The full process of releasing updates for the library is detailed in [Release Process](./notes/release-process.md)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-2023 the Automerge contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Package.swift
+++ b/Package.swift
@@ -49,8 +49,8 @@ if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
 } else {
     FFIbinaryTarget = .binaryTarget(
             name: "automergeFFI",
-            url: "https://github.com/automerge/automerge-swifter/releases/download/0.1.0/automergeFFI.xcframework.zip",
-            checksum: "201a464b1585c0b424a1100f506c12368b3e7473afe5907befc95468147f482d"
+            url: "https://github.com/automerge/automerge-swifter/releases/download/0.1.1/automergeFFI.xcframework.zip",
+            checksum: "2a73a8723c330df82d24ab0e27a7964b68b6b966878335bedae9f46491618f61"
     )
 }
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,29 @@
 
 An Automerge implementation for swift.
 
-This is a reasonably low-level library with relatively few concessions to ergonomics, nicer APIs should be built on top of this work.
+This is a low-level library with few concessions to ergonomics, meant to interact directly with the low-level Automerge API.
+Additional API that is more ergonomic is being added into the repository as this project evolves.
 
-This is also a first draft I (@alexjg) am not particularly familiar with Swift so I expect many things are weird or wrong. Please tell me what those things are!
-
-Docs available [here](https://automerge.org/automerge-swifter/documentation/automerge/)
-
-A demo app [here](https://github.com/automerge/contaaacts)
+[Automerge-Swifter API Documentation](https://automerge.org/automerge-swifter/documentation/automerge/) is available on the [Automerge site](https://automerge.org/).
+A command-line demonstration application ([contaaacts](https://github.com/automerge/contaaacts)) is available that shows using the lower level API.
 
 ## Quickstart
 
-Add a dependency in `Package.swift` (note the use of the `.product(..)` dependency for the target, this is because our repository name does not match the product name, or something like that, [see here](https://forums.swift.org/t/why-does-spm-use-github-repo-name-and-not-package-swift-name/55085/3))
+Add a dependency in `Package.swift`, as the following example shows:
 
 ```swift
 let package = Package(
     ...
     dependencies: [
         ...
-        .package(url: "git@github.com:automerge/automerge-swifter.git", from: "0.0.1")
+        .package(url: "https://github.com/automerge/automerge-swifter.git", from: "0.1.1")
     ],
     targets: [
         .executableTarget(
             ...
             dependencies: [.product(name: "Automerge", package: "automerge-swifter")],
-            ...)
+            ...
+        )
     ]
 )
 ```
@@ -46,56 +45,4 @@ try! doc.delete(obj: list, index: 0)
 try! doc.merge(doc2) // `doc` now contains {"colours": ["green", "red"]}
 ```
 
-## Building and developing
-
-This package is implemented by wrapping the Rust library. There are two problems
-to solve to make this possible:
-
-1. Writing and/or generating a bunch of code to cross the FFI bridge from Rust to
-   swift
-2. Distributing the compiled Rust in a way that swift understands
-
-We use the [Uniffi](https://mozilla.github.io/uniffi-rs/) framework from Mozilla. Uniffi takes in an IDL file describing the FFI interface and some rust source code which implements the Rust side of the interface. Given this IDL Uniffi generates a swift package providing the swift side of the interface. However, the generated code is not very idiomatic swift, so we wrap it in a handwritten swift side wrapper of our own. Finally, we have to actually distribute the rust code as a binary XCFramework. 
-
-The moving parts here then are:
-
-* The `rust/src/automerge.udl` file which describes the FFI interface
-* The `rust/build.rs` build script, which uses Uniffi to generate the boilerplate parts of the rust side of the interface
-* The `rust/src/*`files which implement the Automerge specific parts of the rust binding
-* The `rust/uniffi-bindgen.rs` script, which uses Uniffi to output a Swift wrapper around the interface
-* The source files in `./Sources` and `./Tests` which implement the handwritten swift wrappers
-* The `./scripts/build-xcframework.sh` script, which builds the rust project and packages it into an XCFramework
-
-Actually, the `build-xcframework.sh` script does a bit more than this. It builds the rust framework, then generates the swift package and copies it into `./AutomergeUniffi`, then also generates the XCFramework and places it in `automergeFFI.xcframework.zip`.
-
-What this means is that the typical development cycle usually looks like this:
-
-* Write a failing test in `Tests/*.swift`
-* Modify the `rust/src/automerge.udl` file to expose the additional methods or data you need from the rust side
-* In the rust project write rust code to implement the IDL. The build script generates the new code Uniffi needs and will produce compile errors until you implement the required parts. This means you just run `cargo build` in `./rust` and modify code until cargo is happy
-* Run `./scripts/build-xcframework.sh` to generate the new xcframework based on the new bindings you've implemented
-* Wire up the swift side of the wrappers in `./Sources/*`
-* Run tests on the swift side with `swift test`
-
-### Benchmarking
-
-The repository has two-dimensional benchmarking as a seperate project in the directory `CollectionBenchmarks`.
-It uses the library [swift-collections-benchmarks](https://github.com/apple/swift-collections-benchmark) to run benchmarks that are relevant over the size of the collection.
-The benchmark baselines were built on an Apple M1 MacBook Pro.
-
-### Building the docs
-
-The script `./scripts/preview-docs.sh` will run a web server previewing the docs. This won't pick up all source code changes so you may need to restart it occasionally (I have not figured out which changes it does and does not pick up on).
-
-### Releasing
-
-Swift package manager requires that the built artifacts for the `binaryTarget` we are distributing are part of the repository. It's kind of awkward to have build artifacts in the repository though. To avoid this we only put the build artifacts (specifically, the `AutomergeFFI.xcframework.zip` file and the `AutomergeUniffi` folder which are produced by `scripts/build-xcframework.sh`) in the repository for tagged releases and otherwise we `.gitignore` them. This is a bit of a hack, feel free to suggest better alternatives.
-
-Creating a release then requires doing the following things:
-
-* Checkout a new branch
-* Run `scripts/build-xcframework.sh`
-* Add a commit containing `AutomergeFFI.xcframework.zip` and `AutomergeUniffi` to the index
-* Tag the branch with a version - e.g. `git tag 0.0.1`
-* Push the tag to the remote
-
+For more details on the API, see the [Automerge-swifter API documentation](https://automerge.org/automerge-swifter/documentation/automerge/) and the articles within.

--- a/notes/release-process.md
+++ b/notes/release-process.md
@@ -1,4 +1,4 @@
-# GitHub oriented Swift package release process
+# Release Process
 
 Release process:
 


### PR DESCRIPTION
adds MIT license (normal from Automerge project, but with updated Copyright dates).
adds CONTRIBUTING.md and moves content from README into CONTRIBUTING.
Updates quick example to use latest release and references documentation hosted on GitHub pages.