### PR TITLE
Codable implementation

### DIFF
--- a/.swiftpm/Automerge.xctestplan
+++ b/.swiftpm/Automerge.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "3F49E46F-3749-44D3-BE33-88C4367B858F",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AutomergeTests",
+        "name" : "AutomergeTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Automerge.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Automerge.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Automerge"
+               BuildableName = "Automerge"
+               BlueprintName = "Automerge"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AutomergeTests"
+               BuildableName = "AutomergeTests"
+               BlueprintName = "AutomergeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:.swiftpm/Automerge.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AutomergeTests"
+               BuildableName = "AutomergeTests"
+               BlueprintName = "AutomergeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Automerge"
+            BuildableName = "Automerge"
+            BlueprintName = "Automerge"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/Automerge/Automerge.docc/Automerge.md
+++ b/Sources/Automerge/Automerge.docc/Automerge.md
@@ -92,10 +92,20 @@ Any document method which accepts remote changes has a `*WithPatches` variant wh
 - ``Automerge/Value``
 - ``Automerge/ScalarValue``
 
+### Reading and Writing Codable Types
+
+- ``Automerge/AutomergeEncoder``
+- ``Automerge/AutomergeDecoder``
+- ``Automerge/AnyCodingKey``
+- ``Automerge/Counter``
+- ``Automerge/Text``
+- ``Automerge/SchemaStrategy``
+- ``Automerge/CodingKeyLookupError``
+- ``Automerge/PathParseError``
+
 ### Converting Scalar Values to Local Types
 
 - ``Automerge/ScalarValueRepresentable``
-- ``Automerge/Counter``
 
 ### Replicating Documents
 

--- a/Sources/Automerge/Codable/AnyCodingKey.swift
+++ b/Sources/Automerge/Codable/AnyCodingKey.swift
@@ -53,7 +53,7 @@ public struct AnyCodingKey: Equatable {
 extension AnyCodingKey: CodingKey {
     /// Creates a new schema path element for an un-keyed container using the index you provide.
     ///
-    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)``.
+    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)-6faed``.
     ///
     /// - Parameter intValue: The index position for an un-keyed container.
     public init?(intValue: Int) {
@@ -65,7 +65,7 @@ extension AnyCodingKey: CodingKey {
 
     /// Creates a new schema path element for a keyed container using the string you provide.
     ///
-    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)``.
+    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)-5azuh``.
     ///
     /// - Parameter stringVal: The key for a keyed container.
     public init?(stringValue: String) {
@@ -91,7 +91,7 @@ extension AnyCodingKey: CodingKey {
     }
 }
 
-/// Path Errors
+/// Path Parsing Errors
 public enum PathParseError: LocalizedError {
     /// The path element is not valid.
     case InvalidPathElement(String)

--- a/Sources/Automerge/Codable/AnyCodingKey.swift
+++ b/Sources/Automerge/Codable/AnyCodingKey.swift
@@ -1,0 +1,172 @@
+import Foundation // for LocalizedError
+
+// rough equivalent to an opaque path - serves a similar function to Automerge.PathElement
+// but from an external, path-only point of view to reference or build a potentially existing
+// schema within Automerge.
+
+/// A type that maps provides a coding key value with an enumeration.
+public struct AnyCodingKey: Equatable {
+    private let pathElement: Automerge.Prop
+
+    /// Creates a generalized Coding Key from an Automerge Property.
+    /// - Parameter pathProperty: The Automerge property to convert.
+    init(_ pathProperty: Automerge.Prop) {
+        pathElement = pathProperty
+    }
+
+    /// Creates a generalized Coding Key from an Automerge Path Element.
+    /// - Parameter element: The Automerge path element to convert.
+    init(_ element: Automerge.PathElement) {
+        pathElement = element.prop
+    }
+
+    /// Creates a new schema path element from a generic coding key.
+    /// - Parameter key: The coding key to use for internal values.
+    public init(_ key: some CodingKey) {
+        if let intValue = key.intValue {
+            pathElement = .Index(UInt64(intValue))
+        } else {
+            pathElement = .Key(key.stringValue)
+        }
+    }
+
+    /// Creates a new schema path element for a keyed container using the string you provide.
+    /// - Parameter stringVal: The key for a keyed container.
+    public init(_ stringVal: String) {
+        pathElement = .Key(stringVal)
+    }
+
+    /// Creates a new schema path element for an un-keyed container using the index you provide.
+    /// - Parameter intValue: The index position for an un-keyed container.
+    public init(_ intValue: UInt64) {
+        pathElement = .Index(intValue)
+    }
+
+    /// A coding key that represents the root of a schema hierarchy.
+    ///
+    /// `ROOT` conceptually maps to the equivalent of an empty array of `some CodingKey`.
+    public static let ROOT = AnyCodingKey(.Key(""))
+}
+
+// MARK: CodingKey conformance
+
+extension AnyCodingKey: CodingKey {
+    /// Creates a new schema path element for an un-keyed container using the index you provide.
+    ///
+    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)``.
+    ///
+    /// - Parameter intValue: The index position for an un-keyed container.
+    public init?(intValue: Int) {
+        if intValue < 0 {
+            preconditionFailure("Schema index positions can't be negative")
+        }
+        pathElement = Automerge.Prop.Index(UInt64(intValue))
+    }
+
+    /// Creates a new schema path element for a keyed container using the string you provide.
+    ///
+    /// For a non-failable initializer for ``AnyCodingKey``, use ``AnyCodingKey/init(_:)``.
+    ///
+    /// - Parameter stringVal: The key for a keyed container.
+    public init?(stringValue: String) {
+        pathElement = Automerge.Prop.Key(stringValue)
+    }
+
+    /// The string value for this schema path element.
+    public var stringValue: String {
+        if case let .Key(stringVal) = pathElement {
+            return stringVal
+        }
+        preconditionFailure("Invalid string value from CodingKey that is an index \(pathElement)")
+    }
+
+    /// The integer value of this schema path element.
+    ///
+    /// If `nil`, the schema path element is expected to be a string that represents a key for a keyed container.
+    public var intValue: Int? {
+        if case let .Index(intValue) = pathElement {
+            return Int(intValue)
+        }
+        return nil
+    }
+}
+
+/// Path Errors
+public enum PathParseError: LocalizedError {
+    /// The path element is not valid.
+    case InvalidPathElement(String)
+    /// The path element, structured as a Index location, doesn't include an index value.
+    case EmptyListIndex(String)
+
+    /// A localized message describing the error.
+    public var errorDescription: String? {
+        switch self {
+        case let .InvalidPathElement(str):
+            return str
+        case let .EmptyListIndex(str):
+            return str
+        }
+    }
+}
+
+public extension AnyCodingKey {
+    /// Parses a string into an array of generic coding path elements.
+    /// - Parameter path: The string to parse.
+    /// - Returns: An array of coding path elements corresponding to the string.
+    static func parsePath(_ path: String) throws -> [AnyCodingKey] {
+        // breaks up the provided path, breaking on '.' and parsing the results into a series
+        // of AnyCodingKey
+        try path
+            .split(separator: ".")
+            .map { String($0) }
+            .map { strValue in
+                if let firstChar = strValue.first, firstChar.isASCII, firstChar.isLetter {
+                    return AnyCodingKey(strValue)
+                } else if strValue.first == "[", strValue.last == "]" {
+                    let start = strValue.index(after: strValue.startIndex)
+                    let end = strValue.index(before: strValue.endIndex)
+                    let substring = String(strValue[start ..< end])
+                    if !substring.isEmpty, let parsedIndexValue = UInt64(substring) {
+                        return AnyCodingKey(parsedIndexValue)
+                    } else {
+                        throw PathParseError.EmptyListIndex(String(strValue))
+                    }
+                }
+                throw PathParseError.InvalidPathElement(String(strValue))
+            }
+    }
+}
+
+extension AnyCodingKey: CustomStringConvertible {
+    /// A string description of the schema path element.
+    public var description: String {
+        switch pathElement {
+        case let .Index(uintVal):
+            return "[\(uintVal)]"
+        case let .Key(strVal):
+            return strVal
+        }
+    }
+}
+
+extension AnyCodingKey: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        switch pathElement {
+        case let .Index(intVal):
+            hasher.combine(intVal)
+        case let .Key(strVal):
+            hasher.combine(strVal)
+        }
+    }
+}
+
+extension Sequence where Element: CodingKey {
+    /// Returns a string that represents the schema path.
+    func stringPath() -> String {
+        let path = map { pathElement in
+            AnyCodingKey(pathElement).description
+        }
+        .joined(separator: ".")
+        return ".\(path)"
+    }
+}

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// A decoder that initializes codable-conforming types from an Automerge document.
 public struct AutomergeDecoder {
     public var codingPath: [CodingKey]
 

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct AutomergeDecoder {
+    public var codingPath: [CodingKey]
+
+    public var userInfo: [CodingUserInfoKey: Any] = [:]
+    public let doc: Document
+
+    public init(doc: Document) {
+        self.doc = doc
+        codingPath = []
+    }
+
+    @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
+        let decoder = AutomergeDecoderImpl(
+            doc: doc,
+            userInfo: userInfo,
+            codingPath: []
+        )
+        return try decoder.decode(T.self)
+    }
+
+    @inlinable public func decode<T: Decodable>(_: T.Type, from path: [CodingKey]) throws -> T {
+        let decoder = AutomergeDecoderImpl(
+            doc: doc,
+            userInfo: userInfo,
+            codingPath: path
+        )
+        return try decoder.decode(T.self)
+    }
+}

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/* Code flow example from a user-defined Decoder implementation
+
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    latitude = try values.decode(Double.self, forKey: .latitude)
+    longitude = try values.decode(Double.self, forKey: .longitude)
+
+    let additionalInfo = try values.nestedContainer(keyedBy: AdditionalInfoKeys.self, forKey: .additionalInfo)
+    elevation = try additionalInfo.decode(Double.self, forKey: .elevation)
+
+ */
+
+@usableFromInline struct AutomergeDecoderImpl {
+    @usableFromInline let doc: Document
+    @usableFromInline let codingPath: [CodingKey]
+    @usableFromInline let userInfo: [CodingUserInfoKey: Any]
+
+    @inlinable init(
+        doc: Document,
+        userInfo: [CodingUserInfoKey: Any],
+        codingPath: [CodingKey]
+    ) {
+        self.doc = doc
+        self.userInfo = userInfo
+        self.codingPath = codingPath
+    }
+
+    @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
+        switch T.self {
+        case is Text.Type:
+            let directContainer = try singleValueContainer()
+            return try directContainer.decode(T.self)
+        case is Counter.Type:
+            let directContainer = try singleValueContainer()
+            return try directContainer.decode(T.self)
+        case is Data.Type:
+            let directContainer = try singleValueContainer()
+            return try directContainer.decode(T.self)
+        case is Date.Type:
+            let directContainer = try singleValueContainer()
+            return try directContainer.decode(T.self)
+        default:
+            return try T(from: self)
+        }
+    }
+}
+
+extension AutomergeDecoderImpl: Decoder {
+    @usableFromInline func container<Key>(keyedBy _: Key.Type) throws ->
+        KeyedDecodingContainer<Key> where Key: CodingKey
+    {
+        let result = doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Key,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(objectId):
+            let objectType = doc.objectType(obj: objectId)
+            guard case .Map = objectType else {
+                throw DecodingError.typeMismatch([String: Value].self, DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "ObjectId \(objectId) returned an type of \(objectType)."
+                ))
+            }
+
+            let container = AutomergeKeyedDecodingContainer<Key>(
+                impl: self,
+                codingPath: codingPath,
+                objectId: objectId
+            )
+            return KeyedDecodingContainer(container)
+        case let .failure(err):
+            throw err
+        }
+    }
+
+    @usableFromInline func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        let result = doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Index,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(objectId):
+            let objectType = doc.objectType(obj: objectId)
+            guard case .List = objectType else {
+                throw DecodingError.typeMismatch([String: Value].self, DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "ObjectId \(objectId) returned an type of \(objectType)."
+                ))
+            }
+
+            return AutomergeUnkeyedDecodingContainer(
+                impl: self,
+                codingPath: codingPath,
+                objectId: objectId
+            )
+        case let .failure(err):
+            throw err
+        }
+    }
+
+    @usableFromInline func singleValueContainer() throws -> SingleValueDecodingContainer {
+        let result = doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(objectId):
+            guard let finalKey = codingPath.last else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue("Attempting to establish a single value container with an empty coding path.")
+            }
+            let finalAutomergeValue: Value?
+            if let indexValue = finalKey.intValue {
+                finalAutomergeValue = try doc.get(obj: objectId, index: UInt64(indexValue))
+            } else {
+                finalAutomergeValue = try doc.get(obj: objectId, key: finalKey.stringValue)
+            }
+            guard let value = finalAutomergeValue else {
+                return AutomergeSingleValueDecodingContainer(
+                    impl: self,
+                    codingPath: codingPath,
+                    automergeValue: .Scalar(.Null),
+                    objectId: objectId
+                )
+            }
+            if case let .Object(textObjectId, .Text) = finalAutomergeValue {
+                // if we're creating a singleValueContainer to retrieve an
+                // Automerge Text node, then correct the objectId in the container
+                // and retrieve the text to make our lives easier in the decoding.
+                let stringValue = try doc.text(obj: textObjectId)
+                return AutomergeSingleValueDecodingContainer(
+                    impl: self,
+                    codingPath: codingPath,
+                    automergeValue: .Scalar(.String(stringValue)),
+                    objectId: textObjectId
+                )
+            } else {
+                return AutomergeSingleValueDecodingContainer(
+                    impl: self,
+                    codingPath: codingPath,
+                    automergeValue: value,
+                    objectId: objectId
+                )
+            }
+
+        case let .failure(err):
+            throw err
+        }
+    }
+}

--- a/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+struct AutomergeKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+    typealias Key = K
+
+    let impl: AutomergeDecoderImpl
+    let codingPath: [CodingKey]
+    let objectId: ObjId
+    let keys: [String]
+
+    init(impl: AutomergeDecoderImpl, codingPath: [CodingKey], objectId: ObjId) {
+        self.impl = impl
+        self.codingPath = codingPath
+        self.objectId = objectId
+        keys = impl.doc.keys(obj: objectId)
+    }
+
+    var allKeys: [K] {
+        keys.compactMap { K(stringValue: $0) }
+    }
+
+    func contains(_ key: K) -> Bool {
+        keys.contains(key.stringValue)
+    }
+
+    func decodeNil(forKey key: K) throws -> Bool {
+        let value = try getValue(forKey: key)
+        return value == .Scalar(.Null)
+    }
+
+    func decode(_ type: Bool.Type, forKey key: K) throws -> Bool {
+        let value = try getValue(forKey: key)
+
+        guard case let .Scalar(.Boolean(bool)) = value else {
+            throw createTypeMismatchError(type: type, forKey: key, value: value)
+        }
+
+        return bool
+    }
+
+    func decode(_ type: String.Type, forKey key: K) throws -> String {
+        let value = try getValue(forKey: key)
+
+        guard case let .Scalar(.String(string)) = value else {
+            throw createTypeMismatchError(type: type, forKey: key, value: value)
+        }
+
+        return string
+    }
+
+    func decode(_: Double.Type, forKey key: K) throws -> Double {
+        try decodeLosslessStringConvertible(key: key)
+    }
+
+    func decode(_: Float.Type, forKey key: K) throws -> Float {
+        try decodeLosslessStringConvertible(key: key)
+    }
+
+    func decode(_: Int.Type, forKey key: K) throws -> Int {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: Int8.Type, forKey key: K) throws -> Int8 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: Int16.Type, forKey key: K) throws -> Int16 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: Int32.Type, forKey key: K) throws -> Int32 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: Int64.Type, forKey key: K) throws -> Int64 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: UInt.Type, forKey key: K) throws -> UInt {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: UInt8.Type, forKey key: K) throws -> UInt8 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: UInt16.Type, forKey key: K) throws -> UInt16 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: UInt32.Type, forKey key: K) throws -> UInt32 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode(_: UInt64.Type, forKey key: K) throws -> UInt64 {
+        try decodeFixedWidthInteger(key: key)
+    }
+
+    func decode<S>(_: S.Type, forKey key: K) throws -> S where S: ScalarValueRepresentable {
+        let value = try getValue(forKey: key)
+        switch value {
+        case let .Scalar(scalarValue):
+            let conversionResult = S.fromScalarValue(scalarValue)
+            switch conversionResult {
+            case let .success(success):
+                return success
+            case let .failure(failure):
+                throw DecodingError.typeMismatch(S.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(S.self) from key \(key) but found \(value) instead.",
+                    underlyingError: failure
+                ))
+            }
+        default:
+            throw createTypeMismatchError(type: S.self, forKey: key, value: value)
+        }
+    }
+
+    func decode<T>(_: T.Type, forKey key: K) throws -> T where T: Decodable {
+        switch T.self {
+        case is Date.Type:
+            let retrievedValue = try getValue(forKey: key)
+            if case let Value.Scalar(.Timestamp(intValue)) = retrievedValue {
+                return Date(timeIntervalSince1970: Double(intValue)) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.timestamp`."
+                ))
+            }
+        case is Data.Type:
+            let retrievedValue = try getValue(forKey: key)
+            if case let Value.Scalar(.Bytes(data)) = retrievedValue {
+                return data as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.data`."
+                ))
+            }
+        case is Counter.Type:
+            let retrievedValue = try getValue(forKey: key)
+            if case let Value.Scalar(.Counter(counterValue)) = retrievedValue {
+                return Counter(counterValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.counter`."
+                ))
+            }
+        case is Text.Type:
+            let retrievedValue = try getValue(forKey: key)
+            if case let Value.Object(objectId, .Text) = retrievedValue {
+                let stringValue = try impl.doc.text(obj: objectId)
+                return Text(stringValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.text` object."
+                ))
+            }
+        default:
+            let decoder = try decoderForKey(key)
+            return try T(from: decoder)
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws
+        -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        try decoderForKey(key).container(keyedBy: type)
+    }
+
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        try decoderForKey(key).unkeyedContainer()
+    }
+
+    func superDecoder() throws -> Decoder {
+        impl
+    }
+
+    func superDecoder(forKey _: K) throws -> Decoder {
+        impl
+    }
+}
+
+extension AutomergeKeyedDecodingContainer {
+    private func decoderForKey(_ key: K) throws -> AutomergeDecoderImpl {
+        var newPath = codingPath
+        newPath.append(key)
+
+        return AutomergeDecoderImpl(
+            doc: impl.doc,
+            userInfo: impl.userInfo,
+            codingPath: newPath
+        )
+    }
+
+    @inline(__always) private func getValue(forKey key: K) throws -> Value {
+        guard let value = try impl.doc.get(obj: objectId, key: key.stringValue) else {
+            throw DecodingError.keyNotFound(key, .init(
+                codingPath: codingPath,
+                debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\")."
+            ))
+        }
+        return value
+    }
+
+    @inline(__always) private func createTypeMismatchError(type: Any.Type, forKey key: K, value: Value) ->
+        DecodingError
+    {
+        let codingPath = codingPath + [key]
+        return DecodingError.typeMismatch(type, .init(
+            codingPath: codingPath,
+            debugDescription: "Expected to decode \(type) but found \(value) instead."
+        ))
+    }
+
+    @inline(__always) private func decodeFixedWidthInteger<T: FixedWidthInteger>(key: Self.Key) throws -> T {
+        let value = try getValue(forKey: key)
+
+        guard case let .Scalar(scalar) = value else {
+            throw createTypeMismatchError(type: T.self, forKey: key, value: value)
+        }
+        switch scalar {
+        case let .Int(intValue):
+            return T(intValue)
+        case let .Uint(intValue):
+            return T(intValue)
+        default:
+            throw createTypeMismatchError(type: T.self, forKey: key, value: value)
+        }
+    }
+
+    @inline(__always) private func decodeLosslessStringConvertible<T: LosslessStringConvertible>(
+        key: Self.Key
+    ) throws -> T {
+        let value = try getValue(forKey: key)
+
+        guard case let .Scalar(.F64(number)) = value else {
+            throw createTypeMismatchError(type: T.self, forKey: key, value: value)
+        }
+
+        guard let floatingPoint = T(number.description) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: self,
+                debugDescription: "Parsed Automerge number <\(number)> does not fit in \(T.self)."
+            )
+        }
+
+        return floatingPoint
+    }
+}

