### PR TITLE
doc update clarifying expected representation of a timestamp

### DIFF
--- a/Sources/Automerge/ScalarValue.swift
+++ b/Sources/Automerge/ScalarValue.swift
@@ -17,7 +17,7 @@ public enum ScalarValue: Equatable, Hashable, Sendable {
     case F64(Double)
     /// An integer counter.
     case Counter(Int64)
-    /// A timestamp represented by the milliseconds since UNIX epoch.
+    /// A timestamp represented by the milliseconds since UNIX epoch (Jan 1st, 1970, 00:00 UTC).
     case Timestamp(Int64)
     /// A Boolean value.
     case Boolean(Bool)

--- a/Sources/Automerge/Value.swift
+++ b/Sources/Automerge/Value.swift
@@ -23,9 +23,9 @@ extension Value: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case let .Object(objId, objType):
-            return "OBJ[\(objId), \(objType)]"
+            return "Object<\(objId), \(objType)>"
         case let .Scalar(scalarValue):
-            return "SCALAR[\(scalarValue)]"
+            return "ScalarValue<\(scalarValue)>"
         }
     }
 }


### PR DESCRIPTION
doc update clarifying expected representation of a timestamp using a 64bit signed integer