### PR TITLE
History fix

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -104,12 +104,12 @@ private func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: 
 
 // Reads a float at the current offset.
 private func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
-    Float(bitPattern: try readInt(&reader))
+    try Float(bitPattern: readInt(&reader))
 }
 
 // Reads a float at the current offset.
 private func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
-    Double(bitPattern: try readInt(&reader))
+    try Double(bitPattern: readInt(&reader))
 }
 
 // Indicates if the offset has reached the end of the buffer.
@@ -281,7 +281,7 @@ private func uniffiCheckCallStatus(
         // with the message.  But if that code panics, then it just sends back
         // an empty buffer.
         if callStatus.errorBuf.len > 0 {
-            throw UniffiInternalError.rustPanic(try FfiConverterString.lift(callStatus.errorBuf))
+            throw try UniffiInternalError.rustPanic(FfiConverterString.lift(callStatus.errorBuf))
         } else {
             callStatus.errorBuf.deallocate()
             throw UniffiInternalError.rustPanic("Rust panic")
@@ -395,7 +395,7 @@ private struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        return try String(bytes: readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {
@@ -487,7 +487,7 @@ public class Doc: DocProtocol {
     }
 
     public static func load(bytes: [UInt8]) throws -> Doc {
-        Doc(unsafeFromRawPointer: try rustCallWithError(FfiConverterTypeLoadError.lift) {
+        try Doc(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeLoadError.lift) {
             uniffi_automerge_fn_constructor_doc_load(
                 FfiConverterSequenceUInt8.lower(bytes), $0
             )
@@ -532,15 +532,14 @@ public class Doc: DocProtocol {
 
     public func forkAt(heads: [ChangeHash]) throws -> Doc {
         try FfiConverterTypeDoc.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_fork_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_fork_at(
+                    self.pointer,
 
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -560,17 +559,16 @@ public class Doc: DocProtocol {
 
     public func putObjectInMap(obj: ObjId, key: String, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_put_object_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_put_object_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -590,17 +588,16 @@ public class Doc: DocProtocol {
 
     public func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_put_object_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_put_object_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -620,17 +617,16 @@ public class Doc: DocProtocol {
 
     public func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_insert_object_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_insert_object_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -690,30 +686,28 @@ public class Doc: DocProtocol {
 
     public func marks(obj: ObjId) throws -> [Mark] {
         try FfiConverterSequenceTypeMark.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_marks(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_marks(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func marksAt(obj: ObjId, heads: [ChangeHash]) throws -> [Mark] {
         try FfiConverterSequenceTypeMark.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_marks_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_marks_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -773,154 +767,144 @@ public class Doc: DocProtocol {
 
     public func getInMap(obj: ObjId, key: String) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    $0
+                )
+            }
         )
     }
 
     public func getInList(obj: ObjId, index: UInt64) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    $0
+                )
+            }
         )
     }
 
     public func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_at_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_at_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_at_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_at_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllInMap(obj: ObjId, key: String) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllInList(obj: ObjId, index: UInt64) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_at_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_at_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_at_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_at_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func text(obj: ObjId) throws -> String {
         try FfiConverterString.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_text(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_text(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func textAt(obj: ObjId, heads: [ChangeHash]) throws -> String {
         try FfiConverterString.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_text_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_text_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -955,59 +939,55 @@ public class Doc: DocProtocol {
 
     public func mapEntries(obj: ObjId) throws -> [KeyValue] {
         try FfiConverterSequenceTypeKeyValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_map_entries(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_map_entries(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func mapEntriesAt(obj: ObjId, heads: [ChangeHash]) throws -> [KeyValue] {
         try FfiConverterSequenceTypeKeyValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_map_entries_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_map_entries_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func values(obj: ObjId) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_values(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_values(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func valuesAt(obj: ObjId, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_values_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_values_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -1056,15 +1036,14 @@ public class Doc: DocProtocol {
 
     public func path(obj: ObjId) throws -> [PathElement] {
         try FfiConverterSequenceTypePathElement.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_path(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_path(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
@@ -1106,15 +1085,14 @@ public class Doc: DocProtocol {
 
     public func mergeWithPatches(other: Doc) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_merge_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_merge_with_patches(
+                    self.pointer,
 
-                        FfiConverterTypeDoc.lower(other),
-                        $0
-                    )
-                }
+                    FfiConverterTypeDoc.lower(other),
+                    $0
+                )
+            }
         )
     }
 
@@ -1147,16 +1125,15 @@ public class Doc: DocProtocol {
 
     public func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
-                    uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
+                uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(
+                    self.pointer,
 
-                        FfiConverterTypeSyncState.lower(state),
-                        FfiConverterSequenceUInt8.lower(msg),
-                        $0
-                    )
-                }
+                    FfiConverterTypeSyncState.lower(state),
+                    FfiConverterSequenceUInt8.lower(msg),
+                    $0
+                )
+            }
         )
     }
 
@@ -1174,15 +1151,14 @@ public class Doc: DocProtocol {
 
     public func encodeChangesSince(heads: [ChangeHash]) throws -> [UInt8] {
         try FfiConverterSequenceUInt8.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_encode_changes_since(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_encode_changes_since(
+                    self.pointer,
 
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -1200,15 +1176,14 @@ public class Doc: DocProtocol {
 
     public func applyEncodedChangesWithPatches(changes: [UInt8]) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(
+                    self.pointer,
 
-                        FfiConverterSequenceUInt8.lower(changes),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceUInt8.lower(changes),
+                    $0
+                )
+            }
         )
     }
 }
@@ -1278,7 +1253,7 @@ public class SyncState: SyncStateProtocol {
     }
 
     public static func decode(bytes: [UInt8]) throws -> SyncState {
-        SyncState(unsafeFromRawPointer: try rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
+        try SyncState(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
             uniffi_automerge_fn_constructor_syncstate_decode(
                 FfiConverterSequenceUInt8.lower(bytes), $0
             )
@@ -1593,8 +1568,8 @@ public struct FfiConverterTypeDecodeSyncStateError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DecodeSyncStateError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1631,12 +1606,12 @@ public struct FfiConverterTypeDocError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .WrongObjectType(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .WrongObjectType(
+                message: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 2: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1726,8 +1701,8 @@ public struct FfiConverterTypeLoadError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LoadError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1813,51 +1788,51 @@ public struct FfiConverterTypePatchAction: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PatchAction {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .put(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf),
-                value: try FfiConverterTypeValue.read(from: &buf)
+        case 1: return try .put(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterTypeValue.read(from: &buf)
             )
 
-        case 2: return .insert(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                values: try FfiConverterSequenceTypeValue.read(from: &buf),
-                marks: try FfiConverterDictionaryStringTypeValue.read(from: &buf)
+        case 2: return try .insert(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                values: FfiConverterSequenceTypeValue.read(from: &buf),
+                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
             )
 
-        case 3: return .spliceText(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                value: try FfiConverterString.read(from: &buf),
-                marks: try FfiConverterDictionaryStringTypeValue.read(from: &buf)
+        case 3: return try .spliceText(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                value: FfiConverterString.read(from: &buf),
+                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
             )
 
-        case 4: return .increment(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf),
-                value: try FfiConverterInt64.read(from: &buf)
+        case 4: return try .increment(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 5: return .conflict(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf)
+        case 5: return try .conflict(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf)
             )
 
-        case 6: return .deleteMap(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                key: try FfiConverterString.read(from: &buf)
+        case 6: return try .deleteMap(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                key: FfiConverterString.read(from: &buf)
             )
 
-        case 7: return .deleteSeq(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                length: try FfiConverterUInt64.read(from: &buf)
+        case 7: return try .deleteSeq(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                length: FfiConverterUInt64.read(from: &buf)
             )
 
-        case 8: return .marks(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                marks: try FfiConverterSequenceTypeMark.read(from: &buf)
+        case 8: return try .marks(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                marks: FfiConverterSequenceTypeMark.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1939,12 +1914,12 @@ public struct FfiConverterTypeProp: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Prop {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .key(
-                value: try FfiConverterString.read(from: &buf)
+        case 1: return try .key(
+                value: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .index(
-                value: try FfiConverterUInt64.read(from: &buf)
+        case 2: return try .index(
+                value: FfiConverterUInt64.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1992,12 +1967,12 @@ public struct FfiConverterTypeReceiveSyncError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReceiveSyncError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .InvalidMessage(
-                message: try FfiConverterString.read(from: &buf)
+        case 2: return try .InvalidMessage(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -2039,41 +2014,41 @@ public struct FfiConverterTypeScalarValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ScalarValue {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .bytes(
-                value: try FfiConverterSequenceUInt8.read(from: &buf)
+        case 1: return try .bytes(
+                value: FfiConverterSequenceUInt8.read(from: &buf)
             )
 
-        case 2: return .string(
-                value: try FfiConverterString.read(from: &buf)
+        case 2: return try .string(
+                value: FfiConverterString.read(from: &buf)
             )
 
-        case 3: return .uint(
-                value: try FfiConverterUInt64.read(from: &buf)
+        case 3: return try .uint(
+                value: FfiConverterUInt64.read(from: &buf)
             )
 
-        case 4: return .int(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 4: return try .int(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 5: return .f64(
-                value: try FfiConverterDouble.read(from: &buf)
+        case 5: return try .f64(
+                value: FfiConverterDouble.read(from: &buf)
             )
 
-        case 6: return .counter(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 6: return try .counter(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 7: return .timestamp(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 7: return try .timestamp(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 8: return .boolean(
-                value: try FfiConverterBool.read(from: &buf)
+        case 8: return try .boolean(
+                value: FfiConverterBool.read(from: &buf)
             )
 
-        case 9: return .unknown(
-                typeCode: try FfiConverterUInt8.read(from: &buf),
-                data: try FfiConverterSequenceUInt8.read(from: &buf)
+        case 9: return try .unknown(
+                typeCode: FfiConverterUInt8.read(from: &buf),
+                data: FfiConverterSequenceUInt8.read(from: &buf)
             )
 
         case 10: return .null
@@ -2150,13 +2125,13 @@ public struct FfiConverterTypeValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Value {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .object(
-                typ: try FfiConverterTypeObjType.read(from: &buf),
-                id: try FfiConverterTypeObjId.read(from: &buf)
+        case 1: return try .object(
+                typ: FfiConverterTypeObjType.read(from: &buf),
+                id: FfiConverterTypeObjId.read(from: &buf)
             )
 
-        case 2: return .scalar(
-                value: try FfiConverterTypeScalarValue.read(from: &buf)
+        case 2: return try .scalar(
+                value: FfiConverterTypeScalarValue.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -2266,7 +2241,7 @@ private struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
         var seq = [UInt8]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterUInt8.read(from: &buf))
+            try seq.append(FfiConverterUInt8.read(from: &buf))
         }
         return seq
     }
@@ -2288,7 +2263,7 @@ private struct FfiConverterSequenceString: FfiConverterRustBuffer {
         var seq = [String]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterString.read(from: &buf))
+            try seq.append(FfiConverterString.read(from: &buf))
         }
         return seq
     }
@@ -2310,7 +2285,7 @@ private struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
         var seq = [KeyValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeKeyValue.read(from: &buf))
+            try seq.append(FfiConverterTypeKeyValue.read(from: &buf))
         }
         return seq
     }
@@ -2332,7 +2307,7 @@ private struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
         var seq = [Mark]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeMark.read(from: &buf))
+            try seq.append(FfiConverterTypeMark.read(from: &buf))
         }
         return seq
     }
@@ -2354,7 +2329,7 @@ private struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
         var seq = [Patch]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePatch.read(from: &buf))
+            try seq.append(FfiConverterTypePatch.read(from: &buf))
         }
         return seq
     }
@@ -2376,7 +2351,7 @@ private struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
         var seq = [PathElement]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePathElement.read(from: &buf))
+            try seq.append(FfiConverterTypePathElement.read(from: &buf))
         }
         return seq
     }
@@ -2398,7 +2373,7 @@ private struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
         var seq = [ScalarValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeScalarValue.read(from: &buf))
+            try seq.append(FfiConverterTypeScalarValue.read(from: &buf))
         }
         return seq
     }
@@ -2420,7 +2395,7 @@ private struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
         var seq = [Value]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeValue.read(from: &buf))
+            try seq.append(FfiConverterTypeValue.read(from: &buf))
         }
         return seq
     }
@@ -2442,7 +2417,7 @@ private struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
         var seq = [ChangeHash]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeChangeHash.read(from: &buf))
+            try seq.append(FfiConverterTypeChangeHash.read(from: &buf))
         }
         return seq
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,12 @@ let package = Package(
     products: [
         .library(name: "Automerge", targets: ["Automerge"]),
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/apple/swift-collections.git",
+            .upToNextMajor(from: "1.0.0")
+        ),
+    ],
     targets: [
         FFIbinaryTarget,
         .target(
@@ -71,7 +77,7 @@ let package = Package(
         ),
         .target(
             name: "Automerge",
-            dependencies: ["AutomergeUniffi"],
+            dependencies: ["AutomergeUniffi", .product(name: "Collections", package: "swift-collections")],
             swiftSettings: globalSwiftSettings
         ),
         .testTarget(

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -1,6 +1,7 @@
 import class AutomergeUniffi.Doc
 import protocol AutomergeUniffi.DocProtocol
 import Foundation
+import OrderedCollections
 
 /// The entry point to automerge, a ``Document`` presents a key/value interface to
 /// the data it contains; as well as methods for loading and saving documents, and
@@ -476,7 +477,7 @@ public class Document: @unchecked Sendable {
 
     /// Fork the document as at `heads`
     ///
-    /// Fork the document but such that it only contains changes up to `heads`
+    /// Fork the document but such that it only contains changes up to the set of `heads` you provide.
     public func forkAt(heads: Set<ChangeHash>) throws -> Document {
         try queue.sync {
             try self.doc.wrapErrors { try Document(doc: $0.forkAt(heads: heads.map(\.bytes))) }
@@ -503,11 +504,14 @@ public class Document: @unchecked Sendable {
         }
     }
 
-    /// Returns: a sequence of ``ChangeHash`` representing the changes which were
-    /// made to the document as a result of the merge
-    public func heads() -> Set<ChangeHash> {
+    /// Returns: a sequence of ``ChangeHash`` that represents the changes made to the document.
+    ///
+    /// The collection of change hashes is of unique values, and are accepted into other parts of the API as a set.
+    /// The additional ordering provided by the OrderedSet returned preserves a causal history of the changes applied
+    /// over time.
+    public func heads() -> OrderedSet<ChangeHash> {
         queue.sync {
-            Set(self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } })
+            OrderedSet(self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } })
         }
     }
 

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -176,7 +176,7 @@ public class Document: @unchecked Sendable {
     /// > Tip: Note that if there are multiple conflicting values this method
     /// will return one of them  arbitrarily (but deterministically). If you
     /// need all the conflicting values see ``getAllAt(obj:key:heads:)``
-    public func getAt(obj: ObjId, key: String, heads: Set<ChangeHash>) throws
+    public func getAt(obj: ObjId, key: String, heads: OrderedSet<ChangeHash>) throws
         -> Value?
     {
         try queue.sync {
@@ -192,7 +192,7 @@ public class Document: @unchecked Sendable {
     /// > Tip: Note that if there are multiple conflicting values this method
     /// will return one of them  arbitrarily (but deterministically). If you
     /// need all the conflicting values see ``getAllAt(obj:index:heads:)``
-    public func getAt(obj: ObjId, index: UInt64, heads: Set<ChangeHash>) throws
+    public func getAt(obj: ObjId, index: UInt64, heads: OrderedSet<ChangeHash>) throws
         -> Value?
     {
         try queue.sync {
@@ -204,7 +204,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get all the possibly conflicting values for `key` in map `obj` as at `heads`
-    public func getAllAt(obj: ObjId, key: String, heads: Set<ChangeHash>) throws
+    public func getAllAt(obj: ObjId, key: String, heads: OrderedSet<ChangeHash>) throws
         -> Set<Value>
     {
         try queue.sync {
@@ -216,7 +216,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get all the possibly conflicting values for `index` in list `obj` as at `heads`
-    public func getAllAt(obj: ObjId, index: UInt64, heads: Set<ChangeHash>)
+    public func getAllAt(obj: ObjId, index: UInt64, heads: OrderedSet<ChangeHash>)
         throws -> Set<Value>
     {
         try queue.sync {
@@ -235,7 +235,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get all the keys that were in the map `obj` as at `heads`
-    public func keysAt(obj: ObjId, heads: Set<ChangeHash>) -> [String] {
+    public func keysAt(obj: ObjId, heads: OrderedSet<ChangeHash>) -> [String] {
         queue.sync {
             self.doc.wrapErrors { $0.mapKeysAt(obj: obj.bytes, heads: heads.map(\.bytes)) }
         }
@@ -253,7 +253,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get the values in the map or list `obj` as at `heads`
-    public func valuesAt(obj: ObjId, heads: Set<ChangeHash>) throws -> [Value] {
+    public func valuesAt(obj: ObjId, heads: OrderedSet<ChangeHash>) throws -> [Value] {
         try queue.sync {
             let vals = try self.doc.wrapErrors {
                 try $0.valuesAt(obj: obj.bytes, heads: heads.map(\.bytes))
@@ -271,7 +271,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get the (key,value) entries in the map `obj` as at `heads`
-    public func mapEntriesAt(obj: ObjId, heads: Set<ChangeHash>) throws -> [(
+    public func mapEntriesAt(obj: ObjId, heads: OrderedSet<ChangeHash>) throws -> [(
         String, Value
     )] {
         try queue.sync {
@@ -290,7 +290,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// The length of the list `obj` as at `heads`
-    public func lengthAt(obj: ObjId, heads: Set<ChangeHash>) -> UInt64 {
+    public func lengthAt(obj: ObjId, heads: OrderedSet<ChangeHash>) -> UInt64 {
         queue.sync {
             self.doc.wrapErrors { $0.lengthAt(obj: obj.bytes, heads: heads.map(\.bytes)) }
         }
@@ -314,7 +314,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get the value of the text object `obj` as at `heads`
-    public func textAt(obj: ObjId, heads: Set<ChangeHash>) throws -> String {
+    public func textAt(obj: ObjId, heads: OrderedSet<ChangeHash>) throws -> String {
         try queue.sync {
             try self.doc.wrapErrors { try $0.textAt(obj: obj.bytes, heads: heads.map(\.bytes)) }
         }
@@ -408,7 +408,7 @@ public class Document: @unchecked Sendable {
     }
 
     /// Get the list of marks for a text object at the given heads.
-    public func marksAt(obj: ObjId, heads: Set<ChangeHash>) throws -> [Mark] {
+    public func marksAt(obj: ObjId, heads: OrderedSet<ChangeHash>) throws -> [Mark] {
         try queue.sync {
             try self.doc.wrapErrors {
                 try $0.marksAt(obj: obj.bytes, heads: heads.map(\.bytes)).map(Mark.fromFfi)
@@ -478,7 +478,7 @@ public class Document: @unchecked Sendable {
     /// Fork the document as at `heads`
     ///
     /// Fork the document but such that it only contains changes up to the set of `heads` you provide.
-    public func forkAt(heads: Set<ChangeHash>) throws -> Document {
+    public func forkAt(heads: OrderedSet<ChangeHash>) throws -> Document {
         try queue.sync {
             try self.doc.wrapErrors { try Document(doc: $0.forkAt(heads: heads.map(\.bytes))) }
         }
@@ -537,7 +537,7 @@ public class Document: @unchecked Sendable {
     ///
     /// Returns: encoded changes suitable for sending over the network and
     /// applying to another document using ``applyEncodedChanges(encoded:)``
-    public func encodeChangesSince(heads: Set<ChangeHash>) throws -> Data {
+    public func encodeChangesSince(heads: OrderedSet<ChangeHash>) throws -> Data {
         try queue.sync {
             try self.doc.wrapErrors { try Data($0.encodeChangesSince(heads: heads.map(\.bytes))) }
         }

--- a/Sources/Automerge/SyncState.swift
+++ b/Sources/Automerge/SyncState.swift
@@ -1,5 +1,6 @@
 import class AutomergeUniffi.SyncState
 import Foundation
+import OrderedCollections
 
 typealias FfiSyncState = AutomergeUniffi.SyncState
 
@@ -38,9 +39,9 @@ public struct SyncState: @unchecked Sendable {
     // dispatch queue in order to accommodate marking the wrapping class as `unchecked @Sendable`.
 
     // The heads the other end last reported (`nil` if we haven't received anything from them yet)
-    public var theirHeads: Set<ChangeHash>? {
+    public var theirHeads: OrderedSet<ChangeHash>? {
         queue.sync {
-            ffi_state.theirHeads().map { Set($0.map { ChangeHash(bytes: $0) }) }
+            ffi_state.theirHeads().map { OrderedSet($0.map { ChangeHash(bytes: $0) }) }
         }
     }
 


### PR DESCRIPTION
fix: preserves the causal history of the change sets provided by the heads() function to see the history of an automerge document.

resolves #42