--- a/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+struct AutomergeSingleValueDecodingContainer: SingleValueDecodingContainer {
+    let impl: AutomergeDecoderImpl
+    let value: Value
+    let codingPath: [CodingKey]
+
+    let objectId: ObjId
+
+    init(impl: AutomergeDecoderImpl, codingPath: [CodingKey], automergeValue: Value, objectId: ObjId) {
+        self.impl = impl
+        self.codingPath = codingPath
+        value = automergeValue
+        self.objectId = objectId
+    }
+
+    func decodeNil() -> Bool {
+        value == .Scalar(.Null)
+    }
+
+    func decode(_: Bool.Type) throws -> Bool {
+        guard case let .Scalar(.Boolean(bool)) = value else {
+            throw createTypeMismatchError(type: Bool.self, value: value)
+        }
+
+        return bool
+    }
+
+    func decode(_: String.Type) throws -> String {
+        guard case let .Scalar(.String(string)) = value else {
+            throw createTypeMismatchError(type: String.self, value: value)
+        }
+
+        return string
+    }
+
+    func decode(_: Double.Type) throws -> Double {
+        guard case let .Scalar(.F64(double)) = value else {
+            throw createTypeMismatchError(type: Double.self, value: value)
+        }
+        return double
+    }
+
+    func decode(_: Float.Type) throws -> Float {
+        guard case let .Scalar(.F64(double)) = value else {
+            throw createTypeMismatchError(type: Double.self, value: value)
+        }
+        return Float(double)
+    }
+
+    func decode(_: Int.Type) throws -> Int {
+        guard case let .Scalar(.Int(intValue)) = value else {
+            throw createTypeMismatchError(type: Int.self, value: value)
+        }
+        return Int(intValue)
+    }
+
+    func decode(_: Int8.Type) throws -> Int8 {
+        guard case let .Scalar(.Int(intValue)) = value else {
+            throw createTypeMismatchError(type: Int8.self, value: value)
+        }
+        return Int8(intValue)
+    }
+
+    func decode(_: Int16.Type) throws -> Int16 {
+        guard case let .Scalar(.Int(intValue)) = value else {
+            throw createTypeMismatchError(type: Int16.self, value: value)
+        }
+        return Int16(intValue)
+    }
+
+    func decode(_: Int32.Type) throws -> Int32 {
+        guard case let .Scalar(.Int(intValue)) = value else {
+            throw createTypeMismatchError(type: Int32.self, value: value)
+        }
+        return Int32(intValue)
+    }
+
+    func decode(_: Int64.Type) throws -> Int64 {
+        guard case let .Scalar(.Int(intValue)) = value else {
+            throw createTypeMismatchError(type: Int64.self, value: value)
+        }
+        return intValue
+    }
+
+    func decode(_: UInt.Type) throws -> UInt {
+        guard case let .Scalar(.Uint(uintValue)) = value else {
+            throw createTypeMismatchError(type: UInt.self, value: value)
+        }
+        return UInt(uintValue)
+    }
+
+    func decode(_: UInt8.Type) throws -> UInt8 {
+        guard case let .Scalar(.Uint(uintValue)) = value else {
+            throw createTypeMismatchError(type: UInt8.self, value: value)
+        }
+        return UInt8(uintValue)
+    }
+
+    func decode(_: UInt16.Type) throws -> UInt16 {
+        guard case let .Scalar(.Uint(uintValue)) = value else {
+            throw createTypeMismatchError(type: UInt16.self, value: value)
+        }
+        return UInt16(uintValue)
+    }
+
+    func decode(_: UInt32.Type) throws -> UInt32 {
+        guard case let .Scalar(.Uint(uintValue)) = value else {
+            throw createTypeMismatchError(type: UInt32.self, value: value)
+        }
+        return UInt32(uintValue)
+    }
+
+    func decode(_: UInt64.Type) throws -> UInt64 {
+        guard case let .Scalar(.Uint(uintValue)) = value else {
+            throw createTypeMismatchError(type: UInt64.self, value: value)
+        }
+        return uintValue
+    }
+
+    mutating func decode<S>(_: S.Type) throws -> S where S: ScalarValueRepresentable {
+        if case let .Scalar(scalarValue) = value {
+            let conversionResult = S.fromScalarValue(scalarValue)
+            switch conversionResult {
+            case let .success(success):
+                return success
+            case let .failure(failure):
+                throw DecodingError.typeMismatch(S.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(S.self) but found \(value) instead.",
+                    underlyingError: failure
+                ))
+            }
+        } else {
+            throw createTypeMismatchError(type: S.self, value: value)
+        }
+    }
+
+    func decode<T>(_: T.Type) throws -> T where T: Decodable {
+        switch T.self {
+        case is Date.Type:
+            if case let .Scalar(.Timestamp(intValue)) = value {
+                return Date(timeIntervalSince1970: Double(intValue)) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(value), but it wasn't a `.timestamp`."
+                ))
+            }
+        case is Data.Type:
+            if case let .Scalar(.Bytes(data)) = value {
+                return data as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(value), but it wasn't a `.data`."
+                ))
+            }
+        case is Counter.Type:
+            if case let .Scalar(.Counter(counterValue)) = value {
+                return Counter(counterValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(value), but it wasn't a `.counter`."
+                ))
+            }
+        case is Text.Type:
+            if case let .Scalar(.String(stringValue)) = value {
+                return Text(stringValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(value), but it wasn't `.text`."
+                ))
+            }
+
+        default:
+            return try T(from: impl)
+        }
+    }
+}
+
+extension AutomergeSingleValueDecodingContainer {
+    @inline(__always) private func createTypeMismatchError(type: Any.Type, value: Value) -> DecodingError {
+        DecodingError.typeMismatch(type, .init(
+            codingPath: codingPath,
+            debugDescription: "Expected to decode \(type) but found \(TypeOfAutomergeValue.from(value)) instead."
+        ))
+    }
+}

--- a/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+struct AutomergeUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+    let impl: AutomergeDecoderImpl
+    let codingPath: [CodingKey]
+    let objectId: ObjId
+
+    var count: Int?
+    var isAtEnd: Bool { currentIndex >= (count ?? 0) }
+    var currentIndex = 0
+
+    init(impl: AutomergeDecoderImpl, codingPath: [CodingKey], objectId: ObjId) {
+        self.impl = impl
+        self.codingPath = codingPath
+        self.objectId = objectId
+        count = Int(impl.doc.length(obj: objectId))
+    }
+
+    mutating func decodeNil() throws -> Bool {
+        if try getNextValue(ofType: Never.self) == .Scalar(.Null) {
+            currentIndex += 1
+            return true
+        }
+
+        // The protocol states:
+        //   If the value is not null, does not increment currentIndex.
+        return false
+    }
+
+    mutating func decode(_ type: Bool.Type) throws -> Bool {
+        let value = try getNextValue(ofType: Bool.self)
+        guard case let .Scalar(.Boolean(bool)) = value else {
+            throw createTypeMismatchError(type: type, value: value)
+        }
+
+        currentIndex += 1
+        return bool
+    }
+
+    mutating func decode(_ type: String.Type) throws -> String {
+        let value = try getNextValue(ofType: String.self)
+        guard case let .Scalar(.String(string)) = value else {
+            throw createTypeMismatchError(type: type, value: value)
+        }
+
+        currentIndex += 1
+        return string
+    }
+
+    mutating func decode(_: Double.Type) throws -> Double {
+        try decodeBinaryFloatingPoint()
+    }
+
+    mutating func decode(_: Float.Type) throws -> Float {
+        try decodeBinaryFloatingPoint()
+    }
+
+    mutating func decode(_: Int.Type) throws -> Int {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: Int8.Type) throws -> Int8 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: Int16.Type) throws -> Int16 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: Int32.Type) throws -> Int32 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: Int64.Type) throws -> Int64 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: UInt.Type) throws -> UInt {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: UInt8.Type) throws -> UInt8 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: UInt16.Type) throws -> UInt16 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: UInt32.Type) throws -> UInt32 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode(_: UInt64.Type) throws -> UInt64 {
+        try decodeFixedWidthInteger()
+    }
+
+    mutating func decode<S>(_: S.Type) throws -> S where S: ScalarValueRepresentable {
+        let value = try getNextValue(ofType: S.self)
+
+        switch value {
+        case let .Scalar(scalarValue):
+            let conversionResult = S.fromScalarValue(scalarValue)
+            switch conversionResult {
+            case let .success(success):
+                currentIndex += 1
+                return success
+            case let .failure(failure):
+                throw DecodingError.typeMismatch(S.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(S.self) but found \(value) instead.",
+                    underlyingError: failure
+                ))
+            }
+        default:
+            throw createTypeMismatchError(type: S.self, value: value)
+        }
+    }
+
+    mutating func decode<T>(_: T.Type) throws -> T where T: Decodable {
+        switch T.self {
+        case is Date.Type:
+            let retrievedValue = try getNextValue(ofType: Date.self)
+            if case let Value.Scalar(.Timestamp(intValue)) = retrievedValue {
+                currentIndex += 1
+                return Date(timeIntervalSince1970: Double(intValue)) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.timestamp`."
+                ))
+            }
+        case is Data.Type:
+            let retrievedValue = try getNextValue(ofType: Data.self)
+            if case let Value.Scalar(.Bytes(data)) = retrievedValue {
+                currentIndex += 1
+                return data as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.data`."
+                ))
+            }
+        case is Counter.Type:
+            let retrievedValue = try getNextValue(ofType: Counter.self)
+            if case let Value.Scalar(.Counter(counterValue)) = retrievedValue {
+                currentIndex += 1
+                return Counter(counterValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.counter`."
+                ))
+            }
+        case is Text.Type:
+            let retrievedValue = try getNextValue(ofType: Text.self)
+            if case let Value.Object(objectId, .Text) = retrievedValue {
+                let stringValue = try impl.doc.text(obj: objectId)
+                currentIndex += 1
+                return Text(stringValue) as! T
+            } else {
+                throw DecodingError.typeMismatch(T.self, .init(
+                    codingPath: codingPath,
+                    debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.text` object."
+                ))
+            }
+        default:
+            let decoder = try decoderForNextElement(ofType: T.self)
+            let result = try T(from: decoder)
+
+            // Because of the requirement that the index not be incremented unless
+            // decoding the desired result type succeeds, it can not be a tail call.
+            // Hopefully the compiler still optimizes well enough that the result
+            // doesn't get copied around.
+            currentIndex += 1
+            return result
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws
+        -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        let decoder = try decoderForNextElement(ofType: KeyedDecodingContainer<NestedKey>.self, isNested: true)
+        let container = try decoder.container(keyedBy: type)
+
+        currentIndex += 1
+        return container
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        let decoder = try decoderForNextElement(ofType: UnkeyedDecodingContainer.self, isNested: true)
+        let container = try decoder.unkeyedContainer()
+
+        currentIndex += 1
+        return container
+    }
+
+    mutating func superDecoder() throws -> Decoder {
+        impl
+    }
+}
+
+extension AutomergeUnkeyedDecodingContainer {
+    private mutating func decoderForNextElement<T>(
+        ofType _: T.Type,
+        isNested _: Bool = false
+    ) throws -> AutomergeDecoderImpl {
+        let newPath = codingPath + [AnyCodingKey(UInt64(currentIndex))]
+
+        return AutomergeDecoderImpl(
+            doc: impl.doc,
+            userInfo: impl.userInfo,
+            codingPath: newPath
+        )
+    }
+
+    /// - Note: Instead of having the `isNested` parameter, it would have been quite nice to just check whether
+    ///   `T` conforms to either `KeyedDecodingContainer` or `UnkeyedDecodingContainer`. Unfortunately, since
+    ///   `KeyedDecodingContainer` takes a generic parameter (the `Key` type), we can't just ask if `T` is one, and
+    ///   type-erasure workarounds are not appropriate to this use case due to, among other things, the inability to
+    ///   conform most of the types that would matter. We also can't use `KeyedDecodingContainerProtocol` for the
+    ///   purpose, as it isn't even an existential and conformance to it can't be checked at runtime at all.
+    ///
+    ///   However, it's worth noting that the value of `isNested` is always a compile-time constant and the compiler
+    ///   can quite neatly remove whichever branch of the `if` is not taken during optimization, making doing it this
+    ///   way _much_ more performant (for what little it matters given that it's only checked in case of an error).
+    @inline(__always)
+    private func getNextValue<T>(ofType _: T.Type, isNested: Bool = false) throws -> Value {
+        guard !isAtEnd else {
+            if isNested {
+                throw DecodingError.valueNotFound(
+                    T.self,
+                    .init(
+                        codingPath: codingPath,
+                        debugDescription: "Cannot get nested keyed container -- unkeyed container is at end.",
+                        underlyingError: nil
+                    )
+                )
+            } else {
+                throw DecodingError.valueNotFound(
+                    T.self,
+                    .init(
+                        codingPath: [AnyCodingKey(UInt64(currentIndex))],
+                        debugDescription: "Unkeyed container is at end.",
+                        underlyingError: nil
+                    )
+                )
+            }
+        }
+        if let value = try impl.doc.get(obj: objectId, index: UInt64(currentIndex)) {
+            return value
+        } else {
+            throw DecodingError.valueNotFound(
+                T.self,
+                .init(
+                    codingPath: codingPath,
+                    debugDescription: "Cannot get nested keyed container -- unkeyed container is at end.",
+                    underlyingError: nil
+                )
+            )
+        }
+    }
+
+    @inline(__always) private func createTypeMismatchError(type: Any.Type, value: Value) -> DecodingError {
+        let codingPath = codingPath + [AnyCodingKey(UInt64(currentIndex))]
+        return DecodingError.typeMismatch(type, .init(
+            codingPath: codingPath,
+            debugDescription: "Expected to decode \(type) but found \(value) instead."
+        ))
+    }
+
+    @inline(__always) private mutating func decodeFixedWidthInteger<T: FixedWidthInteger>() throws -> T {
+        let value = try getNextValue(ofType: T.self)
+
+        switch value {
+        case let .Scalar(.Int(intValue)):
+            let integer = T(intValue)
+            currentIndex += 1
+            return integer
+        case let .Scalar(.Uint(intValue)):
+            let integer = T(intValue)
+            currentIndex += 1
+            return integer
+        default:
+            throw createTypeMismatchError(type: T.self, value: value)
+        }
+    }
+
+    @inline(__always) private mutating func decodeBinaryFloatingPoint<T: LosslessStringConvertible>() throws -> T {
+        let value = try getNextValue(ofType: T.self)
+        guard case let .Scalar(.F64(double)) = value else {
+            throw createTypeMismatchError(type: T.self, value: value)
+        }
+
+        guard let float = T(double.description) else {
+            throw DecodingError.dataCorruptedError(
+                in: self,
+                debugDescription: "Parsed Automerge floating point value <\(double)> does not fit in \(T.self)."
+            )
+        }
+
+        currentIndex += 1
+        return float
+    }
+}

--- a/Sources/Automerge/Codable/Document+lookupPath.swift
+++ b/Sources/Automerge/Codable/Document+lookupPath.swift
@@ -1,0 +1,63 @@
+public extension Document {
+    /// Looks up the objectId represented by the schema path string you provide.
+    /// - Parameter path: A string representation of the location within an Automerge document.
+    /// - Returns: The objectId at the schema location you provide, or nil if the path is valid and no object exists in
+    /// the document.
+    ///
+    /// The method throws errors on invalid paths
+    func lookupPath(path: String) throws -> ObjId? {
+        let codingPath = try AnyCodingKey.parsePath(path)
+        if codingPath.isEmpty {
+            return ObjId.ROOT
+        }
+        let result = retrieveObjectId(
+            path: codingPath,
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(objectId):
+            let existingValue: Value?
+            guard let finalCodingKey = codingPath.last else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue("Attempting to establish a single value container with an empty coding path.")
+            }
+            // get any existing value - type of the `get` call is based on the key type
+            if let indexValue = finalCodingKey.intValue {
+                let indexSize = length(obj: objectId)
+                if indexValue > indexSize {
+                    throw CodingKeyLookupError
+                        .IndexOutOfBounds("Attempted to look up index \(indexValue) from a list of size \(indexSize).")
+                }
+                existingValue = try get(obj: objectId, index: UInt64(indexValue))
+            } else {
+                existingValue = try get(obj: objectId, key: finalCodingKey.stringValue)
+            }
+            // if the result found is an Automerge container (Text, List, or Object)
+            // then return the value
+            if case let .Object(finalObjectId, _) = existingValue {
+                return finalObjectId
+            } else {
+                // Otherwise, return nil for any leaf nodes (scalar values or missing schema)
+                return nil
+            }
+        case let .failure(lookupError):
+            throw lookupError
+        }
+    }
+}
+
+extension Sequence where Element == Automerge.PathElement {
+    /// Returns a string that represents the schema path.
+    func stringPath() -> String {
+        let path = map { pathElement in
+            switch pathElement.prop {
+            case let .Index(idx):
+                return String("[\(idx)]")
+            case let .Key(key):
+                return key
+            }
+        }.joined(separator: ".")
+        return ".\(path)"
+    }
+}

--- a/Sources/Automerge/Codable/Document+retrieveObjectId.swift
+++ b/Sources/Automerge/Codable/Document+retrieveObjectId.swift
@@ -1,0 +1,600 @@
+import os // for structured logging
+
+@usableFromInline
+func tracePrint(indent: Int = 0, _ stringval: String) {
+    #if DEBUG
+    if #available(macOS 11, iOS 14, *) {
+        let logger = Logger(subsystem: "Automerge", category: "AutomergeEncoder")
+        let prefix = String(repeating: " ", count: indent)
+        logger.debug("\(prefix, privacy: .public)\(stringval, privacy: .public)")
+    }
+    #endif
+}
+
+// // MARK: Cache for Object Id Lookups
+//
+// typealias CacheKey = [AnyCodingKey]
+// var cache: [CacheKey: ObjId] = [:]
+//
+// func upsert(_ key: CacheKey, value: ObjId) {
+//    if cache[key] == nil {
+//        cache[key] = value
+//    }
+// }
+
+extension Document {
+    /// Returns an Automerge objectId for the location within the document.
+    ///
+    /// The function looks up an Automerge Object Id for a specific schema location, optionally creating schema if
+    /// needed.
+    /// The combination of `path` and `containerType` determine the `ObjId` returned:
+    /// - when requesting an objectId with the type ``EncodingContainerType/Value``, the object Id
+    /// from the second to last coding key element is returned, expecting the call-site to do any further look ups based
+    /// on the final coding key.
+    /// - when requesting an objectId with types ``EncodingContainerType/Index`` or
+    /// ``EncodingContainerType/Key``, the object Id is derived from the last coding key element,
+    /// and the `containerType` is checked to verify it matches the Automerge schema.
+    ///
+    /// Control the pattern of when to create schema and what errors to throw by setting the `strategy` property.
+    ///
+    /// - Parameters:
+    ///   - path: An array of instances conforming to CodingKey that make up the schema path.
+    ///   - containerType: The container type for the lookup, which effects what is returned and at what level of the
+    /// path.
+    ///   - strategy: The strategy for creating schema during encoding if it doesn't exist or conflicts with existing
+    /// schema. The strategy defaults to ``SchemaStrategy/default``.
+    /// - Returns: A result type that contains a tuple of an Automerge object Id of the relevant container, or an error
+    /// if the retrieval failed or there was conflicting schema within in the document.
+    @inlinable func retrieveObjectId(
+        path: [CodingKey],
+        containerType: EncodingContainerType,
+        strategy: SchemaStrategy
+    ) -> Result<ObjId, CodingKeyLookupError> {
+        // with .Value container type returning second-to-last ObjectId, and expecting the
+        // caller to know they'll need to special case whatever they do with the final piece.
+
+        // CONSIDER: making a method that takes an objectId and CodingKey and returns the Value?
+
+        // This method returns a Result type because the Codable protocol constrains the
+        // container initializers to not throw on initialization.
+        // Instead we stash the lookup failure into the container, and throw the relevant
+        // error on any call to one of the `.encode()` methods, which do throw.
+        // This defers the error condition, and the container is essentially invalid in this
+        // state, but it provides a smoother integration with Codable.
+
+        // Path scenarios by the type of Codable container that invokes the lookup.
+        //
+        // [] + Key -> ObjId.ROOT
+        // [] + Index = error
+        // [] + Value = error
+        // [foo] + Value = ObjId.Root
+        // [foo] + Index = error
+        // [foo] + Key = ObjId.lookup(/Root/foo)   (container)
+        // [1] + (Value|Index|Key) = error (root is always a map)
+        // [foo, 1] + Value = /Root/foo, index 1
+        // [foo, 1] + Index = /Root/foo, index 1   (container)
+        // [foo, 1] + Key = /Root/foo, index 1     (container)
+        // [foo, bar] + Value = /Root/foo, key bar
+        // [foo, bar] + Index = /Root/foo, key bar (container)
+        // [foo, bar] + Key = /Root/foo, key bar   (container)
+
+        // Pre-allocate an array the same length as `path` for ObjectId lookups
+        var matchingObjectIds: [Int: ObjId] = [:]
+        matchingObjectIds.reserveCapacity(path.count)
+
+        tracePrint(
+            "`retrieveObjectId` with path [\(path.map { AnyCodingKey($0) })] for container type \(containerType), with strategy: \(strategy)"
+        )
+
+        // - Efficiency boost using a cache
+        // Iterate from the N-1 end of path, backwards - checking [] -> (ObjectId, ObjType) cache,
+        // checking until we get a positive hit from the cache. Worst case there'll be nothing in
+        // the cache and we iterate to the bottom. Save that as the starting cursor position.
+        let startingPosition = 0
+        var previousObjectId = ObjId.ROOT
+
+        if strategy == .override {
+            return .failure(CodingKeyLookupError.UnexpectedLookupFailure("Override strategy not yet implemented"))
+        }
+
+        // initial conditions if we're handed an empty path
+        if path.isEmpty {
+            switch containerType {
+            case .Key:
+                return .success(ObjId.ROOT)
+            case .Index, .Value:
+                return .failure(
+                    CodingKeyLookupError
+                        .InvalidIndexLookup("An empty path refers to ROOT and is always a map.")
+                )
+            }
+        }
+
+        // Iterate the cursor position forward doing lookups against the Automerge document
+        // until we get to the second-to-last element. This range ensures that we're iterating
+        // over "expected containers"
+        for position in startingPosition ..< (path.count - 1) {
+            tracePrint(indent: position, "Checking position \(position): '\(path[position])'")
+            // Strategy to use while creating schema:
+            // defined in SchemaStrategy
+
+            // (default)
+            // schema-create-on-nil: If the schema *doesn't* exist - nil lookups when searched - create
+            // the relevant schema as it goes. This doesn't account for any specific value types or type checking.
+            //
+            // schema-error-on-type-mismatch: If schema in Automerge is a scalar value, Text, or mis-matched
+            // list/object types, throw an error instead of overwriting the schema.
+
+            // (!override!)
+            // schema-overwrite: Disregard any schema that currently exists and overwrite values as needed to
+            // establish the schema that is being encoded.
+
+            // (?readonly?)
+            // read-only/super-double-strict: Only allow encoding into schema that is ALREADY present within
+            // Automerge. Adding additional values (to a map, or to a list) would be invalid in these cases.
+            // In a large sense, it's an "update values only" kind of scenario.
+
+            // Determine the type of the previous element by inspecting the current path.
+            // If it's got an index value, then it's a reference in a list.
+            // Otherwise it's a key on an object.
+            if let indexValue = path[position].intValue {
+                tracePrint(indent: position, "Checking against index position \(indexValue).")
+                // If it's an index, verify that it doesn't represent an element beyond the end of an existing list.
+                if indexValue > length(obj: previousObjectId) {
+                    if strategy == .readonly {
+                        return .failure(
+                            CodingKeyLookupError
+                                .IndexOutOfBounds(
+                                    "Index value \(indexValue) is beyond the length: \(length(obj: previousObjectId)) and schema is read-only"
+                                )
+                        )
+                    } else if indexValue > (length(obj: previousObjectId) + 1) {
+                        return .failure(
+                            CodingKeyLookupError
+                                .IndexOutOfBounds(
+                                    "Index value \(indexValue) is too far beyond the length: \(length(obj: previousObjectId)) to append a new item."
+                                )
+                        )
+                    }
+                }
+
+                // Look up Automerge `Value` matching this index within the list
+                do {
+                    if let value = try get(obj: previousObjectId, index: UInt64(indexValue)) {
+                        switch value {
+                        case let .Object(objId, objType):
+                            //                EncoderPathCache.upsert(extendedPath, value: (objId, objType))
+                            // if the type of Object is Text, we should error here because the schema can't extend
+                            // through a
+                            // leaf node
+                            if objType == .Text {
+                                // If the looked up Value is a Text node, then it's a leaf on the schema structure.
+                                // If there's remaining values to be looked up, the overall path is invalid.
+                                return .failure(
+                                    CodingKeyLookupError
+                                        .PathExtendsThroughText(
+                                            "Path at \(path[0 ... position]) is a Text object, which is not a container - and the path has additional elements: \(path[(position + 1)...])."
+                                        )
+                                )
+                            }
+                            matchingObjectIds[position] = objId
+                            previousObjectId = objId
+                            tracePrint(
+                                indent: position,
+                                "Found \(path[0 ... position]) as objectId \(objId) of type \(objType)"
+                            )
+                        case .Scalar:
+                            // If the looked up Value is a Scalar value, then it's a leaf on the schema structure.
+                            return .failure(
+                                CodingKeyLookupError
+                                    .PathExtendsThroughScalar(
+                                        "Path at \(path[0 ... position]) is a single value, not a container - and the path has additional elements: \(path[(position + 1)...])."
+                                    )
+                            )
+                        }
+                    } else { // value returned from the lookup in Automerge at this position is `nil`
+                        tracePrint(
+                            indent: position,
+                            "Nothing pre-existing in schema at \(path[0 ... position]), will need to create a container."
+                        )
+                        if strategy == .readonly {
+                            // path is a valid request, there's just nothing there
+                            return .failure(
+                                CodingKeyLookupError
+                                    .SchemaMissing(
+                                        "Nothing in schema exists at \(path[0 ... position]) - look u returns nil"
+                                    )
+                            )
+                        } else { // couldn't find the object via lookup, so we need to create it
+                            // Look up the kind of object to create by inspecting the "next path" element
+                            tracePrint(indent: position, "Need to create a container at \(path[0 ... position]).")
+                            tracePrint(indent: position, "Next path element is '\(path[position + 1])'.")
+                            if let _ = path[position + 1].intValue {
+                                // the next item is a list, so create a new list within this list at the index value the
+                                // current position indicates.
+                                let newObjectId = try insertObject(
+                                    obj: previousObjectId,
+                                    index: UInt64(indexValue),
+                                    ty: .List
+                                )
+                                matchingObjectIds[position] = newObjectId
+                                previousObjectId = newObjectId
+                                tracePrint(
+                                    indent: position,
+                                    "created \(path[0 ... position]) as objectId \(newObjectId) of type List"
+                                )
+                                // add to cache
+                                //                        EncoderPathCache.upsert(extendedPath,value: (newObjectId,
+                                //                        .List))
+                            } else {
+                                // need to create an object
+                                let newObjectId = try insertObject(
+                                    obj: previousObjectId,
+                                    index: UInt64(indexValue),
+                                    ty: .Map
+                                )
+                                matchingObjectIds[position] = newObjectId
+                                previousObjectId = newObjectId
+                                tracePrint(
+                                    indent: position,
+                                    "created \(path[0 ... position]) as objectId \(newObjectId) of type Map"
+                                )
+                                // add to cache
+                                //                        EncoderPathCache.upsert(extendedPath,value: (newObjectId,
+                                //                        .Map))
+                                // carry on with remaining path elements
+                            }
+                        }
+                    }
+                } catch {
+                    return .failure(.AutomergeDocError(error))
+                }
+            } else { // path[position] is a string-based key, so we need to get - or insert - an Object
+                let keyValue = path[position].stringValue
+                tracePrint(indent: position, "Checking against key \(keyValue).")
+                do {
+                    if let value = try get(obj: previousObjectId, key: keyValue) {
+                        switch value {
+                        case let .Object(objId, objType):
+                            //                EncoderPathCache.upsert(extendedPath, value: (objId, objType))
+
+                            // If the looked up Value is a Text node, then it's a leaf on the schema structure.
+                            // If there's remaining values to be looked up, the overall path is invalid.
+                            if objType == .Text {
+                                return .failure(
+                                    CodingKeyLookupError
+                                        .PathExtendsThroughText(
+                                            "Path at \(path[0 ... position]) is a Text object, which is not a container - and the path has additional elements: \(path[(position + 1)...])."
+                                        )
+                                )
+                            }
+                            matchingObjectIds[position] = objId
+                            previousObjectId = objId
+                            tracePrint(
+                                indent: position,
+                                "Found \(path[0 ... position]) as objectId \(objId) of type \(objType)"
+                            )
+                        case .Scalar:
+                            // If the looked up Value is a Scalar value, then it's a leaf on the schema structure.
+                            // If there's remaining values to be looked up, the overall path is invalid.
+                            return .failure(
+                                CodingKeyLookupError
+                                    .PathExtendsThroughScalar(
+                                        "Path at \(path[0 ... position]) is a single value, not a container - and the path has additional elements: \(path[(position + 1)...])."
+                                    )
+                            )
+                        }
+                    } else { // value returned from doc.get() is nil, we'll need to create it
+                        tracePrint(
+                            indent: position,
+                            "Nothing pre-existing in schema at \(path[0 ... position]), will need to create a container."
+                        )
+                        if strategy == .readonly {
+                            // path is a valid request, there's just nothing there
+                            return .failure(
+                                CodingKeyLookupError
+                                    .SchemaMissing(
+                                        "Nothing in schema exists at \(path[0 ... position]) - look u returns nil"
+                                    )
+                            )
+                        } else { // looked-up value was nil AND we're not read-only, create the object
+                            tracePrint(indent: position, "Need to create a container at \(path[0 ... position]).")
+                            tracePrint(indent: position, "Next path element is \(path[position + 1]).")
+                            // Look up the kind of object to create by inspecting the "next path" element
+                            if let _ = path[position + 1].intValue {
+                                // the next item is a list, so create a new list within this object using the key value
+                                // the current position indicates.
+                                let newObjectId = try putObject(
+                                    obj: previousObjectId,
+                                    key: keyValue,
+                                    ty: .List
+                                )
+                                matchingObjectIds[position] = newObjectId
+                                previousObjectId = newObjectId
+                                tracePrint(
+                                    indent: position,
+                                    "created \(path[0 ... position]) as objectId \(newObjectId) of type List"
+                                )
+                                // add to cache
+                                //                       EncoderPathCache.upsert(extendedPath, value: (newObjectId,
+                                //                        .List))
+                            } else {
+                                // the next item is an object, so create a new object within this object using the key
+                                // value the current position indicates.
+                                let newObjectId = try putObject(
+                                    obj: previousObjectId,
+                                    key: keyValue,
+                                    ty: .Map
+                                )
+                                matchingObjectIds[position] = newObjectId
+                                previousObjectId = newObjectId
+                                tracePrint(
+                                    indent: position,
+                                    "created \(path[0 ... position]) as objectId \(newObjectId) of type Map"
+                                )
+                                // add to cache
+                                //                       EncoderPathCache.upsert(extendedPath, value: (newObjectId,
+                                //                        .Map))
+                                // carry on with remaining pathelements
+                            }
+                        }
+                    }
+                } catch {
+                    return .failure(.AutomergeDocError(error))
+                }
+            }
+        }
+
+        #if DEBUG
+        tracePrint("All prior containers created or found:")
+        for position in startingPosition ..< (path.count - 1) {
+            tracePrint("   \(position) -> \(String(describing: matchingObjectIds[position]))")
+        }
+        #endif
+
+        // Then what we do depends on the type of lookup.
+        // - on SingleValueContainer, we return the second-to-last objectId and the key and/or Index
+        // - on KeyedContainer or UnkeyedContainer, we look up and return the final objectId
+        let finalpiece = path[path.count - 1]
+        switch containerType {
+        case .Index, .Key: // the element that we're looking up (or creating) is for a key or index container
+            if let indexValue = finalpiece.intValue { // The value within the CodingKey indicates it's a List
+                tracePrint(
+                    indent: path.count - 1,
+                    "Final piece of the path is '\(finalpiece)', index \(indexValue) of a List."
+                )
+                // short circuit beyond-length of array
+                if indexValue > length(obj: previousObjectId) {
+                    if strategy == .readonly {
+                        return .failure(
+                            CodingKeyLookupError
+                                .IndexOutOfBounds(
+                                    "Index value \(indexValue) is beyond the length: \(length(obj: previousObjectId)) and schema is read-only"
+                                )
+                        )
+                    } else if indexValue > (length(obj: previousObjectId) + 1) {
+                        return .failure(
+                            CodingKeyLookupError
+                                .IndexOutOfBounds(
+                                    "Index value \(indexValue) is too far beyond the length: \(length(obj: previousObjectId)) to append a new item."
+                                )
+                        )
+                    }
+                }
+
+                // Look up Automerge `Value` matching this index within the list
+                do {
+                    tracePrint(
+                        indent: path.count - 1,
+                        "Look up what's at index \(indexValue) of objectId: \(previousObjectId):"
+                    )
+                    if let value = try get(obj: previousObjectId, index: UInt64(indexValue)) {
+                        switch value {
+                        case let .Object(objId, objType):
+                            switch objType {
+                            case .Text:
+                                return .failure(
+                                    CodingKeyLookupError
+                                        .MismatchedSchema(
+                                            "Path at \(path) is a Text object, which is not the List container that we expected."
+                                        )
+                                )
+                            case .Map:
+                                if containerType == .Key {
+                                    tracePrint("Found Object container with ObjectId \(objId).")
+                                    return .success(objId)
+                                } else {
+                                    return .failure(
+                                        CodingKeyLookupError
+                                            .MismatchedSchema(
+                                                "Path at \(path) is an object container, not the List container that we expected."
+                                            )
+                                    )
+                                }
+                            case .List:
+                                //                            EncoderPathCache.upsert(extendedPath, value: (objId,
+                                //                            objType))
+                                if containerType == .Index {
+                                    tracePrint("Found List container with ObjectId \(objId).")
+                                    return .success(objId)
+                                } else {
+                                    return .failure(
+                                        CodingKeyLookupError
+                                            .MismatchedSchema(
+                                                "Path at \(path) is a list container, not the Object container that we expected."
+                                            )
+                                    )
+                                }
+                            }
+                        case .Scalar:
+                            // If the looked up Value is a Scalar value, then it's a leaf on the schema structure.
+                            return .failure(
+                                CodingKeyLookupError
+                                    .MismatchedSchema(
+                                        "Path at \(path) is an scalar value, which is not the List container that we expected."
+                                    )
+                            )
+                        }
+                    } else { // value returned from the lookup in Automerge at this position is `nil`
+                        tracePrint(indent: path.count - 1, "Need to create a container at \(path).")
+                        tracePrint(indent: path.count - 1, "Path type to create is \(containerType).")
+                        if strategy == .readonly {
+                            // path is a valid request, there's just nothing there
+                            return .failure(
+                                CodingKeyLookupError
+                                    .SchemaMissing(
+                                        "Nothing in schema exists at \(path) - look u returns nil"
+                                    )
+                            )
+                        } else {
+                            if containerType == .Index {
+                                // need to create a list within the list
+                                let newObjectId = try insertObject(
+                                    obj: previousObjectId,
+                                    index: UInt64(indexValue),
+                                    ty: .List
+                                )
+                                //                        EncoderPathCache.upsert(extendedPath, value: (objId, .List))
+                                tracePrint(
+                                    indent: path.count - 1,
+                                    "Created new List container with ObjectId \(newObjectId)."
+                                )
+                                return .success(newObjectId)
+                            } else {
+                                // need to create a map within the list
+                                let newObjectId = try insertObject(
+                                    obj: previousObjectId,
+                                    index: UInt64(indexValue),
+                                    ty: .Map
+                                )
+                                //                        EncoderPathCache.upsert(extendedPath, value: (objId, .List))
+                                tracePrint(
+                                    indent: path.count - 1,
+                                    "Created new Map container with ObjectId \(newObjectId)."
+                                )
+                                return .success(newObjectId)
+                            }
+                        }
+                    }
+                } catch {
+                    return .failure(.AutomergeDocError(error))
+                }
+            } else { // final path element is a key
+                let keyValue = finalpiece.stringValue
+
+                // Look up Automerge `Value` matching this key on an object
+                do {
+                    tracePrint(
+                        indent: path.count - 1,
+                        "Look up what's at key '\(keyValue)' of objectId: \(previousObjectId)."
+                    )
+                    if let value = try get(obj: previousObjectId, key: keyValue) {
+                        switch value {
+                        case let .Object(objId, objType):
+                            switch objType {
+                            case .Text:
+                                return .failure(
+                                    CodingKeyLookupError
+                                        .MismatchedSchema(
+                                            "Container at \(path) is a Text object, which is not the Object container expected."
+                                        )
+                                )
+                            case .Map:
+                                if containerType == .Key {
+                                    //                            EncoderPathCache.upsert(extendedPath, value: (objId,
+                                    //                            objType))
+                                    tracePrint(indent: path.count - 1, "Found Map container with ObjectId \(objId).")
+                                    return .success(objId)
+                                } else {
+                                    return .failure(
+                                        CodingKeyLookupError
+                                            .MismatchedSchema(
+                                                "Container at \(path) is a Map container, not the List container that we expected."
+                                            )
+                                    )
+                                }
+                            case .List:
+                                if containerType == .Index {
+                                    //                            EncoderPathCache.upsert(extendedPath, value: (objId,
+                                    //                            objType))
+                                    tracePrint(indent: path.count - 1, "Found List container with ObjectId \(objId).")
+                                    return .success(objId)
+                                } else {
+                                    return .failure(
+                                        CodingKeyLookupError
+                                            .MismatchedSchema(
+                                                "Container at \(path) is a List container, not the object container that we expected."
+                                            )
+                                    )
+                                }
+                            }
+                        case .Scalar:
+                            // If the looked up Value is a Scalar value, then it's a leaf on the schema structure.
+                            return .failure(
+                                CodingKeyLookupError
+                                    .MismatchedSchema(
+                                        "Item at \(path) is an scalar value, which is not the List container that we expected."
+                                    )
+                            )
+                        }
+                    } else { // value returned from the lookup in Automerge at this position is `nil`
+                        tracePrint(indent: path.count - 1, "Need to create a container at \(path).")
+                        tracePrint(indent: path.count - 1, "Path type to create is \(containerType).")
+                        if strategy == .readonly {
+                            // path is a valid request, there's just nothing there
+                            return .failure(
+                                CodingKeyLookupError
+                                    .SchemaMissing(
+                                        "Nothing in schema exists at \(path) - look u returns nil"
+                                    )
+                            )
+                        } else {
+                            if containerType == .Index {
+                                // need to create a list within the list
+                                let newObjectId = try putObject(
+                                    obj: previousObjectId,
+                                    key: keyValue,
+                                    ty: .List
+                                )
+                                //                        EncoderPathCache.upsert(extendedPath, value: (objId, .List))
+                                tracePrint(
+                                    indent: path.count - 1,
+                                    "Created new List container with ObjectId \(newObjectId)."
+                                )
+                                return .success(newObjectId)
+                            } else {
+                                // need to create a map within the list
+                                let newObjectId = try putObject(
+                                    obj: previousObjectId,
+                                    key: keyValue,
+                                    ty: .Map
+                                )
+                                //                        EncoderPathCache.upsert(extendedPath, value: (objId, .List))
+                                tracePrint(
+                                    indent: path.count - 1,
+                                    "Created new Map container with ObjectId \(newObjectId)."
+                                )
+                                return .success(newObjectId)
+                            }
+                        }
+                    }
+                } catch {
+                    return .failure(.AutomergeDocError(error))
+                }
+            }
+        case .Value:
+            if path.count < 2 {
+                // corner case where the root encoder (equivalent to position -1 in the matchingObjectIds) isn't in the
+                // lookup list
+                return .success(ObjId.ROOT)
+            } else {
+                guard let containerObjectId = matchingObjectIds[path.count - 2] else {
+                    fatalError(
+                        "objectId lookups failed to identify an object Id for the last element in path: \(path)"
+                    )
+                }
+                return .success(containerObjectId)
+            }
+        }
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
@@ -1,3 +1,4 @@
+/// An encoder that stores codable-conforming types into an Automerge document.
 public struct AutomergeEncoder {
     public var userInfo: [CodingUserInfoKey: Any] = [:]
     var doc: Document

--- a/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
@@ -1,0 +1,42 @@
+public struct AutomergeEncoder {
+    public var userInfo: [CodingUserInfoKey: Any] = [:]
+    var doc: Document
+    var schemaStrategy: SchemaStrategy
+    var cautiousWrite: Bool
+
+    public init(doc: Document, strategy: SchemaStrategy = .createWhenNeeded, cautiousWrite: Bool = false) {
+        self.doc = doc
+        schemaStrategy = strategy
+        self.cautiousWrite = cautiousWrite
+    }
+
+    public func encode<T: Encodable>(_ value: T?) throws {
+        // capture any top-level optional types being encoded, and encode as
+        // the underlying type if the provided value isn't nil.
+        if let definiteValue = value {
+            try encode(definiteValue)
+        }
+    }
+
+    public func encode<T: Encodable>(_ value: T) throws {
+        let encoder = AutomergeEncoderImpl(
+            userInfo: userInfo,
+            codingPath: [],
+            doc: doc,
+            strategy: schemaStrategy,
+            cautiousWrite: cautiousWrite
+        )
+        try value.encode(to: encoder)
+    }
+
+    public func encode<T: Encodable>(_ value: T, at path: [CodingKey]) throws {
+        let encoder = AutomergeEncoderImpl(
+            userInfo: userInfo,
+            codingPath: path,
+            doc: doc,
+            strategy: schemaStrategy,
+            cautiousWrite: cautiousWrite
+        )
+        try value.encode(to: encoder)
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/AutomergeEncoderImpl.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeEncoderImpl.swift
@@ -1,0 +1,101 @@
+/// The internal implementation of AutomergeEncoder.
+///
+/// Instances of the class capture one of the various kinds of schema value types - single value, array, or object.
+/// The instance also tracks the dynamic state associated with that value as it encodes types you provide.
+final class AutomergeEncoderImpl {
+    let userInfo: [CodingUserInfoKey: Any]
+    let codingPath: [CodingKey]
+    let document: Document
+    let schemaStrategy: SchemaStrategy
+    let cautiousWrite: Bool
+
+    // indicator that the singleValue has written a value
+    var singleValueWritten: Bool = false
+
+    init(
+        userInfo: [CodingUserInfoKey: Any],
+        codingPath: [CodingKey],
+        doc: Document,
+        strategy: SchemaStrategy,
+        cautiousWrite: Bool
+    ) {
+        self.userInfo = userInfo
+        self.codingPath = codingPath
+        document = doc
+        schemaStrategy = strategy
+        self.cautiousWrite = cautiousWrite
+    }
+}
+
+// A bit of example code that someone might implement to provide Encodable conformance
+// for their own type.
+//
+//
+// extension Coordinate: Encodable {
+//    func encode(to encoder: Encoder) throws {
+//        var container = encoder.container(keyedBy: CodingKeys.self)
+//        try container.encode(latitude, forKey: .latitude)
+//        try container.encode(longitude, forKey: .longitude)
+//
+//        var additionalInfo = container.nestedContainer(keyedBy: AdditionalInfoKeys.self, forKey: .additionalInfo)
+//        try additionalInfo.encode(elevation, forKey: .elevation)
+//    }
+// }
+
+extension AutomergeEncoderImpl: Encoder {
+    /// Returns a KeyedCodingContainer that a developer uses when conforming to the Encodable protocol.
+    /// - Parameter _: The CodingKey type that this keyed coding container expects when encoding properties.
+    ///
+    /// This method provides a generic, type-erased container that conforms to KeyedEncodingContainer, allowing
+    /// either a developer, or compiler synthesized code, to encode single value properties or create nested containers,
+    /// such as an array (nested unkeyed container) or dictionary (nested keyed container) while serializing/encoding
+    /// their type.
+    func container<Key>(keyedBy _: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+        guard singleValueWritten == false else {
+            preconditionFailure()
+        }
+
+        let container = AutomergeKeyedEncodingContainer<Key>(
+            impl: self,
+            codingPath: codingPath,
+            doc: document
+        )
+        return KeyedEncodingContainer(container)
+    }
+
+    /// Returns an UnkeyedEncodingContainer that a developer uses when conforming to the Encodable protocol.
+    ///
+    /// This method provides a generic, type-erased container that conforms to UnkeyedEncodingContainer, allowing
+    /// either a developer, or compiler synthesized code, to encode single value properties or create nested containers,
+    /// such as an array (nested unkeyed container) or dictionary (nested keyed container) while serializing/encoding
+    /// their type.
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        guard singleValueWritten == false else {
+            preconditionFailure()
+        }
+
+        return AutomergeUnkeyedEncodingContainer(
+            impl: self,
+            codingPath: codingPath,
+            doc: document
+        )
+    }
+
+    /// Returns a SingleValueEncodingContainer that a developer uses when conforming to the Encodable protocol.
+    ///
+    /// This method provides a generic, type-erased container that conforms to KeyedEncodingContainer, allowing
+    /// either a developer, or compiler synthesized code, to encode single value properties or create nested containers,
+    /// such as an array (nested unkeyed container) or dictionary (nested keyed container) while serializing/encoding
+    /// their type.
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        guard singleValueWritten == false else {
+            preconditionFailure()
+        }
+
+        return AutomergeSingleValueEncodingContainer(
+            impl: self,
+            codingPath: codingPath,
+            doc: document
+        )
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -1,0 +1,373 @@
+import Foundation // for Date support
+import os // for structured logging
+
+struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    /// A reference to the Automerge Encoding Implementation class used for tracking encoding state.
+    let impl: AutomergeEncoderImpl
+    /// An instance that represents a Map being constructed in an Automerge Document that maps to the keyed container
+    /// you provide to encode.
+    // let object: AutomergeObject
+    /// An array of types that conform to CodingKey that make up the "schema path" to this instance from the root of the
+    /// top-level encoded type.
+    let codingPath: [CodingKey]
+    /// The Automerge document that the encoder writes into.
+    let document: Document
+    /// The objectId that this keyed encoding container maps to within an Automerge document.
+    ///
+    /// If `document` is `nil`, the error attempting to retrieve should be in ``lookupError``.
+    let objectId: ObjId?
+    /// An error captured when attempting to look up or create an objectId in Automerge based on the coding path
+    /// provided.
+    let lookupError: Error?
+
+    /// Creates a new keyed-encoding container you use to encode into an Automerge document.
+    ///
+    /// After initialization, the container has one of two properties set: ``objectId`` or ``lookupError``.
+    /// As the container is created and initialized, it attempts to either look up or create an Automerge objectId that
+    /// maps to the relevant schema path matching from the ``codingPath``.
+    /// If the lookup was successful, the property `objectId` has the proper value from the associated document.
+    /// Otherwise, the initialization captures the error into ``lookupError`` and is thrown when you invoke any of the
+    /// `encode` methods.
+    ///
+    /// Called from within a developer's type providing conformance to `Encodable`, for example:
+    /// ```swift
+    /// var container = encoder.container(keyedBy: CodingKeys.self)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - impl: A reference to the AutomergeEncodingImpl that this container represents.
+    ///   - codingPath: An array of types that conform to CodingKey that make up the "schema path" to this instance from
+    /// the root of the top-level encoded type.
+    ///   - doc: The Automerge document that the encoder writes into.
+    init(impl: AutomergeEncoderImpl, codingPath: [CodingKey], doc: Document) {
+        self.impl = impl
+        self.codingPath = codingPath
+        document = doc
+        switch doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Key,
+            strategy: impl.schemaStrategy
+        ) {
+        case let .success(objId):
+            objectId = objId
+            lookupError = nil
+        case let .failure(capturedError):
+            objectId = nil
+            lookupError = capturedError
+        }
+        if #available(macOS 11, iOS 14, *) {
+            let logger = Logger(subsystem: "Automerge", category: "AutomergeEncoder")
+            logger.debug("Establishing Keyed Encoding Container for path \(codingPath.map { AnyCodingKey($0) })")
+        }
+    }
+
+    fileprivate func reportBestError() -> Error {
+        // Returns the best value it can from a lookup error scenario.
+        if let containerLookupError = lookupError {
+            return containerLookupError
+        } else {
+            // If the error wasn't captured for some reason, drop back to a more general error exposing
+            // the precondition failure.
+            return CodingKeyLookupError
+                .UnexpectedLookupFailure(
+                    "Encoding called on KeyedContainer when ObjectId is nil, and there was no recorded lookup error for the path \(codingPath)"
+                )
+        }
+    }
+
+    fileprivate func checkTypeMatch<T>(value: T, objectId: ObjId, key: Self.Key, type: TypeOfAutomergeValue) throws {
+        if let testCurrentValue = try document.get(obj: objectId, key: key.stringValue),
+           TypeOfAutomergeValue.from(testCurrentValue) != type
+        {
+            // BLOW UP HERE
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError
+                    .Context(
+                        codingPath: codingPath,
+                        debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(type))"
+                    )
+            )
+        }
+    }
+
+    mutating func encodeNil(forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: .Null)
+    }
+
+    mutating func encode(_ value: Bool, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bool)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: .Boolean(value))
+    }
+
+    mutating func encode(_ value: String, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .string)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: .String(value))
+    }
+
+    mutating func encode(_ value: Double, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        guard !value.isNaN, !value.isInfinite else {
+            throw EncodingError.invalidValue(value, .init(
+                codingPath: codingPath + [key],
+                debugDescription: "Unable to encode Double.\(value) at \(codingPath) into an Automerge F64."
+            ))
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Float, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        guard !value.isNaN, !value.isInfinite else {
+            throw EncodingError.invalidValue(value, .init(
+                codingPath: codingPath + [key],
+                debugDescription: "Unable to encode Float.\(value) directly in JSON."
+            ))
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Int, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Int8, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Int16, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Int32, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: Int64, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: UInt, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: UInt8, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: UInt16, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: UInt32, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode(_ value: UInt64, forKey key: Self.Key) throws {
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        if impl.cautiousWrite {
+            try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
+        }
+        try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+    }
+
+    mutating func encode<T: Encodable>(_ value: T, forKey key: Self.Key) throws {
+        let newPath = impl.codingPath + [key]
+        // this is where we need to figure out what the encodable type is in order to create
+        // the correct Automerge objectType underneath the covers.
+        // For example - for encoding another struct, class, or dict - we'd want to make it .map,
+        // array or list would be .list, and for a singleValue property we don't want to create a new
+        // objectId.
+        // This should ideally be an "upsert" - look up and find if there already, otherwise create
+        // a new instance to write into...
+
+        // as we create newEncoder, we don't have any idea what kind of thing this is - singleValue, keyed, or
+        // unkeyed...
+        // As such, we can't easily assert the "new" objectId - because we don't know if we need one,
+        // and if so, if it's associated with singleValue (don't need a new one), keyed (need a new map one),
+        // or unkeyed (need a new list one). In fact, we don't even know for sure what we'll need until
+        // the Codable method `encode` is called - because that's where a container is created. So while we
+        // can set this "newPath", we don't have the deets to create (if needed) a new objectId until we
+        // initialize a specific container type.
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+
+        let newEncoder = AutomergeEncoderImpl(
+            userInfo: impl.userInfo,
+            codingPath: newPath,
+            doc: document,
+            strategy: impl.schemaStrategy,
+            cautiousWrite: impl.cautiousWrite
+        )
+        switch T.self {
+        case is Date.Type:
+            // Capture and override the default encodable pathing for Date since
+            // Automerge supports it as a primitive value type.
+            let downcastDate = value as! Date
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .timestamp)
+            }
+            try document.put(obj: objectId, key: key.stringValue, value: downcastDate.toScalarValue())
+        case is Data.Type:
+            // Capture and override the default encodable pathing for Data since
+            // Automerge supports it as a primitive value type.
+            let downcastData = value as! Data
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bytes)
+            }
+            try document.put(obj: objectId, key: key.stringValue, value: downcastData.toScalarValue())
+        case is Counter.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastCounter = value as! Counter
+            if impl.cautiousWrite {
+                try checkTypeMatch(value: value, objectId: objectId, key: key, type: .counter)
+            }
+            try document.put(obj: objectId, key: key.stringValue, value: downcastCounter.toScalarValue())
+        case is Text.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastText = value as! Text
+            let textNodeId: ObjId
+            if let existingNode = try document.get(obj: objectId, key: key.stringValue) {
+                guard case let .Object(textId, .Text) = existingNode else {
+                    throw CodingKeyLookupError
+                        .MismatchedSchema(
+                            "Text Encoding on KeyedContainer at \(codingPath) exists and is \(existingNode), not Text."
+                        )
+                }
+                textNodeId = textId
+            } else {
+                textNodeId = try document.putObject(obj: objectId, key: key.stringValue, ty: .Text)
+            }
+
+            // Iterate through
+            let currentText = try! document.text(obj: textNodeId).utf8
+            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
+                .difference(from: currentText)
+            for change in diff {
+                switch change {
+                case let .insert(offset, element, _):
+                    let char = String(bytes: [element], encoding: .utf8)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
+                case let .remove(offset, _, _):
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
+                }
+            }
+        default:
+            try value.encode(to: newEncoder)
+        }
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type, forKey key: Self.Key) ->
+        KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        let newPath = impl.codingPath + [key]
+        let nestedContainer = AutomergeKeyedEncodingContainer<NestedKey>(
+            impl: impl,
+            codingPath: newPath,
+            doc: document
+        )
+        return KeyedEncodingContainer(nestedContainer)
+    }
+
+    mutating func nestedUnkeyedContainer(forKey key: Self.Key) -> UnkeyedEncodingContainer {
+        let newPath = impl.codingPath + [key]
+        let nestedContainer = AutomergeUnkeyedEncodingContainer(
+            impl: impl,
+            codingPath: newPath,
+            doc: document
+        )
+        return nestedContainer
+    }
+
+    mutating func superEncoder() -> Encoder {
+        impl
+    }
+
+    mutating func superEncoder(forKey _: Self.Key) -> Encoder {
+        impl
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -1,0 +1,395 @@
+import Foundation // for Date support
+import os // for structured logging
+
+struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
+    let impl: AutomergeEncoderImpl
+    let codingPath: [CodingKey]
+    let document: Document
+    /// The objectId that this keyed encoding container maps to within an Automerge document.
+    ///
+    /// If `document` is `nil`, the error attempting to retrieve should be in ``lookupError``.
+    let objectId: ObjId?
+    let codingkey: AnyCodingKey?
+    /// An error captured when attempting to look up or create an objectId in Automerge based on the coding path
+    /// provided.
+    let lookupError: Error?
+
+    init(impl: AutomergeEncoderImpl, codingPath: [CodingKey], doc: Document) {
+        self.impl = impl
+        self.codingPath = codingPath
+        document = doc
+        switch doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Value,
+            strategy: impl.schemaStrategy
+        ) {
+        case let .success(objId):
+            if let lastCodingKey = codingPath.last {
+                objectId = objId
+                codingkey = AnyCodingKey(lastCodingKey)
+                lookupError = nil
+            } else {
+                objectId = objId
+                codingkey = nil
+                lookupError = CodingKeyLookupError
+                    .NoPathForSingleValue("Attempting to encode a value with an empty coding path.")
+            }
+        case let .failure(capturedError):
+            objectId = nil
+            codingkey = nil
+            lookupError = capturedError
+        }
+        if #available(macOS 11, iOS 14, *) {
+            let logger = Logger(subsystem: "Automerge", category: "AutomergeEncoder")
+            logger.debug("Establishing Single Value Encoding Container for path \(codingPath.map { AnyCodingKey($0) })")
+        }
+    }
+
+    mutating func encodeNil() throws {}
+
+    mutating func encode(_ value: Bool) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Int) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Int8) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Int16) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Int32) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Int64) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: UInt) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: UInt8) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: UInt16) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: UInt32) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: UInt64) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Float) throws {
+        guard !value.isNaN, !value.isInfinite else {
+            throw EncodingError.invalidValue(value, .init(
+                codingPath: codingPath,
+                debugDescription: "Unable to encode Float.\(value) directly in Automerge."
+            ))
+        }
+
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: Double) throws {
+        guard !value.isNaN, !value.isInfinite else {
+            throw EncodingError.invalidValue(value, .init(
+                codingPath: codingPath,
+                debugDescription: "Unable to encode Double.\(value) directly in Automerge."
+            ))
+        }
+
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode(_ value: String) throws {
+        try scalarValueEncode(value: value)
+        impl.singleValueWritten = true
+    }
+
+    mutating func encode<T: Encodable>(_ value: T) throws {
+        preconditionCanEncodeNewValue()
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+        switch T.self {
+        case is Date.Type:
+            // Capture and override the default encodable pathing for Date since
+            // Automerge supports it as a primitive value type.
+            let downcastDate = value as! Date
+            guard let codingkey = codingkey else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue(
+                        "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
+                    )
+            }
+            let valueToWrite = downcastDate.toScalarValue()
+            if let indexToWrite = codingkey.intValue {
+                if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
+            } else {
+                if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
+            }
+        case is Data.Type:
+            // Capture and override the default encodable pathing for Data since
+            // Automerge supports it as a primitive value type.
+            let downcastData = value as! Data
+            guard let codingkey = codingkey else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue(
+                        "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
+                    )
+            }
+            let valueToWrite = downcastData.toScalarValue()
+            if let indexToWrite = codingkey.intValue {
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
+            } else {
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
+            }
+        case is Counter.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastCounter = value as! Counter
+            guard let codingkey = codingkey else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue(
+                        "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
+                    )
+            }
+            let valueToWrite = downcastCounter.toScalarValue()
+            if let indexToWrite = codingkey.intValue {
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+                try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
+            } else {
+                if impl.cautiousWrite {
+                    if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                       TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                    {
+                        // BLOW UP HERE
+                        throw EncodingError.invalidValue(
+                            value,
+                            EncodingError
+                                .Context(
+                                    codingPath: codingPath,
+                                    debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                                )
+                        )
+                    }
+                }
+                try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
+            }
+        case is Text.Type:
+            guard let codingkey = codingkey else {
+                throw CodingKeyLookupError
+                    .NoPathForSingleValue(
+                        "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
+                    )
+            }
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastText = value as! Text
+
+            let existingValue: Value?
+            // get any existing value - type of `get` based on the key type
+            if let indexToWrite = codingkey.intValue {
+                existingValue = try document.get(obj: objectId, index: UInt64(indexToWrite))
+            } else {
+                existingValue = try document.get(obj: objectId, key: codingkey.stringValue)
+            }
+
+            let textNodeId: ObjId
+            if let existingNode = existingValue {
+                guard case let .Object(textId, .Text) = existingNode else {
+                    throw CodingKeyLookupError
+                        .MismatchedSchema(
+                            "Text Encoding on KeyedContainer at \(codingPath) exists and is \(existingNode), not Text."
+                        )
+                }
+                textNodeId = textId
+            } else {
+                // no existing value is there, so create a Text node
+                if let indexToWrite = codingkey.intValue {
+                    textNodeId = try document.putObject(obj: objectId, index: UInt64(indexToWrite), ty: .Text)
+                } else {
+                    textNodeId = try document.putObject(obj: objectId, key: codingkey.stringValue, ty: .Text)
+                }
+            }
+
+            // Iterate through
+            let currentText = try! document.text(obj: textNodeId).utf8
+            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
+                .difference(from: currentText)
+            for change in diff {
+                switch change {
+                case let .insert(offset, element, _):
+                    let char = String(bytes: [element], encoding: .utf8)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
+                case let .remove(offset, _, _):
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
+                }
+            }
+        default:
+            try value.encode(to: impl)
+            impl.singleValueWritten = true
+        }
+    }
+
+    private func scalarValueEncode(value: some ScalarValueRepresentable) throws {
+        preconditionCanEncodeNewValue()
+        guard let objectId = objectId, let codingkey = codingkey else {
+            throw reportBestError()
+        }
+        let valueToWrite = value.toScalarValue()
+        if let indexToWrite = codingkey.intValue {
+            if impl.cautiousWrite {
+                if let testCurrentValue = try document.get(obj: objectId, index: UInt64(indexToWrite)),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+            }
+            try document.insert(obj: objectId, index: UInt64(indexToWrite), value: valueToWrite)
+        } else {
+            if impl.cautiousWrite {
+                if let testCurrentValue = try document.get(obj: objectId, key: codingkey.stringValue),
+                   TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+                {
+                    // BLOW UP HERE
+                    throw EncodingError.invalidValue(
+                        value,
+                        EncodingError
+                            .Context(
+                                codingPath: codingPath,
+                                debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                            )
+                    )
+                }
+            }
+            try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
+        }
+    }
+
+    func preconditionCanEncodeNewValue() {
+        precondition(
+            impl.singleValueWritten == false,
+            "Attempt to encode value through single value container when previously value already encoded."
+        )
+    }
+
+    fileprivate func reportBestError() -> Error {
+        // Returns the best value it can from a lookup error scenario.
+        if let containerLookupError = lookupError {
+            return containerLookupError
+        } else {
+            // If the error wasn't captured for some reason, drop back to a more general error exposing
+            // the precondition failure.
+            return CodingKeyLookupError
+                .UnexpectedLookupFailure(
+                    "Encoding called on KeyedContainer when ObjectId is nil, and there was no recorded lookup error for the path \(codingPath)"
+                )
+        }
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -1,0 +1,191 @@
+import Foundation // for Date support
+import os // for structured logging
+
+struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    let impl: AutomergeEncoderImpl
+    let codingPath: [CodingKey]
+    /// The Automerge document that the encoder writes into.
+    let document: Document
+    /// The objectId that this keyed encoding container maps to within an Automerge document.
+    ///
+    /// If `document` is `nil`, the error attempting to retrieve should be in ``lookupError``.
+    let objectId: ObjId?
+    /// An error captured when attempting to look up or create an objectId in Automerge based on the coding path
+    /// provided.
+    let lookupError: Error?
+
+    private(set) var count: Int = 0
+
+    init(impl: AutomergeEncoderImpl, codingPath: [CodingKey], doc: Document) {
+        self.impl = impl
+        // array = impl.array!
+        self.codingPath = codingPath
+        document = doc
+        switch doc.retrieveObjectId(
+            path: codingPath,
+            containerType: .Index,
+            strategy: impl.schemaStrategy
+        ) {
+        case let .success(objId):
+            objectId = objId
+            lookupError = nil
+        case let .failure(capturedError):
+            objectId = nil
+            lookupError = capturedError
+        }
+        if #available(macOS 11, iOS 14, *) {
+            let logger = Logger(subsystem: "Automerge", category: "AutomergeEncoder")
+            logger.debug("Establishing Unkeyed Encoding Container for path \(codingPath.map { AnyCodingKey($0) })")
+        }
+    }
+
+    fileprivate func reportBestError() -> Error {
+        // Returns the best value it can from a lookup error scenario.
+        if let containerLookupError = lookupError {
+            return containerLookupError
+        } else {
+            // If the error wasn't captured for some reason, drop back to a more general error exposing
+            // the precondition failure.
+            return CodingKeyLookupError
+                .UnexpectedLookupFailure(
+                    "Encoding called on UnkeyedContainer when ObjectId is nil, and there was no recorded lookup error for the path \(codingPath)"
+                )
+        }
+    }
+
+    mutating func encodeNil() throws {}
+
+    mutating func encode<T>(_ value: T) throws where T: Encodable {
+        let newPath = impl.codingPath + [AnyCodingKey(UInt64(count))]
+        let newEncoder = AutomergeEncoderImpl(
+            userInfo: impl.userInfo,
+            codingPath: newPath,
+            doc: document,
+            strategy: impl.schemaStrategy,
+            cautiousWrite: impl.cautiousWrite
+        )
+        guard let objectId = objectId else {
+            throw reportBestError()
+        }
+
+        switch T.self {
+        case is Date.Type:
+            // Capture and override the default encodable pathing for Date since
+            // Automerge supports it as a primitive value type.
+            let downcastDate = value as! Date
+            let valueToWrite = downcastDate.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+            try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+        case is Data.Type:
+            // Capture and override the default encodable pathing for Data since
+            // Automerge supports it as a primitive value type.
+            let downcastData = value as! Data
+            let valueToWrite = downcastData.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+
+            try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+        case is Counter.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastCounter = value as! Counter
+            let valueToWrite = downcastCounter.toScalarValue()
+            if let testCurrentValue = try document.get(obj: objectId, index: UInt64(count)),
+               TypeOfAutomergeValue.from(testCurrentValue) != TypeOfAutomergeValue.from(valueToWrite)
+            {
+                // BLOW UP HERE
+                throw EncodingError.invalidValue(
+                    value,
+                    EncodingError
+                        .Context(
+                            codingPath: codingPath,
+                            debugDescription: "The type in the automerge document (\(TypeOfAutomergeValue.from(testCurrentValue))) doesn't match the type being written (\(TypeOfAutomergeValue.from(valueToWrite)))"
+                        )
+                )
+            }
+            try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+        case is Text.Type:
+            // Capture and override the default encodable pathing for Counter since
+            // Automerge supports it as a primitive value type.
+            let downcastText = value as! Text
+
+            let textNodeId: ObjId
+            if let existingNode = try document.get(obj: objectId, index: UInt64(count)) {
+                guard case let .Object(textId, .Text) = existingNode else {
+                    throw CodingKeyLookupError
+                        .MismatchedSchema(
+                            "Text Encoding on KeyedContainer at \(codingPath) exists and is \(existingNode), not Text."
+                        )
+                }
+                textNodeId = textId
+            } else {
+                textNodeId = try document.insertObject(obj: objectId, index: UInt64(count), ty: .Text)
+            }
+
+            let currentText = try! document.text(obj: textNodeId).utf8
+            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
+                .difference(from: currentText)
+            for change in diff {
+                switch change {
+                case let .insert(offset, element, _):
+                    let char = String(bytes: [element], encoding: .utf8)
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
+                case let .remove(offset, _, _):
+                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
+                }
+            }
+        default:
+            try value.encode(to: newEncoder)
+        }
+        count += 1
+    }
+
+    mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type) ->
+        KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey
+    {
+        let newPath = impl.codingPath + [AnyCodingKey(UInt64(count))]
+        let nestedContainer = AutomergeKeyedEncodingContainer<NestedKey>(
+            impl: impl,
+            codingPath: newPath,
+            doc: document
+        )
+        return KeyedEncodingContainer(nestedContainer)
+    }
+
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let newPath = impl.codingPath + [AnyCodingKey(UInt64(count))]
+        let nestedContainer = AutomergeUnkeyedEncodingContainer(
+            impl: impl,
+            codingPath: newPath,
+            doc: document
+        )
+        return nestedContainer
+    }
+
+    mutating func superEncoder() -> Encoder {
+        preconditionFailure()
+    }
+}

--- a/Sources/Automerge/Codable/Encoding/CodingKeyLookupError.swift
+++ b/Sources/Automerge/Codable/Encoding/CodingKeyLookupError.swift
@@ -1,0 +1,66 @@
+import Foundation // for LocalizedError
+
+public enum CodingKeyLookupError: LocalizedError, Equatable {
+    public static func == (lhs: CodingKeyLookupError, rhs: CodingKeyLookupError) -> Bool {
+        lhs.errorDescription == rhs.errorDescription
+    }
+
+    /// An error that represents a coding container was unable to look up a relevant Automerge objectId and was unable
+    /// to capture a more specific error.
+    case UnexpectedLookupFailure(String)
+    /// The path element is not valid.
+    case InvalidPathElement(String)
+    /// The path element, structured as a Index location, doesn't include an index value.
+    case EmptyListIndex(String)
+    /// The list index requested was longer than the list in the Document.
+    case IndexOutOfBounds(String)
+    /// The path provided to look up a value is invalid.
+    case InvalidValueLookup(String)
+    /// The path provided to look up an index is invalid.
+    case InvalidIndexLookup(String)
+    /// The path provided extends through Automerge Text, a leaf node in the schema.
+    case PathExtendsThroughText(String)
+    /// The path provided extends through an Automerge ScalarValue, a leaf node in the schema.
+    case PathExtendsThroughScalar(String)
+    /// The path provided doesn't match the schema within the Automerge Document.
+    case MismatchedSchema(String)
+    /// The path provided expected schema within the Automerge document that doesn't exist.
+    case SchemaMissing(String)
+    /// No coding path was provided for encoding a single value into the Automerge document.
+    case NoPathForSingleValue(String)
+    /// An underlying Automerge Document error.
+    case AutomergeDocError(Error)
+
+    /// A localized message describing the error.
+    public var errorDescription: String? {
+        switch self {
+        case let .UnexpectedLookupFailure(str):
+            return str
+        case let .InvalidPathElement(str):
+            return str
+        case let .EmptyListIndex(str):
+            return str
+        case let .IndexOutOfBounds(str):
+            return str
+        case let .InvalidValueLookup(str):
+            return str
+        case let .InvalidIndexLookup(str):
+            return str
+        case let .PathExtendsThroughText(str):
+            return str
+        case let .PathExtendsThroughScalar(str):
+            return str
+        case let .SchemaMissing(str):
+            return str
+        case let .MismatchedSchema(str):
+            return str
+        case let .NoPathForSingleValue(str):
+            return str
+        case let .AutomergeDocError(err):
+            return "An underlying Automerge error: \(err.localizedDescription)"
+        }
+    }
+
+    /// A localized message describing the reason for the failure.
+    public var failureReason: String? { nil }
+}

--- a/Sources/Automerge/Codable/Encoding/CodingKeyLookupError.swift
+++ b/Sources/Automerge/Codable/Encoding/CodingKeyLookupError.swift
@@ -1,5 +1,6 @@
 import Foundation // for LocalizedError
 
+/// Automerge Encoding errors
 public enum CodingKeyLookupError: LocalizedError, Equatable {
     public static func == (lhs: CodingKeyLookupError, rhs: CodingKeyLookupError) -> Bool {
         lhs.errorDescription == rhs.errorDescription

--- a/Sources/Automerge/Codable/EncodingContainerType.swift
+++ b/Sources/Automerge/Codable/EncodingContainerType.swift
@@ -1,0 +1,9 @@
+/// An enumeration that represents the type of encoding container.
+@usableFromInline enum EncodingContainerType {
+    /// A keyed container.
+    case Key
+    /// An un-keyed container.
+    case Index
+    /// A single-value container.
+    case Value
+}

--- a/Sources/Automerge/Codable/SchemaStrategy.swift
+++ b/Sources/Automerge/Codable/SchemaStrategy.swift
@@ -1,0 +1,27 @@
+/// A type that represents the encoder strategy to establish or error on differences in existing Automerge documents
+/// as compared to expected encoding.
+public enum SchemaStrategy {
+    /// Creates schema where none exists, errors on schema mismatch.
+    ///
+    /// Basic schema checking for containers that creates relevant objects in Automerge at the relevant path doesn't
+    /// exist.
+    /// If there is something in an existing Automerge document that doesn't match the type of container, or if the
+    /// path
+    /// is a leaf-node
+    /// (a scalar value, or a Text instance), then the lookup captures the schema error for later presentation.
+    case createWhenNeeded
+
+    /// Creates schema, irregardless of existing schema.
+    ///
+    /// Disregards any existing schema that currently exists in the Automerge document and overwrites the path
+    /// elements
+    /// as
+    /// the encoding progresses. This option will potentially change the schema within an Automerge document.
+    case override
+
+    /// Allows updating of values only.
+    /// If the schema does not pre-exist in the format that the encoder expects, the lookup doesn't create schema
+    /// and
+    /// captures an error for later presentation.
+    case readonly
+}

--- a/Sources/Automerge/Codable/Text.swift
+++ b/Sources/Automerge/Codable/Text.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A type that presents a string backed by a Sequential CRDT
+public struct Text: Hashable, Codable {
+    public var value: String
+
+    // NOTE(heckj): The version Automerge after 2.0 is adding support for "marks"
+    // that apply to runs of text within the .Text primitive. This should map
+    // reasonably well to AttributedStrings. When it's merged, this type
+    // should be a reasonable placeholder from which to derive `AttributedString` and
+    // the flat `String` variations from the underlying data source in Automerge.
+
+    /// Creates a new Text instance with the string value you provide.
+    /// - Parameter value: The value for the text.
+    public init(_ value: String) {
+        self.value = value
+    }
+}
+
+extension Text: CustomStringConvertible {
+    public var description: String {
+        value
+    }
+}

--- a/Sources/Automerge/Codable/TypeOfAutomergeValue.swift
+++ b/Sources/Automerge/Codable/TypeOfAutomergeValue.swift
@@ -1,0 +1,95 @@
+/// A type that encapsulates only the type information from an Automerge value.
+enum TypeOfAutomergeValue: Equatable, Hashable {
+    /// A list CRDT.
+    case array
+    /// A map CRDT.
+    case object
+    /// A specialized list CRDT for representing text.
+    case text
+    /// A byte buffer.
+    case bytes
+    /// A string.
+    case string
+    /// An unsigned integer.
+    case uint
+    /// A signed integer.
+    case int
+    /// A floating point number.
+    case double
+    /// An integer counter.
+    case counter
+    /// A timestamp represented by the milliseconds since UNIX epoch.
+    case timestamp
+    /// A Boolean value.
+    case bool
+    /// Nil.
+    case unknown(UInt8)
+    /// Nil.
+    case null
+
+    /// Returns the type information from an Automerge Value
+    /// - Parameter val: The value to describe.
+    static func from(_ val: Value) -> Self {
+        switch val {
+        case let .Object(_, objType):
+            switch objType {
+            case .List:
+                return .array
+            case .Map:
+                return .object
+            case .Text:
+                return .text
+            }
+        case let .Scalar(scalarValue):
+            switch scalarValue {
+            case .Boolean:
+                return .bool
+            case .Bytes:
+                return .bytes
+            case .String:
+                return .string
+            case .Uint:
+                return .uint
+            case .Int:
+                return .int
+            case .F64:
+                return .double
+            case .Counter:
+                return .counter
+            case .Timestamp:
+                return .timestamp
+            case let .Unknown(type, _):
+                return .unknown(type)
+            case .Null:
+                return .null
+            }
+        }
+    }
+
+    /// Returns the type information from an Automerge ScalarValue
+    /// - Parameter val: The scalar value to describe.
+    static func from(_ val: ScalarValue) -> Self {
+        switch val {
+        case .Boolean:
+            return .bool
+        case .Bytes:
+            return .bytes
+        case .String:
+            return .string
+        case .Uint:
+            return .uint
+        case .Int:
+            return .int
+        case .F64:
+            return .double
+        case .Counter:
+            return .counter
+        case .Timestamp:
+            return .timestamp
+        case let .Unknown(type, _):
+            return .unknown(type)
+        case .Null:
+            return .null
+        }
+    }
+}

--- a/Sources/Automerge/SyncState.swift
+++ b/Sources/Automerge/SyncState.swift
@@ -4,6 +4,7 @@ import Foundation
 typealias FfiSyncState = AutomergeUniffi.SyncState
 
 /// A synchronisation session with another peer
+/// 
 /// The sync protocol is designed to run over a reliable in-order transport with
 /// the ``SyncState`` tracking the state between successive calls to
 /// ``Document/generateSyncMessage(state:)`` and

--- a/Sources/Automerge/SyncState.swift
+++ b/Sources/Automerge/SyncState.swift
@@ -4,7 +4,7 @@ import Foundation
 typealias FfiSyncState = AutomergeUniffi.SyncState
 
 /// A synchronisation session with another peer
-/// 
+///
 /// The sync protocol is designed to run over a reliable in-order transport with
 /// the ``SyncState`` tracking the state between successive calls to
 /// ``Document/generateSyncMessage(state:)`` and

--- a/Tests/AutomergeTests/CodableTests/AnyCodingKeyTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AnyCodingKeyTests.swift
@@ -1,0 +1,55 @@
+
+@testable import Automerge
+import XCTest
+
+final class AnyCodingKeyTests: XCTestCase {
+    func testPathParsing() throws {
+        let empty = try AnyCodingKey.parsePath("")
+        XCTAssertEqual(empty, [])
+
+        XCTAssertThrowsError(try AnyCodingKey.parsePath("/"))
+
+        let single = try AnyCodingKey.parsePath("list")
+        XCTAssertEqual(single, [AnyCodingKey("list")])
+
+        XCTAssertThrowsError(try AnyCodingKey.parsePath("1"))
+
+        let singleInt = try AnyCodingKey.parsePath("[1]")
+        XCTAssertEqual(singleInt, [AnyCodingKey(1)])
+
+        XCTAssertThrowsError(try AnyCodingKey.parsePath("[]"))
+
+        XCTAssertThrowsError(try AnyCodingKey.parsePath("[foo]"))
+
+        let sequence = try AnyCodingKey.parsePath(".list.[45].notes")
+        XCTAssertEqual(sequence.count, 3)
+        XCTAssertEqual(sequence[0].stringValue, "list")
+        XCTAssertNil(sequence[0].intValue)
+        XCTAssertEqual(sequence[1].intValue, 45)
+        XCTAssertEqual(sequence[2].stringValue, "notes")
+        XCTAssertNil(sequence[2].intValue)
+    }
+
+    func testAnyCodingKeyDescription() throws {
+        let one = AnyCodingKey("list")
+        XCTAssertNil(one.intValue)
+        XCTAssertEqual(one.description, "list")
+        let two = AnyCodingKey(5)
+        XCTAssertNotNil(two.intValue)
+        XCTAssertEqual(two.description, "[5]")
+    }
+
+    func testDescriptionParseRoundTrip() throws {
+        let examplePath = [
+            AnyCodingKey("list"),
+            AnyCodingKey(5),
+            AnyCodingKey("notes"),
+        ]
+
+        let strPath = examplePath.stringPath()
+        XCTAssertEqual(strPath, ".list.[5].notes")
+
+        let parsedResult = try AnyCodingKey.parsePath(strPath)
+        XCTAssertEqual(parsedResult, examplePath)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -1,0 +1,140 @@
+import Automerge
+import XCTest
+
+final class AutomergeDecoderTests: XCTestCase {
+    var doc: Document!
+    var setupCache: [String: ObjId] = [:]
+
+    override func setUp() {
+        setupCache = [:]
+        doc = Document()
+
+        try! doc.put(obj: ObjId.ROOT, key: "name", value: .String("Joe"))
+        try! doc.put(obj: ObjId.ROOT, key: "duration", value: .F64(3.14159))
+        try! doc.put(obj: ObjId.ROOT, key: "flag", value: .Boolean(true))
+        try! doc.put(obj: ObjId.ROOT, key: "count", value: .Int(5))
+        try! doc.put(obj: ObjId.ROOT, key: "uuid", value: .String("99CEBB16-1062-4F21-8837-CF18EC09DCD7"))
+        try! doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
+        try! doc.put(obj: ObjId.ROOT, key: "data", value: .Bytes(Data("hello".utf8)))
+
+        let text = try! doc.putObject(obj: ObjId.ROOT, key: "notes", ty: .Text)
+        setupCache["notes"] = text
+        try! doc.spliceText(obj: text, start: 0, delete: 0, value: "Hello")
+
+        let votes = try! doc.putObject(obj: ObjId.ROOT, key: "votes", ty: .List)
+        setupCache["votes"] = votes
+        try! doc.insert(obj: votes, index: 0, value: .Int(3))
+        try! doc.insert(obj: votes, index: 1, value: .Int(4))
+        try! doc.insert(obj: votes, index: 2, value: .Int(5))
+
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        setupCache["list"] = list
+
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        setupCache["nestedMap"] = nestedMap
+
+        try! doc.put(obj: nestedMap, key: "image", value: .Bytes(Data()))
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+        setupCache["deeplyNestedText"] = deeplyNestedText
+    }
+
+    func testSimpleKeyDecode() throws {
+        struct SimpleStruct: Codable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+            let date: Date
+            let data: Data
+            let uuid: UUID
+            let notes: Text
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertNoThrow(try decoder.decode(SimpleStruct.self))
+
+        let decodedStruct = try decoder.decode(SimpleStruct.self)
+
+        XCTAssertEqual(decodedStruct.name, "Joe")
+        XCTAssertEqual(decodedStruct.duration, 3.14159, accuracy: 0.0001)
+        XCTAssertTrue(decodedStruct.flag)
+        XCTAssertEqual(decodedStruct.count, 5)
+
+        let expectedUUID = UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!
+        XCTAssertEqual(decodedStruct.uuid, expectedUUID)
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        XCTAssertEqual(earlyDate, decodedStruct.date)
+        XCTAssertEqual(Data("hello".utf8), decodedStruct.data)
+
+        XCTAssertEqual("Hello", decodedStruct.notes.description)
+    }
+
+    func testDecodeTypeMismatch_propType() throws {
+        struct SimpleStruct: Codable {
+            let name: Double
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertThrowsError(try decoder.decode(SimpleStruct.self), "Expected type mismatch error") { _ in
+            // print(error)
+        }
+    }
+
+    func testDecodeTypeMismatch_list() throws {
+        struct SimpleStruct: Codable {
+            let name: [String]
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertThrowsError(try decoder.decode(SimpleStruct.self), "Expected type mismatch error") { _ in
+            // print(error)
+        }
+    }
+
+    func testDecodeTypeMismatch_key() throws {
+        struct SimpleStruct: Codable {
+            let votes: String
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertThrowsError(try decoder.decode(SimpleStruct.self), "Expected type mismatch error") { _ in
+            // print(error)
+        }
+    }
+
+    func testKeyAndListDecode() throws {
+        struct StructWithArray: Codable {
+            let name: String
+            let votes: [Int]
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertNoThrow(try decoder.decode(StructWithArray.self))
+
+        let decodedStruct = try decoder.decode(StructWithArray.self)
+
+        XCTAssertEqual(decodedStruct.name, "Joe")
+        XCTAssertEqual(decodedStruct.votes, [3, 4, 5])
+    }
+
+    func testListOfTextDecode() throws {
+        doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        setupCache["list"] = list
+        let text0 = try! doc.insertObject(obj: list, index: 0, ty: .Text)
+        try doc.spliceText(obj: text0, start: 0, delete: 0, value: "Hello?")
+        let text1 = try! doc.insertObject(obj: list, index: 1, ty: .Text)
+        try doc.spliceText(obj: text1, start: 0, delete: 0, value: "Hello!")
+
+        struct ListOfText: Codable {
+            let list: [Text]
+        }
+
+        let decoder = AutomergeDecoder(doc: doc)
+        let decodedStruct = try decoder.decode(ListOfText.self)
+        XCTAssertEqual(decodedStruct.list.count, 2)
+        XCTAssertEqual(decodedStruct.list[0].description, "Hello?")
+        XCTAssertEqual(decodedStruct.list[1].description, "Hello!")
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -63,7 +63,8 @@ final class AutomergeDecoderTests: XCTestCase {
         let expectedUUID = UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!
         XCTAssertEqual(decodedStruct.uuid, expectedUUID)
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         XCTAssertEqual(earlyDate, decodedStruct.date)
         XCTAssertEqual(Data("hello".utf8), decodedStruct.data)
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
@@ -1,0 +1,378 @@
+import Automerge
+import XCTest
+
+final class AutomergeEncoderTests: XCTestCase {
+    var doc: Document!
+    var setupCache: [String: ObjId] = [:]
+
+    override func setUp() {
+        setupCache = [:]
+        doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        setupCache["list"] = list
+
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        setupCache["nestedMap"] = nestedMap
+
+        try! doc.put(obj: nestedMap, key: "image", value: .Bytes(Data()))
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+        setupCache["deeplyNestedText"] = deeplyNestedText
+    }
+
+    func testSimpleKeyEncode() throws {
+        struct SimpleStruct: Codable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+            let date: Date
+            let data: Data
+            let uuid: UUID
+            let notes: Text
+        }
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            duration: 3.14159,
+            flag: true,
+            count: 5,
+            date: earlyDate,
+            data: Data("hello".utf8),
+            uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
+            notes: Text("Something wicked this way comes.")
+        )
+
+        try automergeEncoder.encode(sample)
+
+        if case let .Scalar(.String(a_name)) = try doc.get(obj: ObjId.ROOT, key: "name") {
+            XCTAssertEqual(a_name, "henry")
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "name")))")
+        }
+
+        if case let .Scalar(.F64(duration_value)) = try doc.get(obj: ObjId.ROOT, key: "duration") {
+            XCTAssertEqual(duration_value, 3.14159, accuracy: 0.01)
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "duration")))")
+        }
+
+        if case let .Scalar(.Boolean(boolean_value)) = try doc.get(obj: ObjId.ROOT, key: "flag") {
+            XCTAssertEqual(boolean_value, true)
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "flag")))")
+        }
+
+        if case let .Scalar(.Int(int_value)) = try doc.get(obj: ObjId.ROOT, key: "count") {
+            XCTAssertEqual(int_value, 5)
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "count")))")
+        }
+
+        if case let .Scalar(.Timestamp(timestamp_value)) = try doc.get(obj: ObjId.ROOT, key: "date") {
+            XCTAssertEqual(timestamp_value, -905182980)
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "date")))")
+        }
+
+        // try debugPrint(doc.get(obj: ObjId.ROOT, key: "data") as Any)
+        if case let .Scalar(.Bytes(data_value)) = try doc.get(obj: ObjId.ROOT, key: "data") {
+            XCTAssertEqual(data_value, Data("hello".utf8))
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "data")))")
+        }
+
+        // debugPrint(try doc.get(obj: ObjId.ROOT, key: "uuid") as Any)
+        if case let .Scalar(.String(uuid_string)) = try doc.get(obj: ObjId.ROOT, key: "uuid") {
+            XCTAssertEqual(uuid_string, "99CEBB16-1062-4F21-8837-CF18EC09DCD7")
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "uuid")))")
+        }
+
+        if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
+            XCTAssertEqual(nodeType, .Text)
+            XCTAssertEqual(try doc.text(obj: textNode), "Something wicked this way comes.")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+        try debugPrint(doc.get(obj: ObjId.ROOT, key: "notes") as Any)
+    }
+
+    func testNestedKeyEncode() throws {
+        struct SimpleStruct: Codable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+        }
+
+        struct RootModel: Codable {
+            let example: SimpleStruct
+        }
+
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        let sample = RootModel(example: SimpleStruct(name: "henry", duration: 3.14159, flag: true, count: 5))
+
+        try automergeEncoder.encode(sample)
+
+        if case let .Object(container_id, container_type) = try doc.get(obj: ObjId.ROOT, key: "example") {
+            XCTAssertEqual(container_type, ObjType.Map)
+
+            if case let .Scalar(.String(a_name)) = try doc.get(obj: container_id, key: "name") {
+                XCTAssertEqual(a_name, "henry")
+            } else {
+                try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, key: "name")))")
+            }
+
+            if case let .Scalar(.F64(duration_value)) = try doc.get(obj: container_id, key: "duration") {
+                XCTAssertEqual(duration_value, 3.14159, accuracy: 0.01)
+            } else {
+                try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, key: "duration")))")
+            }
+
+            if case let .Scalar(.Boolean(boolean_value)) = try doc.get(obj: container_id, key: "flag") {
+                XCTAssertEqual(boolean_value, true)
+            } else {
+                try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, key: "flag")))")
+            }
+
+            if case let .Scalar(.Int(int_value)) = try doc.get(obj: container_id, key: "count") {
+                XCTAssertEqual(int_value, 5)
+            } else {
+                try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, key: "count")))")
+            }
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "example")))")
+        }
+    }
+
+    func testNestedListSingleValueEncode() throws {
+        struct RootModel: Codable {
+            let numbers: [Int]
+        }
+
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+        let sample = RootModel(numbers: [1, 2, 3])
+
+        try automergeEncoder.encode(sample)
+
+        if case let .Object(container_id, container_type) = try doc.get(obj: ObjId.ROOT, key: "numbers") {
+            XCTAssertEqual(container_type, ObjType.List)
+            XCTAssertEqual(try doc.get(obj: container_id, index: 0), .Scalar(.Int(1)))
+            XCTAssertEqual(try doc.get(obj: container_id, index: 1), .Scalar(.Int(2)))
+            XCTAssertEqual(try doc.get(obj: container_id, index: 2), .Scalar(.Int(3)))
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "example")))")
+        }
+    }
+
+    func testNestedListEncode() throws {
+        struct SimpleStruct: Codable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+        }
+
+        struct RootModel: Codable {
+            let example: [SimpleStruct]
+        }
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        let sample = RootModel(example: [
+            SimpleStruct(name: "henry", duration: 3.14159, flag: true, count: 5),
+            SimpleStruct(name: "jules", duration: 2.7182818, flag: false, count: 2),
+        ])
+
+        try automergeEncoder.encode(sample)
+
+        if case let .Object(container_id, container_type) = try doc.get(obj: ObjId.ROOT, key: "example") {
+            XCTAssertEqual(container_type, ObjType.List)
+
+            if case let .Object(firstListItem, first_list_type) = try doc.get(obj: container_id, index: 0) {
+                XCTAssertEqual(first_list_type, ObjType.Map)
+
+                if case let .Scalar(.String(a_name)) = try doc.get(obj: firstListItem, key: "name") {
+                    XCTAssertEqual(a_name, "henry")
+                } else {
+                    try XCTFail("Didn't find: \(String(describing: doc.get(obj: firstListItem, key: "name")))")
+                }
+
+                if case let .Scalar(.F64(duration_value)) = try doc.get(obj: firstListItem, key: "duration") {
+                    XCTAssertEqual(duration_value, 3.14159, accuracy: 0.01)
+                } else {
+                    try XCTFail("Didn't find: \(String(describing: doc.get(obj: firstListItem, key: "duration")))")
+                }
+
+                if case let .Scalar(.Boolean(boolean_value)) = try doc.get(obj: firstListItem, key: "flag") {
+                    XCTAssertEqual(boolean_value, true)
+                } else {
+                    try XCTFail("Didn't find: \(String(describing: doc.get(obj: firstListItem, key: "flag")))")
+                }
+
+                if case let .Scalar(.Int(int_value)) = try doc.get(obj: firstListItem, key: "count") {
+                    XCTAssertEqual(int_value, 5)
+                } else {
+                    try XCTFail("Didn't find: \(String(describing: doc.get(obj: firstListItem, key: "count")))")
+                }
+            } else {
+                try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, index: 0)))")
+            }
+        } else {
+            try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "example")))")
+        }
+    }
+
+    func testLayeredEncode() throws {
+        let sample = Samples.layered
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        try automergeEncoder.encode(sample)
+    }
+
+    func testTextUpdateWithEncoding_Object() throws {
+        let doc = Document()
+        struct TestModel: Codable {
+            var notes: Text
+        }
+        var model = TestModel(notes: Text("Hello"))
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        try automergeEncoder.encode(model)
+
+        if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
+            XCTAssertEqual(nodeType, .Text)
+            XCTAssertEqual(try doc.text(obj: textNode), "Hello")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+
+        model.notes = Text("Hello World!")
+        try automergeEncoder.encode(model)
+
+        if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
+            XCTAssertEqual(nodeType, .Text)
+            XCTAssertEqual(try doc.text(obj: textNode), "Hello World!")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+
+        model.notes = Text("Wassup World?")
+        try automergeEncoder.encode(model)
+
+        if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
+            XCTAssertEqual(nodeType, .Text)
+            XCTAssertEqual(try doc.text(obj: textNode), "Wassup World?")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+    }
+
+    func testTextUpdateWithEncoding_List() throws {
+        let doc = Document()
+        struct TestModel: Codable {
+            var notes: [Text]
+        }
+        var model = TestModel(notes: [Text("Hello")])
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        try automergeEncoder.encode(model)
+
+        if case let .Object(listNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes"),
+           case let .Object(textNode, .Text) = try doc.get(obj: listNode, index: 0)
+        {
+            XCTAssertEqual(nodeType, .List)
+            XCTAssertEqual(try doc.text(obj: textNode), "Hello")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+
+        model.notes = [Text("Hello World!")]
+        try automergeEncoder.encode(model)
+
+        if case let .Object(listNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes"),
+           case let .Object(textNode, .Text) = try doc.get(obj: listNode, index: 0)
+        {
+            XCTAssertEqual(nodeType, .List)
+            XCTAssertEqual(try doc.text(obj: textNode), "Hello World!")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+
+        model.notes = [Text("Wassup World?")]
+        try automergeEncoder.encode(model)
+
+        if case let .Object(listNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes"),
+           case let .Object(textNode, .Text) = try doc.get(obj: listNode, index: 0)
+        {
+            XCTAssertEqual(nodeType, .List)
+            XCTAssertEqual(try doc.text(obj: textNode), "Wassup World?")
+        } else {
+            try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
+        }
+    }
+
+    func testTextEncodingMismatch_object() throws {
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        struct InitialTestModel: Codable {
+            var notes: String
+        }
+        struct UpdatedTestModel: Codable {
+            var notes: Text
+        }
+
+        let model = InitialTestModel(notes: "Hello")
+        try automergeEncoder.encode(model)
+        let followupModel = UpdatedTestModel(notes: Text("Hello"))
+
+        XCTAssertThrowsError(
+            try automergeEncoder.encode(followupModel),
+            "Expected mismatched schema to throw error"
+        ) { error in
+            print(error)
+        }
+    }
+
+    func testTextEncodingMismatch_list() throws {
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        struct InitialTestModel: Codable {
+            var notes: [String]
+        }
+        struct UpdatedTestModel: Codable {
+            var notes: [Text]
+        }
+
+        let model = InitialTestModel(notes: ["Hello"])
+        try automergeEncoder.encode(model)
+        let followupModel = UpdatedTestModel(notes: [Text("Hello")])
+
+        XCTAssertThrowsError(
+            try automergeEncoder.encode(followupModel),
+            "Expected mismatched schema to throw error"
+        ) { error in
+            print(error)
+        }
+    }
+
+    func testOptionalTypeEncode() throws {
+        let doc = Document()
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+
+        struct TestModel: Codable {
+            var notes: [String]
+        }
+
+        let model: TestModel? = TestModel(notes: ["Hello"])
+        XCTAssertNoThrow(try automergeEncoder.encode(model))
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
@@ -32,7 +32,8 @@ final class AutomergeEncoderTests: XCTestCase {
         }
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
 
         let sample = SimpleStruct(
             name: "henry",

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
@@ -246,7 +246,8 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Date_CautiousFailure() throws {
         try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         XCTAssertThrowsError(
             try cautiousKeyedContainer.encode(earlyDate, forKey: .value)
         )

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
@@ -1,0 +1,424 @@
+@testable import Automerge
+import XCTest
+
+final class AutomergeKeyEncoderImplTests: XCTestCase {
+    var doc: Document!
+    var rootKeyedContainer: KeyedEncodingContainer<AutomergeKeyEncoderImplTests.SampleCodingKeys>!
+    var cautiousKeyedContainer: KeyedEncodingContainer<AutomergeKeyEncoderImplTests.SampleCodingKeys>!
+
+    enum SampleCodingKeys: String, CodingKey {
+        case value
+    }
+
+    override func setUp() {
+        doc = Document()
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+
+        let cautious = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: true
+        )
+        cautiousKeyedContainer = cautious.container(keyedBy: SampleCodingKeys.self)
+    }
+
+    func testSimpleKeyEncode_Bool() throws {
+        try rootKeyedContainer.encode(true, forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+
+        try cautiousKeyedContainer.encode(false, forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+    }
+
+    func testSimpleKeyEncode_Bool_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(false, forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Float() throws {
+        try rootKeyedContainer.encode(Float(4.3), forKey: .value)
+        if case let .Scalar(.F64(floatValue)) = try doc.get(obj: ObjId.ROOT, key: "value") {
+            XCTAssertEqual(floatValue, 4.3, accuracy: 0.01)
+        } else {
+            XCTFail("Scalar Float value not retrieved.")
+        }
+
+        try cautiousKeyedContainer.encode(Float(3.4), forKey: .value)
+        try cautiousKeyedContainer.encode(Double(7.8), forKey: .value)
+    }
+
+    func testErrorEncode_Float() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Float(3.4), forKey: .value))
+    }
+
+    func testSimpleKeyEncode_InvalidFloat() throws {
+        XCTAssertThrowsError(
+            try rootKeyedContainer.encode(Float.infinity, forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_InvalidDouble() throws {
+        XCTAssertThrowsError(
+            try rootKeyedContainer.encode(Double.nan, forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Float_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Float(4.0), forKey: .value)
+        )
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Double(4.0), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int8() throws {
+        try rootKeyedContainer.encode(Int8(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousKeyedContainer.encode(Int8(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Int8_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int8(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int16() throws {
+        try rootKeyedContainer.encode(Int16(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousKeyedContainer.encode(Int16(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Int16_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int16(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int32() throws {
+        try rootKeyedContainer.encode(Int32(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try rootKeyedContainer.encode(Int32(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Int32_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int32(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int64() throws {
+        try rootKeyedContainer.encode(Int64(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousKeyedContainer.encode(Int64(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Int64_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int64(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Int_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Int(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_UInt() throws {
+        try rootKeyedContainer.encode(UInt(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousKeyedContainer.encode(UInt(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_UInt_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_UInt8() throws {
+        try rootKeyedContainer.encode(UInt8(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousKeyedContainer.encode(UInt8(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_UInt8_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt8(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_UInt16() throws {
+        try rootKeyedContainer.encode(UInt16(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousKeyedContainer.encode(UInt16(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_UInt16_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt16(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_UInt32() throws {
+        try rootKeyedContainer.encode(UInt32(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+        try cautiousKeyedContainer.encode(UInt32(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_UInt32_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt32(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_UInt64() throws {
+        try rootKeyedContainer.encode(UInt64(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+        try cautiousKeyedContainer.encode(UInt64(5), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_UInt64_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(UInt64(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Counter() throws {
+        try rootKeyedContainer.encode(Counter(4), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
+
+        try cautiousKeyedContainer.encode(Counter(45), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Counter_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(Counter(4), forKey: .value)
+        )
+    }
+
+    func testSimpleKeyEncode_Data() throws {
+        try rootKeyedContainer.encode(Data("Hello".utf8), forKey: .value)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Bytes(Data("Hello".utf8))))
+
+        try cautiousKeyedContainer.encode(Data("World".utf8), forKey: .value)
+    }
+
+    func testSimpleKeyEncode_Date_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        XCTAssertThrowsError(
+            try cautiousKeyedContainer.encode(earlyDate, forKey: .value)
+        )
+    }
+
+    func testErrorEncode_Bool() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(true, forKey: .value))
+    }
+
+    func testErrorEncode_Double() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Double(8.16), forKey: .value))
+    }
+
+    func testErrorEncode_Int() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Int(8), forKey: .value))
+    }
+
+    func testErrorEncode_Int8() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Int8(8), forKey: .value))
+    }
+
+    func testErrorEncode_Int16() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Int16(8), forKey: .value))
+    }
+
+    func testErrorEncode_Int32() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Int32(8), forKey: .value))
+    }
+
+    func testErrorEncode_Int64() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(Int64(8), forKey: .value))
+    }
+
+    func testErrorEncode_UInt() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(UInt(8), forKey: .value))
+    }
+
+    func testErrorEncode_UInt8() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(UInt8(8), forKey: .value))
+    }
+
+    func testErrorEncode_UInt16() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(UInt16(8), forKey: .value))
+    }
+
+    func testErrorEncode_UInt32() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(UInt32(8), forKey: .value))
+    }
+
+    func testErrorEncode_UInt64() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(UInt64(8), forKey: .value))
+    }
+
+    func testErrorEncode_Codable() throws {
+        struct SimpleStruct: Codable {
+            let a: String
+        }
+
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        rootKeyedContainer = impl.container(keyedBy: SampleCodingKeys.self)
+        XCTAssertThrowsError(try rootKeyedContainer.encode(SimpleStruct(a: "foo"), forKey: .value))
+    }
+
+    func testSuperEncoder() throws {
+        let enc = rootKeyedContainer.superEncoder()
+        XCTAssertEqual(enc.codingPath.count, 0)
+    }
+
+    func testSuperEncoderForKey() throws {
+        let enc = rootKeyedContainer.superEncoder(forKey: .value)
+        XCTAssertEqual(enc.codingPath.count, 0)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
@@ -1,0 +1,252 @@
+import Automerge
+import XCTest
+
+final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
+    var doc: Document!
+    var encoder: AutomergeEncoder!
+    var decoder: AutomergeDecoder!
+
+    override func setUp() {
+        doc = Document()
+        encoder = AutomergeEncoder(doc: doc)
+        decoder = AutomergeDecoder(doc: doc)
+    }
+
+    func testSimpleEncodeDecode() throws {
+        struct SimpleStruct: Codable, Equatable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+            let date: Date
+            let data: Data
+            let uuid: UUID
+            let notes: Text
+        }
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            duration: 3.14159,
+            flag: true,
+            count: 5,
+            date: earlyDate,
+            data: Data("hello".utf8),
+            uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
+            notes: Text("Something wicked this way comes.")
+        )
+
+        try encoder.encode(sample)
+        let decodedStruct = try decoder.decode(SimpleStruct.self)
+
+        XCTAssertEqual(sample, decodedStruct)
+    }
+
+    func testSimpleCounterEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let counter: Counter
+        }
+
+        let topLevel = WrapperStruct(counter: Counter(5))
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.counter.value, 5)
+    }
+
+    func testSimpleOptionalCounterEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let counter: Counter?
+            let anotherOptional: String?
+        }
+
+        let topLevel = WrapperStruct(counter: Counter(5), anotherOptional: nil)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.counter?.value, 5)
+        XCTAssertNil(decodedStruct.anotherOptional)
+    }
+
+    func testSimpleFloatEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Float
+        }
+
+        let topLevel = WrapperStruct(thing: 3.0)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3.0, decodedStruct.thing, accuracy: 0.1)
+    }
+
+    func testSimpleDoubleEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Double
+        }
+
+        let topLevel = WrapperStruct(thing: 3.0)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3.0, decodedStruct.thing, accuracy: 0.1)
+    }
+
+    func testSimpleInt8EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Int8
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleInt16EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Int16
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleInt32EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Int32
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleInt64EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Int64
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleIntEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Int
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleUInt8EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: UInt8
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleUInt16EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: UInt16
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleUInt32EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: UInt32
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleUInt64EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: UInt64
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleUIntEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: UInt
+        }
+
+        let topLevel = WrapperStruct(thing: 3)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(3, decodedStruct.thing)
+    }
+
+    func testSimpleDateEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Date
+        }
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let topLevel = WrapperStruct(thing: earlyDate)
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(earlyDate, decodedStruct.thing)
+    }
+
+    func testSimpleDataEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Data
+        }
+
+        let topLevel = WrapperStruct(thing: Data("Hello".utf8))
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(Data("Hello".utf8), decodedStruct.thing)
+    }
+
+    func testSimpleTextEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let thing: Text
+        }
+
+        let topLevel = WrapperStruct(thing: Text("hi"))
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual("hi", decodedStruct.thing.value)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
@@ -24,7 +24,8 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let notes: Text
         }
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
 
         let sample = SimpleStruct(
             name: "henry",
@@ -218,7 +219,8 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let thing: Date
         }
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         let topLevel = WrapperStruct(thing: earlyDate)
 
         try encoder.encode(topLevel)

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -1,0 +1,461 @@
+@testable import Automerge
+import XCTest
+
+final class AutomergeSingleValueEncoderImplTests: XCTestCase {
+    var doc: Document!
+    var singleValueContainer: SingleValueEncodingContainer!
+    var cautiousSingleValueContainer: SingleValueEncodingContainer!
+
+    enum SampleCodingKeys: String, CodingKey {
+        case value
+    }
+
+    override func setUp() {
+        doc = Document()
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("value")],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        let cautious = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("value")],
+            doc: doc,
+            strategy: .createWhenNeeded,
+            cautiousWrite: true
+        )
+        cautiousSingleValueContainer = cautious.singleValueContainer()
+    }
+
+    func testSimpleKeyEncode_Bool() throws {
+        try singleValueContainer.encode(true)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+
+        try cautiousSingleValueContainer.encode(false)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+    }
+
+    func testSimpleKeyEncode_Bool_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(true)
+        )
+    }
+
+    func testSimpleKeyEncode_Float() throws {
+        try singleValueContainer.encode(Float(4.3))
+        if case let .Scalar(.F64(floatValue)) = try doc.get(obj: ObjId.ROOT, key: "value") {
+            XCTAssertEqual(floatValue, 4.3, accuracy: 0.01)
+        } else {
+            XCTFail("Scalar Float value not retrieved.")
+        }
+
+        try cautiousSingleValueContainer.encode(Float(3.4))
+        if case let .Scalar(.F64(floatValue)) = try doc.get(obj: ObjId.ROOT, key: "value") {
+            XCTAssertEqual(floatValue, 3.4, accuracy: 0.01)
+        } else {
+            XCTFail("Scalar Float value not retrieved.")
+        }
+    }
+
+    func testSimpleKeyEncode_InvalidFloat() throws {
+        XCTAssertThrowsError(
+            try singleValueContainer.encode(Float.infinity)
+        )
+    }
+
+    func testSimpleKeyEncode_InvalidDouble() throws {
+        XCTAssertThrowsError(
+            try singleValueContainer.encode(Double.nan)
+        )
+    }
+
+    func testSimpleKeyEncode_Double_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(40))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Double(3.4))
+        )
+
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Float(3.4))
+        )
+    }
+
+    func testSimpleKeyEncode_Int8() throws {
+        try singleValueContainer.encode(Int8(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int8(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+    }
+
+    func testSimpleKeyEncode_Int_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int8(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int16(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int32(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Int64(4))
+        )
+    }
+
+    func testSimpleKeyEncode_Int16() throws {
+        try singleValueContainer.encode(Int16(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int16(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+    }
+
+    func testSimpleKeyEncode_Int32() throws {
+        try singleValueContainer.encode(Int32(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int32(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+    }
+
+    func testSimpleKeyEncode_Int64() throws {
+        try singleValueContainer.encode(Int64(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+
+        try cautiousSingleValueContainer.encode(Int64(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+    }
+
+    func testSimpleKeyEncode_UInt() throws {
+        try singleValueContainer.encode(UInt(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt8() throws {
+        try singleValueContainer.encode(UInt8(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt8(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt16() throws {
+        try singleValueContainer.encode(UInt16(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt16(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt32() throws {
+        try singleValueContainer.encode(UInt32(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt32(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt64() throws {
+        try singleValueContainer.encode(UInt64(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(4)))
+
+        try cautiousSingleValueContainer.encode(UInt64(5))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Uint(5)))
+    }
+
+    func testSimpleKeyEncode_UInt_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt8(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt16(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt32(4))
+        )
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(UInt64(4))
+        )
+    }
+
+    func testSimpleKeyEncode_Date() throws {
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        try singleValueContainer.encode(earlyDate)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(-905182980)))
+
+        let anotherDate = try Date("1942-04-26T08:17:00Z", strategy: .iso8601)
+        try cautiousSingleValueContainer.encode(anotherDate)
+    }
+
+    func testSimpleKeyEncode_Date_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(earlyDate)
+        )
+    }
+
+    func testSimpleKeyEncode_Data() throws {
+        let data = Data("Hello".utf8)
+        try singleValueContainer.encode(data)
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Bytes(data)))
+
+        try cautiousSingleValueContainer.encode(Data("World".utf8))
+    }
+
+    func testSimpleKeyEncode_Data_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Data("World".utf8))
+        )
+    }
+
+    func testSimpleKeyEncode_Text() throws {
+        try singleValueContainer.encode(Text("hi"))
+        let value = try doc.get(obj: ObjId.ROOT, key: "value")
+        if case let .Object(objectId, .Text) = value {
+            XCTAssertEqual(try doc.text(obj: objectId), "hi")
+        } else {
+            XCTFail("Expected Automerge text object")
+        }
+    }
+
+    func testSimpleKeyEncode_Counter() throws {
+        try singleValueContainer.encode(Counter(4))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Counter(4)))
+
+        try cautiousSingleValueContainer.encode(Counter(14))
+    }
+
+    func testSimpleKeyEncode_Counter_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encode(Counter(443))
+        )
+    }
+
+    func testErrorEncode_Bool() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(true))
+    }
+
+    func testErrorEncode_Float() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Float(3.4)))
+    }
+
+    func testErrorEncode_Double() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Double(8.16)))
+    }
+
+    func testErrorEncode_Int() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Int(8)))
+    }
+
+    func testErrorEncode_Int8() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Int8(8)))
+    }
+
+    func testErrorEncode_Int16() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Int16(8)))
+    }
+
+    func testErrorEncode_Int32() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Int32(8)))
+    }
+
+    func testErrorEncode_Int64() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Int64(8)))
+    }
+
+    func testErrorEncode_UInt() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(UInt(8)))
+    }
+
+    func testErrorEncode_UInt8() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(UInt8(8)))
+    }
+
+    func testErrorEncode_UInt16() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(UInt16(8)))
+    }
+
+    func testErrorEncode_UInt32() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(UInt32(8)))
+    }
+
+    func testErrorEncode_UInt64() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(UInt64(8)))
+    }
+
+    func testErrorEncode_Text() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Text("hi")))
+    }
+
+    func testErrorEncode_Date() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(earlyDate))
+    }
+
+    func testErrorEncode_Data() throws {
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere"), AnyCodingKey("value")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(Data("Hello".utf8)))
+    }
+
+    func testErrorEncode_Codable() throws {
+        struct SimpleStruct: Codable {
+            let a: String
+        }
+
+        let impl = AutomergeEncoderImpl(
+            userInfo: [:],
+            codingPath: [AnyCodingKey("nothere")],
+            doc: doc,
+            strategy: .readonly,
+            cautiousWrite: false
+        )
+        singleValueContainer = impl.singleValueContainer()
+        XCTAssertThrowsError(try singleValueContainer.encode(SimpleStruct(a: "foo")))
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -195,17 +195,19 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Date() throws {
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         try singleValueContainer.encode(earlyDate)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(-905182980)))
 
-        let anotherDate = try Date("1942-04-26T08:17:00Z", strategy: .iso8601)
+        let anotherDate = dateFormatter.date(from: "1942-04-26T08:17:00Z")!
         try cautiousSingleValueContainer.encode(anotherDate)
     }
 
     func testSimpleKeyEncode_Date_CautiousFailure() throws {
         try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(earlyDate)
         )
@@ -426,7 +428,8 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             strategy: .readonly,
             cautiousWrite: false
         )
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         singleValueContainer = impl.singleValueContainer()
         XCTAssertThrowsError(try singleValueContainer.encode(earlyDate))
     }

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -73,12 +73,13 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
     }
 
     func testTargetedDecodeOfDate() throws {
-        let exampleDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         try doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
 
         let automergeDecoder = AutomergeDecoder(doc: doc)
         let decodedDate = try automergeDecoder.decode(Date.self, from: [AnyCodingKey("date")])
-        XCTAssertEqual(decodedDate, exampleDate)
+        XCTAssertEqual(decodedDate, earlyDate)
     }
 
     func testTargetedDecodeOfCounter() throws {

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -1,0 +1,135 @@
+import Automerge
+import XCTest
+
+final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
+    var doc: Document!
+
+    override func setUp() {
+        doc = Document()
+    }
+
+    func testSimpleKeyEncode() throws {
+        struct SimpleStruct: Codable, Equatable {
+            let name: String
+            let notes: Text
+        }
+
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            notes: Text("Something wicked this way comes.")
+        )
+
+        let pathToTry: [AnyCodingKey] = [
+            AnyCodingKey("example"),
+            AnyCodingKey(0),
+        ]
+        try automergeEncoder.encode(sample, at: pathToTry)
+
+        XCTAssertNotNil(try doc.get(obj: ObjId.ROOT, key: "example"))
+        let foo = try doc.lookupPath(path: ".example.[0]")
+        XCTAssertNotNil(foo)
+
+        let decodedStruct = try automergeDecoder.decode(SimpleStruct.self, from: pathToTry)
+        XCTAssertEqual(decodedStruct, sample)
+    }
+
+    func testTargetedSingleValueDecode() throws {
+        struct SimpleStruct: Codable, Equatable {
+            let name: String
+            let notes: Text
+        }
+
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            notes: Text("Something wicked this way comes.")
+        )
+
+        let pathToTry: [AnyCodingKey] = [
+            AnyCodingKey("example"),
+            AnyCodingKey(0),
+        ]
+        try automergeEncoder.encode(sample, at: pathToTry)
+
+        let decoded1 = try automergeDecoder.decode(String.self, from: AnyCodingKey.parsePath("example.[0].name"))
+        XCTAssertEqual(decoded1, "henry")
+
+        let decoded2 = try automergeDecoder.decode(Text.self, from: AnyCodingKey.parsePath("example.[0].notes"))
+        XCTAssertEqual(decoded2.value, "Something wicked this way comes.")
+    }
+
+    func testTargetedDecodeOfData() throws {
+        let exampleData = Data("Hello".utf8)
+        try doc.put(obj: ObjId.ROOT, key: "data", value: .Bytes(exampleData))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+        let decodedData = try automergeDecoder.decode(Data.self, from: [AnyCodingKey("data")])
+        XCTAssertEqual(decodedData, exampleData)
+    }
+
+    func testTargetedDecodeOfDate() throws {
+        let exampleDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        try doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+        let decodedDate = try automergeDecoder.decode(Date.self, from: [AnyCodingKey("date")])
+        XCTAssertEqual(decodedDate, exampleDate)
+    }
+
+    func testTargetedDecodeOfCounter() throws {
+        let exampleCounter = Counter(342)
+        try doc.put(obj: ObjId.ROOT, key: "counter", value: .Counter(342))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+        let decodedCounter = try automergeDecoder.decode(Counter.self, from: [AnyCodingKey("counter")])
+        XCTAssertEqual(decodedCounter, exampleCounter)
+    }
+
+    func testTargetedDecodeOfInts() throws {
+        try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertEqual(try automergeDecoder.decode(Int.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(Int64.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(Int8.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(Int16.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(Int32.self, from: [AnyCodingKey("int")]), 34)
+    }
+
+    func testTargetedDecodeOfUInts() throws {
+        try doc.put(obj: ObjId.ROOT, key: "int", value: .Uint(34))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertEqual(try automergeDecoder.decode(UInt.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(UInt64.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(UInt8.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(UInt16.self, from: [AnyCodingKey("int")]), 34)
+        XCTAssertEqual(try automergeDecoder.decode(UInt32.self, from: [AnyCodingKey("int")]), 34)
+    }
+
+    func testTargetedDecodeOfFloats() throws {
+        try doc.put(obj: ObjId.ROOT, key: "double", value: .F64(3.4))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertEqual(try automergeDecoder.decode(Double.self, from: [AnyCodingKey("double")]), 3.4, accuracy: 0.1)
+        XCTAssertEqual(try automergeDecoder.decode(Float.self, from: [AnyCodingKey("double")]), 3.4, accuracy: 0.1)
+    }
+
+    func testTargetedDecodeOfOptionalInt() throws {
+        try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
+
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertEqual(try automergeDecoder.decode(Int?.self, from: [AnyCodingKey("int")]), 34)
+        let nothing = try automergeDecoder.decode(Int?.self, from: [AnyCodingKey("blarg")])
+        XCTAssertNil(nothing)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
@@ -1,0 +1,260 @@
+import Automerge
+import XCTest
+
+final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
+    var doc: Document!
+    var encoder: AutomergeEncoder!
+    var decoder: AutomergeDecoder!
+
+    override func setUp() {
+        doc = Document()
+        encoder = AutomergeEncoder(doc: doc)
+        decoder = AutomergeDecoder(doc: doc)
+    }
+
+    func testListOfSimpleEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [SimpleStruct]
+        }
+
+        struct SimpleStruct: Codable, Equatable {
+            let name: String
+            let duration: Double
+            let flag: Bool
+            let count: Int
+            let date: Date
+            let data: Data
+            let uuid: UUID
+            let notes: Text
+        }
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            duration: 3.14159,
+            flag: true,
+            count: 5,
+            date: earlyDate,
+            data: Data("hello".utf8),
+            uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
+            notes: Text("Something wicked this way comes.")
+        )
+        let topLevel = WrapperStruct(list: [sample])
+
+        try encoder.encode(topLevel)
+
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(sample, decodedStruct.list.first)
+    }
+
+    func testListOfFloatEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Float]
+        }
+
+        let topLevel = WrapperStruct(list: [3.0])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3.0, decodedStruct.list.first!, accuracy: 0.1)
+    }
+
+    func testListOfDoubleEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Float]
+        }
+
+        let topLevel = WrapperStruct(list: [3.0])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3.0, decodedStruct.list.first!, accuracy: 0.1)
+    }
+
+    func testListOfInt8EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int8]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfInt16EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int16]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfInt32EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int32]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfInt64EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int64]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfIntEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfUInt8EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [UInt8]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfUInt16EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [UInt16]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfUInt32EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [UInt32]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfUInt64EncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [UInt64]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfUIntEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [UInt]
+        }
+
+        let topLevel = WrapperStruct(list: [3])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first)
+    }
+
+    func testListOfDateEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Date]
+        }
+
+        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let topLevel = WrapperStruct(list: [earlyDate])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(earlyDate, decodedStruct.list.first)
+    }
+
+    func testListOfDataEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Data]
+        }
+
+        let topLevel = WrapperStruct(list: [Data("Hello".utf8)])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(Data("Hello".utf8), decodedStruct.list.first)
+    }
+
+    func testListOfTextEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Text]
+        }
+
+        let topLevel = WrapperStruct(list: [Text("hi")])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual("hi", decodedStruct.list.first?.description)
+    }
+
+    func testListOfCounterEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Counter]
+        }
+
+        let topLevel = WrapperStruct(list: [Counter(3)])
+
+        try encoder.encode(topLevel)
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(3, decodedStruct.list.first?.value)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
@@ -28,7 +28,8 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let notes: Text
         }
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
 
         let sample = SimpleStruct(
             name: "henry",
@@ -210,7 +211,8 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let list: [Date]
         }
 
-        let earlyDate = try Date("1941-04-26T08:17:00Z", strategy: .iso8601)
+        let dateFormatter = ISO8601DateFormatter()
+        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         let topLevel = WrapperStruct(list: [earlyDate])
 
         try encoder.encode(topLevel)

--- a/Tests/AutomergeTests/CodableTests/Document+PathElementConversionTests.swift
+++ b/Tests/AutomergeTests/CodableTests/Document+PathElementConversionTests.swift
@@ -1,0 +1,63 @@
+@testable import Automerge
+import XCTest
+
+final class Document_PathElementConversionTests: XCTestCase {
+    func testPathElementListToPath() throws {
+        let doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+        let pathToList = try! doc.path(obj: nestedMap)
+        XCTAssertEqual(
+            pathToList,
+            [
+                PathElement(
+                    obj: ObjId.ROOT,
+                    prop: .Key("list")
+                ),
+                PathElement(
+                    obj: list,
+                    prop: .Index(0)
+                ),
+            ]
+        )
+        XCTAssertEqual(pathToList.stringPath(), ".list.[0]")
+
+        let pathToText = try! doc.path(obj: deeplyNestedText)
+        // print("textPath: \(pathToText)")
+        XCTAssertEqual(
+            pathToText,
+            [
+                PathElement(
+                    obj: ObjId.ROOT,
+                    prop: .Key("list")
+                ),
+                PathElement(
+                    obj: list,
+                    prop: .Index(0)
+                ),
+                PathElement(
+                    obj: nestedMap,
+                    prop: .Key("notes")
+                ),
+            ]
+        )
+
+        XCTAssertEqual(pathToText.stringPath(), ".list.[0].notes")
+    }
+
+    func testPathElementListToAnyCodingKey() throws {
+        let doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+        let pathToList = try! doc.path(obj: deeplyNestedText)
+        XCTAssertEqual(pathToList.count, 3)
+
+        let converted = pathToList.map { AnyCodingKey($0) }
+        XCTAssertEqual(converted.count, 3)
+
+        XCTAssertEqual(pathToList.stringPath(), converted.stringPath())
+        XCTAssertEqual(converted.stringPath(), ".list.[0].notes")
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/Document+lookupPathTests.swift
+++ b/Tests/AutomergeTests/CodableTests/Document+lookupPathTests.swift
@@ -1,0 +1,33 @@
+@testable import Automerge
+import XCTest
+
+final class Document_PathTests: XCTestCase {
+    func testLookupPath() throws {
+        let doc = Document()
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+
+        let result = try XCTUnwrap(doc.lookupPath(path: ""))
+        XCTAssertEqual(result, ObjId.ROOT)
+
+        XCTAssertEqual(ObjId.ROOT, try XCTUnwrap(doc.lookupPath(path: "")))
+        XCTAssertEqual(ObjId.ROOT, try XCTUnwrap(doc.lookupPath(path: ".")))
+        XCTAssertNil(try doc.lookupPath(path: "a"))
+        XCTAssertNil(try doc.lookupPath(path: "a."))
+        XCTAssertEqual(try doc.lookupPath(path: "list"), list)
+        XCTAssertEqual(try doc.lookupPath(path: ".list"), list)
+        XCTAssertNil(try doc.lookupPath(path: "list.[1]"))
+
+        XCTAssertThrowsError(try doc.lookupPath(path: ".list.[5]"), "Index Out of Bounds should throw an error")
+        // The top level object isn't a list - so an index lookup should fail with an error
+        XCTAssertThrowsError(try doc.lookupPath(path: "[1].a"))
+
+        // XCTAssertEqual(ObjId.ROOT, try XCTUnwrap(doc.lookupPath(path: "1.a")))
+        // threw error "DocError(inner: AutomergeUniffi.DocError.WrongObjectType(message: "WrongObjectType"))"
+        XCTAssertEqual(try doc.lookupPath(path: "list.[0]"), nestedMap)
+        XCTAssertEqual(try doc.lookupPath(path: ".list.[0]"), nestedMap)
+        XCTAssertEqual(try doc.lookupPath(path: "list.[0].notes"), deeplyNestedText)
+        XCTAssertEqual(try doc.lookupPath(path: ".list.[0].notes"), deeplyNestedText)
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/Document+retrieveObjectIdTests.swift
+++ b/Tests/AutomergeTests/CodableTests/Document+retrieveObjectIdTests.swift
@@ -1,0 +1,446 @@
+@testable import Automerge
+import XCTest
+
+final class RetrieveObjectIdTests: XCTestCase {
+    var doc: Document!
+    var setupCache: [String: ObjId] = [:]
+
+    override func setUp() {
+        setupCache = [:]
+        doc = Document()
+
+        let _ = try! doc.put(obj: ObjId.ROOT, key: "name", value: .String("joe"))
+
+        let topMap = try! doc.putObject(obj: ObjId.ROOT, key: "topMap", ty: .Map)
+        setupCache["topMap"] = topMap
+
+        let description = try! doc.putObject(obj: ObjId.ROOT, key: "description", ty: .Text)
+        setupCache["description"] = description
+
+        let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
+        setupCache["list"] = list
+
+        let nestedMap = try! doc.insertObject(obj: list, index: 0, ty: .Map)
+        setupCache["nestedMap"] = nestedMap
+
+        let nestedText = try! doc.insertObject(obj: list, index: 1, ty: .Text)
+        setupCache["nestedText"] = nestedText
+
+        let _ = try! doc.insert(obj: list, index: 2, value: .String("alex"))
+
+        try! doc.put(obj: nestedMap, key: "image", value: .Bytes(Data()))
+        let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)
+        setupCache["deeplyNestedText"] = deeplyNestedText
+    }
+
+    func testSetupDocPath() throws {
+        let pathToText = try! doc.path(obj: setupCache["deeplyNestedText"]!).stringPath()
+        XCTAssertEqual(setupCache.count, 6)
+        XCTAssertEqual(pathToText, ".list.[0].notes")
+    }
+
+    func testPathAtRoot() throws {
+        let doc = Document()
+        let path = try! doc.path(obj: ObjId.ROOT)
+        XCTAssertEqual(path, [])
+    }
+
+    func testOverrideStrategy() throws {
+        let result = doc.retrieveObjectId(path: [AnyCodingKey("list")], containerType: .Key, strategy: .override)
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testInvalidIndexLookup() throws {
+        let result = doc.retrieveObjectId(path: [], containerType: .Index, strategy: .readonly)
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testInvalidValueLookup() throws {
+        let result = doc.retrieveObjectId(path: [], containerType: .Value, strategy: .override)
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupThroughText() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("description"), AnyCodingKey("list")],
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupThroughTextInList() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("list"), AnyCodingKey(1), AnyCodingKey("name")],
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupObjectThroughScalarInList() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("list"), AnyCodingKey(2), AnyCodingKey("name")],
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupListThroughScalarinList() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("list"), AnyCodingKey(2), AnyCodingKey(0)],
+            containerType: .Index,
+            strategy: .createWhenNeeded
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupValueThroughScalar() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("name"), AnyCodingKey("age")],
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupKeyThroughScalar() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("name"), AnyCodingKey("age")],
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupListThroughScalar() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("name"), AnyCodingKey(0)],
+            containerType: .Index,
+            strategy: .createWhenNeeded
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(try! doc.path(obj: success).stringPath())")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupBeyondBounds() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("list"), AnyCodingKey(2), AnyCodingKey("name")],
+            containerType: .Value,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(success)")
+        case .failure:
+            break
+        }
+    }
+
+    func testLookupBeyondBoundsIndexReadonly() throws {
+        let result = doc.retrieveObjectId(
+            path: [AnyCodingKey("list"), AnyCodingKey(4), AnyCodingKey("name")],
+            containerType: .Index,
+            strategy: .readonly
+        )
+        switch result {
+        case let .success(success):
+            XCTFail("Expected invalid lookup error, received: \(success)")
+        case .failure:
+            break
+        }
+    }
+
+    func testRetrieveLeafValue() throws {
+        let fullCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("list"),
+            AnyCodingKey(0),
+            AnyCodingKey("notes"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: fullCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            XCTAssertEqual(objectId, setupCache["nestedMap"])
+        case .failure:
+            XCTFail("Failure looking up full path to notes as a value")
+        }
+        // Caching not yet implemented
+        // XCTAssertEqual(encoderImpl.cache.count, 2)
+    }
+
+    func testCreateSchemaWhereNull() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("alpha"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".alpha")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateSchemaWhereNullFailureReadOnly() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("alpha"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .readonly
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTFail("Expected failure, but received output \(pathToNewMap)")
+        case .failure:
+            break
+        }
+    }
+
+    func testCreateSchemaWhereNullFailure() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("topMap"),
+            AnyCodingKey("beta"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .readonly
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTFail("Expected failure, but received output \(pathToNewMap)")
+        case .failure:
+            break
+        }
+    }
+
+    func testCreateSchemaWhereNullInList() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("list"),
+            AnyCodingKey(3),
+            AnyCodingKey("a"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".list.[3]")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateListSchemaWhereNullInList() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("list"),
+            AnyCodingKey(3),
+            AnyCodingKey(0),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Index,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".list.[3].[0]")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateListSchemaWhereNullInListFailureReadOnly() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("list"),
+            AnyCodingKey(3),
+            AnyCodingKey(0),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Index,
+            strategy: .readonly
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToObject = try! doc.path(obj: objectId).stringPath()
+            XCTFail("expected failure, but found schema \(pathToObject)")
+        case .failure:
+            break
+        }
+    }
+
+    func testCreateDeeperNewSchema_Key() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("redfish"),
+            AnyCodingKey(0),
+            AnyCodingKey("bluefish"),
+            AnyCodingKey("yellowfish"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Key,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish.yellowfish")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateDeeperNewSchema_List() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("redfish"),
+            AnyCodingKey(0),
+            AnyCodingKey("bluefish"),
+            AnyCodingKey(0),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Index,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish.[0]")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateDeeperNewSchema_Value() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("redfish"),
+            AnyCodingKey(0),
+            AnyCodingKey("bluefish"),
+            AnyCodingKey("yellowfish"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
+
+        switch result {
+        case let .success(objectId):
+            let pathToNewMap = try! doc.path(obj: objectId).stringPath()
+            XCTAssertEqual(pathToNewMap, ".redfish.[0].bluefish")
+        case let .failure(err):
+            XCTFail("Failure looking up new path location: \(err)")
+        }
+    }
+
+    func testCreateDeeperNewSchema_TooDeepFailure() throws {
+        let newCodingPath: [AnyCodingKey] = [
+            AnyCodingKey("redfish"),
+            AnyCodingKey(5),
+            AnyCodingKey("bluefish"),
+            AnyCodingKey("yellowfish"),
+        ]
+
+        let result = doc.retrieveObjectId(
+            path: newCodingPath,
+            containerType: .Value,
+            strategy: .createWhenNeeded
+        )
+        switch result {
+        case .success:
+            XCTFail("Expected this to fail with index 5 in a new array")
+        case let .failure(err):
+            XCTAssertEqual(
+                err.localizedDescription,
+                "Index value 5 is too far beyond the length: 0 to append a new item."
+            )
+        }
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/Samples.swift
+++ b/Tests/AutomergeTests/CodableTests/Samples.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+public enum Samples {
+    public static var layered = ExampleModel(title: "Samples", notes: generateSampleNotes())
+}
+
+public struct GeoLocation: Hashable, Codable {
+    var latitude: Double
+    var longitude: Double
+    var altitude: Double?
+    var speed: Double?
+    var heading: Double?
+
+    init(latitude: Double, longitude: Double, altitude: Double? = nil, speed: Double? = nil, heading: Double? = nil) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+        self.speed = speed
+        self.heading = heading
+    }
+}
+
+public struct Note: Hashable, Codable {
+    var timestamp: Date
+    var description: String
+    var location: GeoLocation
+    var ratings: [Int]
+
+    init(timestamp: Date, description: String, location: GeoLocation, ratings: [Int]) {
+        self.timestamp = timestamp
+        self.description = description
+        self.location = location
+        self.ratings = ratings
+    }
+}
+
+public struct ExampleModel: Codable {
+    var title: String
+    var notes: [Note]
+
+    init(title: String, notes: [Note]) {
+        self.title = title
+        self.notes = notes
+    }
+}
+
+func generateSampleNotes() -> [Note] {
+    var result: [Note] = []
+    do {
+        try result.append(Note(
+            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
+            description: "Burlington",
+            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+            ratings: [2, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
+            description: "St. Louis",
+            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+            ratings: [1, 3, 4, 2]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
+            description: "Seattle",
+            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+            ratings: [4, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
+            description: "WWDC",
+            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+            ratings: [1, 2, 3, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
+            description: "Burlington",
+            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+            ratings: [2, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
+            description: "St. Louis",
+            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+            ratings: [1, 3, 4, 2]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
+            description: "Seattle",
+            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+            ratings: [4, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
+            description: "WWDC",
+            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+            ratings: [1, 2, 3, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
+            description: "Burlington",
+            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+            ratings: [2, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
+            description: "St. Louis",
+            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+            ratings: [1, 3, 4, 2]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
+            description: "Seattle",
+            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+            ratings: [4, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
+            description: "WWDC",
+            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+            ratings: [1, 2, 3, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
+            description: "Burlington",
+            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+            ratings: [2, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
+            description: "St. Louis",
+            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+            ratings: [1, 3, 4, 2]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
+            description: "Seattle",
+            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+            ratings: [4, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
+            description: "WWDC",
+            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+            ratings: [1, 2, 3, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
+            description: "Burlington",
+            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+            ratings: [2, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
+            description: "St. Louis",
+            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+            ratings: [1, 3, 4, 2]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
+            description: "Seattle",
+            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+            ratings: [4, 5, 4]
+        ))
+        try result.append(Note(
+            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
+            description: "WWDC",
+            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+            ratings: [1, 2, 3, 5, 4]
+        ))
+    } catch {}
+    return result
+}

--- a/Tests/AutomergeTests/CodableTests/Samples.swift
+++ b/Tests/AutomergeTests/CodableTests/Samples.swift
@@ -46,127 +46,78 @@ public struct ExampleModel: Codable {
 
 func generateSampleNotes() -> [Note] {
     var result: [Note] = []
-    do {
-        try result.append(Note(
-            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
-            description: "Burlington",
-            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
-            ratings: [2, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
-            description: "St. Louis",
-            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
-            ratings: [1, 3, 4, 2]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
-            description: "Seattle",
-            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
-            ratings: [4, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
-            description: "WWDC",
-            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
-            ratings: [1, 2, 3, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
-            description: "Burlington",
-            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
-            ratings: [2, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
-            description: "St. Louis",
-            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
-            ratings: [1, 3, 4, 2]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
-            description: "Seattle",
-            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
-            ratings: [4, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
-            description: "WWDC",
-            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
-            ratings: [1, 2, 3, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
-            description: "Burlington",
-            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
-            ratings: [2, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
-            description: "St. Louis",
-            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
-            ratings: [1, 3, 4, 2]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
-            description: "Seattle",
-            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
-            ratings: [4, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
-            description: "WWDC",
-            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
-            ratings: [1, 2, 3, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
-            description: "Burlington",
-            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
-            ratings: [2, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
-            description: "St. Louis",
-            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
-            ratings: [1, 3, 4, 2]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
-            description: "Seattle",
-            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
-            ratings: [4, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
-            description: "WWDC",
-            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
-            ratings: [1, 2, 3, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1941-04-26T08:17:00Z", strategy: .iso8601),
-            description: "Burlington",
-            location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
-            ratings: [2, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("1967-05-22T03:23:00Z", strategy: .iso8601),
-            description: "St. Louis",
-            location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
-            ratings: [1, 3, 4, 2]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-05-24T19:14:11Z", strategy: .iso8601),
-            description: "Seattle",
-            location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
-            ratings: [4, 5, 4]
-        ))
-        try result.append(Note(
-            timestamp: Date("2023-06-05T17:00:00Z", strategy: .iso8601),
-            description: "WWDC",
-            location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
-            ratings: [1, 2, 3, 5, 4]
-        ))
-    } catch {}
+    let dateFormatter = ISO8601DateFormatter()
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1941-04-26T08:17:00Z")!,
+        description: "Burlington",
+        location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+        ratings: [2, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1967-05-22T03:23:00Z")!,
+        description: "St. Louis",
+        location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+        ratings: [1, 3, 4, 2]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-05-24T19:14:11Z")!,
+        description: "Seattle",
+        location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+        ratings: [4, 5, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-06-05T17:00:00Z")!,
+        description: "WWDC",
+        location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+        ratings: [1, 2, 3, 5, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1941-04-26T08:17:00Z")!,
+        description: "Burlington",
+        location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+        ratings: [2, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1967-05-22T03:23:00Z")!,
+        description: "St. Louis",
+        location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+        ratings: [1, 3, 4, 2]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-05-24T19:14:11Z")!,
+        description: "Seattle",
+        location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+        ratings: [4, 5, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-06-05T17:00:00Z")!,
+        description: "WWDC",
+        location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+        ratings: [1, 2, 3, 5, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1941-04-26T08:17:00Z")!,
+        description: "Burlington",
+        location: GeoLocation(latitude: 40.8057015, longitude: -91.1704486),
+        ratings: [2, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "1967-05-22T03:23:00Z")!,
+        description: "St. Louis",
+        location: GeoLocation(latitude: 38.653253, longitude: -90.4082707),
+        ratings: [1, 3, 4, 2]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-05-24T19:14:11Z")!,
+        description: "Seattle",
+        location: GeoLocation(latitude: 47.6131419, longitude: -122.5068714, altitude: 112),
+        ratings: [4, 5, 4]
+    ))
+    result.append(Note(
+        timestamp: dateFormatter.date(from: "2023-06-05T17:00:00Z")!,
+        description: "WWDC",
+        location: GeoLocation(latitude: 37.334648, longitude: -122.0115469, altitude: 50),
+        ratings: [1, 2, 3, 5, 4]
+    ))
     return result
 }


### PR DESCRIPTION
- encoder/decoder for backing dev-provided structs into Automerge
  - any developer-provided type that conforms to Codable can be written into Automerge
- support and mapping for swift types into for Automerge primitives:
  - `Data` -> `.Bytes`
  - `Date` -> `.Timestamp`
- explicit type holders for `Counter` and `Text` as separate from `String` scalar values
- Encoder has options for "create schema when missing" and "read-only" modes, with a placeholder for potentially adding an "overwrite" mode.
  - "Create When Needed" will error appropriately when attempting to _change_ an existing Schema structure - for example, putting a container type (object or list) where there's currently a ScalarValue or Text, or vice-verse. 
- Encoder also has a "cautiousWrite" option that can be set to do additional type checking on any existing values before overwriting them with a different Automerge primitive type
- added a "string path" concept to support referencing objects within the Automerge structure, and used that as a means of generating a type-erased [CodingKey] implementation, which is Codable's rough equivalent to PathElement.