### PR TITLE
Adding a Get changes for causally ordered updates to the document

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -104,12 +104,12 @@ private func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: 
 
 // Reads a float at the current offset.
 private func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
-    Float(bitPattern: try readInt(&reader))
+    try Float(bitPattern: readInt(&reader))
 }
 
 // Reads a float at the current offset.
 private func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
-    Double(bitPattern: try readInt(&reader))
+    try Double(bitPattern: readInt(&reader))
 }
 
 // Indicates if the offset has reached the end of the buffer.
@@ -281,7 +281,7 @@ private func uniffiCheckCallStatus(
         // with the message.  But if that code panics, then it just sends back
         // an empty buffer.
         if callStatus.errorBuf.len > 0 {
-            throw UniffiInternalError.rustPanic(try FfiConverterString.lift(callStatus.errorBuf))
+            throw try UniffiInternalError.rustPanic(FfiConverterString.lift(callStatus.errorBuf))
         } else {
             callStatus.errorBuf.deallocate()
             throw UniffiInternalError.rustPanic("Rust panic")
@@ -395,7 +395,7 @@ private struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        return try String(bytes: readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {
@@ -446,6 +446,7 @@ public protocol DocProtocol {
     func objectType(obj: ObjId) -> ObjType
     func path(obj: ObjId) throws -> [PathElement]
     func heads() -> [ChangeHash]
+    func changes() -> [ChangeHash]
     func save() -> [UInt8]
     func merge(other: Doc) throws
     func mergeWithPatches(other: Doc) throws -> [Patch]
@@ -487,7 +488,7 @@ public class Doc: DocProtocol {
     }
 
     public static func load(bytes: [UInt8]) throws -> Doc {
-        Doc(unsafeFromRawPointer: try rustCallWithError(FfiConverterTypeLoadError.lift) {
+        try Doc(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeLoadError.lift) {
             uniffi_automerge_fn_constructor_doc_load(
                 FfiConverterSequenceUInt8.lower(bytes), $0
             )
@@ -532,15 +533,14 @@ public class Doc: DocProtocol {
 
     public func forkAt(heads: [ChangeHash]) throws -> Doc {
         try FfiConverterTypeDoc.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_fork_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_fork_at(
+                    self.pointer,
 
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -560,17 +560,16 @@ public class Doc: DocProtocol {
 
     public func putObjectInMap(obj: ObjId, key: String, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_put_object_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_put_object_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -590,17 +589,16 @@ public class Doc: DocProtocol {
 
     public func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_put_object_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_put_object_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -620,17 +618,16 @@ public class Doc: DocProtocol {
 
     public func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
         try FfiConverterTypeObjId.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_insert_object_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_insert_object_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterTypeObjType.lower(objType),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterTypeObjType.lower(objType),
+                    $0
+                )
+            }
         )
     }
 
@@ -690,30 +687,28 @@ public class Doc: DocProtocol {
 
     public func marks(obj: ObjId) throws -> [Mark] {
         try FfiConverterSequenceTypeMark.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_marks(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_marks(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func marksAt(obj: ObjId, heads: [ChangeHash]) throws -> [Mark] {
         try FfiConverterSequenceTypeMark.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_marks_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_marks_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -773,154 +768,144 @@ public class Doc: DocProtocol {
 
     public func getInMap(obj: ObjId, key: String) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    $0
+                )
+            }
         )
     }
 
     public func getInList(obj: ObjId, index: UInt64) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    $0
+                )
+            }
         )
     }
 
     public func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_at_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_at_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> Value? {
         try FfiConverterOptionTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_at_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_at_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllInMap(obj: ObjId, key: String) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllInList(obj: ObjId, index: UInt64) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_at_in_map(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_at_in_map(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterString.lower(key),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterString.lower(key),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_get_all_at_in_list(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_get_all_at_in_list(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterUInt64.lower(index),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterUInt64.lower(index),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func text(obj: ObjId) throws -> String {
         try FfiConverterString.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_text(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_text(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func textAt(obj: ObjId, heads: [ChangeHash]) throws -> String {
         try FfiConverterString.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_text_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_text_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -955,59 +940,55 @@ public class Doc: DocProtocol {
 
     public func mapEntries(obj: ObjId) throws -> [KeyValue] {
         try FfiConverterSequenceTypeKeyValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_map_entries(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_map_entries(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func mapEntriesAt(obj: ObjId, heads: [ChangeHash]) throws -> [KeyValue] {
         try FfiConverterSequenceTypeKeyValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_map_entries_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_map_entries_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
     public func values(obj: ObjId) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_values(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_values(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
     public func valuesAt(obj: ObjId, heads: [ChangeHash]) throws -> [Value] {
         try FfiConverterSequenceTypeValue.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_values_at(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_values_at(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -1056,15 +1037,14 @@ public class Doc: DocProtocol {
 
     public func path(obj: ObjId) throws -> [PathElement] {
         try FfiConverterSequenceTypePathElement.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_path(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_path(
+                    self.pointer,
 
-                        FfiConverterTypeObjId.lower(obj),
-                        $0
-                    )
-                }
+                    FfiConverterTypeObjId.lower(obj),
+                    $0
+                )
+            }
         )
     }
 
@@ -1073,6 +1053,18 @@ public class Doc: DocProtocol {
             try!
                 rustCall {
                     uniffi_automerge_fn_method_doc_heads(
+                        self.pointer,
+                        $0
+                    )
+                }
+        )
+    }
+
+    public func changes() -> [ChangeHash] {
+        try! FfiConverterSequenceTypeChangeHash.lift(
+            try!
+                rustCall {
+                    uniffi_automerge_fn_method_doc_changes(
                         self.pointer,
                         $0
                     )
@@ -1106,15 +1098,14 @@ public class Doc: DocProtocol {
 
     public func mergeWithPatches(other: Doc) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_merge_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_merge_with_patches(
+                    self.pointer,
 
-                        FfiConverterTypeDoc.lower(other),
-                        $0
-                    )
-                }
+                    FfiConverterTypeDoc.lower(other),
+                    $0
+                )
+            }
         )
     }
 
@@ -1147,16 +1138,15 @@ public class Doc: DocProtocol {
 
     public func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
-                    uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
+                uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(
+                    self.pointer,
 
-                        FfiConverterTypeSyncState.lower(state),
-                        FfiConverterSequenceUInt8.lower(msg),
-                        $0
-                    )
-                }
+                    FfiConverterTypeSyncState.lower(state),
+                    FfiConverterSequenceUInt8.lower(msg),
+                    $0
+                )
+            }
         )
     }
 
@@ -1174,15 +1164,14 @@ public class Doc: DocProtocol {
 
     public func encodeChangesSince(heads: [ChangeHash]) throws -> [UInt8] {
         try FfiConverterSequenceUInt8.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_encode_changes_since(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_encode_changes_since(
+                    self.pointer,
 
-                        FfiConverterSequenceTypeChangeHash.lower(heads),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceTypeChangeHash.lower(heads),
+                    $0
+                )
+            }
         )
     }
 
@@ -1200,15 +1189,14 @@ public class Doc: DocProtocol {
 
     public func applyEncodedChangesWithPatches(changes: [UInt8]) throws -> [Patch] {
         try FfiConverterSequenceTypePatch.lift(
-            try
-                rustCallWithError(FfiConverterTypeDocError.lift) {
-                    uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(
-                        self.pointer,
+            rustCallWithError(FfiConverterTypeDocError.lift) {
+                uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(
+                    self.pointer,
 
-                        FfiConverterSequenceUInt8.lower(changes),
-                        $0
-                    )
-                }
+                    FfiConverterSequenceUInt8.lower(changes),
+                    $0
+                )
+            }
         )
     }
 }
@@ -1278,7 +1266,7 @@ public class SyncState: SyncStateProtocol {
     }
 
     public static func decode(bytes: [UInt8]) throws -> SyncState {
-        SyncState(unsafeFromRawPointer: try rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
+        try SyncState(unsafeFromRawPointer: rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
             uniffi_automerge_fn_constructor_syncstate_decode(
                 FfiConverterSequenceUInt8.lower(bytes), $0
             )
@@ -1593,8 +1581,8 @@ public struct FfiConverterTypeDecodeSyncStateError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DecodeSyncStateError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1631,12 +1619,12 @@ public struct FfiConverterTypeDocError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .WrongObjectType(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .WrongObjectType(
+                message: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 2: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1726,8 +1714,8 @@ public struct FfiConverterTypeLoadError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LoadError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1813,51 +1801,51 @@ public struct FfiConverterTypePatchAction: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PatchAction {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .put(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf),
-                value: try FfiConverterTypeValue.read(from: &buf)
+        case 1: return try .put(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterTypeValue.read(from: &buf)
             )
 
-        case 2: return .insert(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                values: try FfiConverterSequenceTypeValue.read(from: &buf),
-                marks: try FfiConverterDictionaryStringTypeValue.read(from: &buf)
+        case 2: return try .insert(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                values: FfiConverterSequenceTypeValue.read(from: &buf),
+                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
             )
 
-        case 3: return .spliceText(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                value: try FfiConverterString.read(from: &buf),
-                marks: try FfiConverterDictionaryStringTypeValue.read(from: &buf)
+        case 3: return try .spliceText(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                value: FfiConverterString.read(from: &buf),
+                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
             )
 
-        case 4: return .increment(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf),
-                value: try FfiConverterInt64.read(from: &buf)
+        case 4: return try .increment(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 5: return .conflict(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                prop: try FfiConverterTypeProp.read(from: &buf)
+        case 5: return try .conflict(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf)
             )
 
-        case 6: return .deleteMap(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                key: try FfiConverterString.read(from: &buf)
+        case 6: return try .deleteMap(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                key: FfiConverterString.read(from: &buf)
             )
 
-        case 7: return .deleteSeq(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                index: try FfiConverterUInt64.read(from: &buf),
-                length: try FfiConverterUInt64.read(from: &buf)
+        case 7: return try .deleteSeq(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                length: FfiConverterUInt64.read(from: &buf)
             )
 
-        case 8: return .marks(
-                obj: try FfiConverterTypeObjId.read(from: &buf),
-                marks: try FfiConverterSequenceTypeMark.read(from: &buf)
+        case 8: return try .marks(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                marks: FfiConverterSequenceTypeMark.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1939,12 +1927,12 @@ public struct FfiConverterTypeProp: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Prop {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .key(
-                value: try FfiConverterString.read(from: &buf)
+        case 1: return try .key(
+                value: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .index(
-                value: try FfiConverterUInt64.read(from: &buf)
+        case 2: return try .index(
+                value: FfiConverterUInt64.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -1992,12 +1980,12 @@ public struct FfiConverterTypeReceiveSyncError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReceiveSyncError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .Internal(
-                message: try FfiConverterString.read(from: &buf)
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
             )
 
-        case 2: return .InvalidMessage(
-                message: try FfiConverterString.read(from: &buf)
+        case 2: return try .InvalidMessage(
+                message: FfiConverterString.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -2039,41 +2027,41 @@ public struct FfiConverterTypeScalarValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ScalarValue {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .bytes(
-                value: try FfiConverterSequenceUInt8.read(from: &buf)
+        case 1: return try .bytes(
+                value: FfiConverterSequenceUInt8.read(from: &buf)
             )
 
-        case 2: return .string(
-                value: try FfiConverterString.read(from: &buf)
+        case 2: return try .string(
+                value: FfiConverterString.read(from: &buf)
             )
 
-        case 3: return .uint(
-                value: try FfiConverterUInt64.read(from: &buf)
+        case 3: return try .uint(
+                value: FfiConverterUInt64.read(from: &buf)
             )
 
-        case 4: return .int(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 4: return try .int(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 5: return .f64(
-                value: try FfiConverterDouble.read(from: &buf)
+        case 5: return try .f64(
+                value: FfiConverterDouble.read(from: &buf)
             )
 
-        case 6: return .counter(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 6: return try .counter(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 7: return .timestamp(
-                value: try FfiConverterInt64.read(from: &buf)
+        case 7: return try .timestamp(
+                value: FfiConverterInt64.read(from: &buf)
             )
 
-        case 8: return .boolean(
-                value: try FfiConverterBool.read(from: &buf)
+        case 8: return try .boolean(
+                value: FfiConverterBool.read(from: &buf)
             )
 
-        case 9: return .unknown(
-                typeCode: try FfiConverterUInt8.read(from: &buf),
-                data: try FfiConverterSequenceUInt8.read(from: &buf)
+        case 9: return try .unknown(
+                typeCode: FfiConverterUInt8.read(from: &buf),
+                data: FfiConverterSequenceUInt8.read(from: &buf)
             )
 
         case 10: return .null
@@ -2150,13 +2138,13 @@ public struct FfiConverterTypeValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Value {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        case 1: return .object(
-                typ: try FfiConverterTypeObjType.read(from: &buf),
-                id: try FfiConverterTypeObjId.read(from: &buf)
+        case 1: return try .object(
+                typ: FfiConverterTypeObjType.read(from: &buf),
+                id: FfiConverterTypeObjId.read(from: &buf)
             )
 
-        case 2: return .scalar(
-                value: try FfiConverterTypeScalarValue.read(from: &buf)
+        case 2: return try .scalar(
+                value: FfiConverterTypeScalarValue.read(from: &buf)
             )
 
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -2266,7 +2254,7 @@ private struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
         var seq = [UInt8]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterUInt8.read(from: &buf))
+            try seq.append(FfiConverterUInt8.read(from: &buf))
         }
         return seq
     }
@@ -2288,7 +2276,7 @@ private struct FfiConverterSequenceString: FfiConverterRustBuffer {
         var seq = [String]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterString.read(from: &buf))
+            try seq.append(FfiConverterString.read(from: &buf))
         }
         return seq
     }
@@ -2310,7 +2298,7 @@ private struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
         var seq = [KeyValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeKeyValue.read(from: &buf))
+            try seq.append(FfiConverterTypeKeyValue.read(from: &buf))
         }
         return seq
     }
@@ -2332,7 +2320,7 @@ private struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
         var seq = [Mark]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeMark.read(from: &buf))
+            try seq.append(FfiConverterTypeMark.read(from: &buf))
         }
         return seq
     }
@@ -2354,7 +2342,7 @@ private struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
         var seq = [Patch]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePatch.read(from: &buf))
+            try seq.append(FfiConverterTypePatch.read(from: &buf))
         }
         return seq
     }
@@ -2376,7 +2364,7 @@ private struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
         var seq = [PathElement]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePathElement.read(from: &buf))
+            try seq.append(FfiConverterTypePathElement.read(from: &buf))
         }
         return seq
     }
@@ -2398,7 +2386,7 @@ private struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
         var seq = [ScalarValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeScalarValue.read(from: &buf))
+            try seq.append(FfiConverterTypeScalarValue.read(from: &buf))
         }
         return seq
     }
@@ -2420,7 +2408,7 @@ private struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
         var seq = [Value]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeValue.read(from: &buf))
+            try seq.append(FfiConverterTypeValue.read(from: &buf))
         }
         return seq
     }
@@ -2442,7 +2430,7 @@ private struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
         var seq = [ChangeHash]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeChangeHash.read(from: &buf))
+            try seq.append(FfiConverterTypeChangeHash.read(from: &buf))
         }
         return seq
     }
@@ -2694,6 +2682,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_automerge_checksum_method_doc_heads() != 41278 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_automerge_checksum_method_doc_changes() != 11521 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_automerge_checksum_method_doc_save() != 57703 {

--- a/AutomergeUniffi/automergeFFI.h
+++ b/AutomergeUniffi/automergeFFI.h
@@ -169,6 +169,8 @@ RustBuffer uniffi_automerge_fn_method_doc_path(void*_Nonnull ptr, RustBuffer obj
 );
 RustBuffer uniffi_automerge_fn_method_doc_heads(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_automerge_fn_method_doc_changes(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_automerge_fn_method_doc_save(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 void uniffi_automerge_fn_method_doc_merge(void*_Nonnull ptr, void*_Nonnull other, RustCallStatus *_Nonnull out_status
@@ -330,6 +332,9 @@ uint16_t uniffi_automerge_checksum_method_doc_path(void
     
 );
 uint16_t uniffi_automerge_checksum_method_doc_heads(void
+    
+);
+uint16_t uniffi_automerge_checksum_method_doc_changes(void
     
 );
 uint16_t uniffi_automerge_checksum_method_doc_save(void

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -513,7 +513,7 @@ public class Document: @unchecked Sendable {
     /// Returns an list of change hashes that represent the causal sequence of changes to the document.
     public func changes() -> [ChangeHash] {
         queue.sync {
-            self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } }
+            self.doc.wrapErrors { $0.changes().map { ChangeHash(bytes: $0) } }
         }
     }
 

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -504,6 +504,8 @@ public class Document: @unchecked Sendable {
     }
 
     /// Returns a set of change hashes that represent the current state of the document.
+    ///
+    /// The number of change hashes returned represents the number of concurrent changes the document tracks.
     public func heads() -> Set<ChangeHash> {
         queue.sync {
             Set(self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } })

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -503,11 +503,17 @@ public class Document: @unchecked Sendable {
         }
     }
 
-    /// Returns: a sequence of ``ChangeHash`` representing the changes which were
-    /// made to the document as a result of the merge
+    /// Returns a set of change hashes that represent the current state of the document.
     public func heads() -> Set<ChangeHash> {
         queue.sync {
             Set(self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } })
+        }
+    }
+
+    /// Returns an list of change hashes that represent the causal sequence of changes to the document.
+    public func changes() -> [ChangeHash] {
+        queue.sync {
+            self.doc.wrapErrors { $0.heads().map { ChangeHash(bytes: $0) } }
         }
     }
 

--- a/Sources/Automerge/Marks.swift
+++ b/Sources/Automerge/Marks.swift
@@ -40,7 +40,7 @@ public struct Mark: Equatable, Hashable, Sendable {
 ///
 /// For more information on marks and how they expand,
 /// see the [The Peritext Essay](https://www.inkandswitch.com/peritext/).
-public enum ExpandMark {
+public enum ExpandMark: Equatable, Hashable, Sendable {
     /// Characters added just before the mark should be inside the mark.
     case before
     /// Characters added just after the mark should be inside the mark.

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -1,0 +1,29 @@
+import Automerge
+import XCTest
+
+class HistoryTests: XCTestCase {
+    func testChangeCountsInHeads() {
+        let doc = Document()
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+
+        var heads = doc.heads()
+        XCTAssertEqual(heads.count, 1)
+        heads = doc.heads()
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        XCTAssertEqual(heads.count, 2)
+    }
+
+    func testChangeCountsInHeadsAndChanges() {
+        let doc = Document()
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+
+        var heads = doc.heads()
+        XCTAssertEqual(heads.count, 1)
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        heads = doc.heads()
+        XCTAssertEqual(heads.count, 2)
+
+        let changes = doc.changes()
+        XCTAssertEqual(changes.count, heads.count)
+    }
+}

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -9,36 +9,41 @@ class HistoryTests: XCTestCase {
 
         try doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
         XCTAssertEqual(doc.heads().count, 1)
-        
+
         let replicaDoc = doc.fork()
         XCTAssertEqual(doc.heads().count, 1)
         XCTAssertEqual(replicaDoc.heads().count, 1)
         XCTAssertEqual(doc.heads(), replicaDoc.heads())
-        
-        try replicaDoc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
+
+        try doc.put(obj: ObjId.ROOT, key: "newkey", value: .String("beta"))
+        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: .String("alpha"))
         XCTAssertEqual(doc.heads().count, 1)
         XCTAssertEqual(replicaDoc.heads().count, 1)
         XCTAssertNotEqual(doc.heads(), replicaDoc.heads())
-        
+
+        // The number of ChangeHash values returned from heads() is the
+        // number of concurrent changes to the document that it's aware of.
+
+        // In a linear document, the number of heads is 1.
         try doc.merge(other: replicaDoc)
-        XCTAssertEqual(doc.heads().count, 1)
+        XCTAssertEqual(doc.heads().count, 2)
         XCTAssertEqual(replicaDoc.heads().count, 1)
-        XCTAssertEqual(doc.heads(), replicaDoc.heads())
+        XCTAssertNotEqual(doc.heads(), replicaDoc.heads())
     }
 
     func testChangeCountsInHeadsAndChanges() throws {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
-        print(doc.changes())
-//        XCTAssertEqual(doc.changes().count, 1)
+        XCTAssertEqual(doc.changes().count, 1)
 
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
-//        XCTAssertEqual(doc.changes().count, 1)
-        print(doc.changes())
+        XCTAssertEqual(doc.changes().count, 2)
 
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
-//        XCTAssertEqual(doc.changes().count, 1)
-        print(doc.changes())
+        XCTAssertEqual(doc.changes().count, 3)
 
+        let replicaDoc = doc.fork()
+        XCTAssertEqual(doc.heads(), replicaDoc.heads())
+        XCTAssertEqual(doc.changes(), replicaDoc.changes())
     }
 }

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -5,20 +5,20 @@ class HistoryTests: XCTestCase {
     func testChangeCountsInHeads() {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
-
         var heads = doc.heads()
         XCTAssertEqual(heads.count, 1)
-        heads = doc.heads()
+
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        heads = doc.heads()
         XCTAssertEqual(heads.count, 2)
     }
 
     func testChangeCountsInHeadsAndChanges() {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
-
         var heads = doc.heads()
         XCTAssertEqual(heads.count, 1)
+
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
         heads = doc.heads()
         XCTAssertEqual(heads.count, 2)

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -2,28 +2,43 @@ import Automerge
 import XCTest
 
 class HistoryTests: XCTestCase {
-    func testChangeCountsInHeads() {
+    func testHeadsDuringChanges() throws {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
-        var heads = doc.heads()
-        XCTAssertEqual(heads.count, 1)
+        try doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+        XCTAssertEqual(doc.heads().count, 1)
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
-        heads = doc.heads()
-        XCTAssertEqual(heads.count, 2)
+        try doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        XCTAssertEqual(doc.heads().count, 1)
+        
+        let replicaDoc = doc.fork()
+        XCTAssertEqual(doc.heads().count, 1)
+        XCTAssertEqual(replicaDoc.heads().count, 1)
+        XCTAssertEqual(doc.heads(), replicaDoc.heads())
+        
+        try replicaDoc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
+        XCTAssertEqual(doc.heads().count, 1)
+        XCTAssertEqual(replicaDoc.heads().count, 1)
+        XCTAssertNotEqual(doc.heads(), replicaDoc.heads())
+        
+        try doc.merge(other: replicaDoc)
+        XCTAssertEqual(doc.heads().count, 1)
+        XCTAssertEqual(replicaDoc.heads().count, 1)
+        XCTAssertEqual(doc.heads(), replicaDoc.heads())
     }
 
-    func testChangeCountsInHeadsAndChanges() {
+    func testChangeCountsInHeadsAndChanges() throws {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
-        var heads = doc.heads()
-        XCTAssertEqual(heads.count, 1)
+        print(doc.changes())
+//        XCTAssertEqual(doc.changes().count, 1)
 
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
-        heads = doc.heads()
-        XCTAssertEqual(heads.count, 2)
+//        XCTAssertEqual(doc.changes().count, 1)
+        print(doc.changes())
 
-        let changes = doc.changes()
-        XCTAssertEqual(changes.count, heads.count)
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
+//        XCTAssertEqual(doc.changes().count, 1)
+        print(doc.changes())
+
     }
 }

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -39,11 +39,21 @@ class HistoryTests: XCTestCase {
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
         XCTAssertEqual(doc.changes().count, 2)
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
-        XCTAssertEqual(doc.changes().count, 3)
-
         let replicaDoc = doc.fork()
         XCTAssertEqual(doc.heads(), replicaDoc.heads())
         XCTAssertEqual(doc.changes(), replicaDoc.changes())
+
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
+        XCTAssertEqual(doc.changes().count, 3)
+        XCTAssertEqual(replicaDoc.changes().count, 2)
+
+        try doc.put(obj: ObjId.ROOT, key: "newkey", value: .String("beta"))
+        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: .String("alpha"))
+        XCTAssertEqual(doc.changes().count, 4)
+        XCTAssertEqual(replicaDoc.changes().count, 3)
+
+        try doc.merge(other: replicaDoc)
+        XCTAssertEqual(doc.changes().count, 5)
+        XCTAssertEqual(replicaDoc.changes().count, 3)
     }
 }

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -215,6 +215,8 @@ interface Doc {
 
     sequence<ChangeHash> heads();
 
+    sequence<ChangeHash> changes();
+
     sequence<u8> save();
 
     [Throws=DocError]

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -515,16 +515,10 @@ impl Doc {
     }
 
     pub fn changes(&self) -> Vec<ChangeHash> {
-        let mut emptyHeads: Vec<am::ChangeHash> = Vec::new();
+        let empty_heads: Vec<am::ChangeHash> = Vec::new();
         let mut doc = self.0.write().unwrap();
-        let changes = doc.get_changes(&emptyHeads);
-
-        let mut result = Vec::new();
-        let x = changes
-            .into_iter()
-            .map(|h| h.into())
-            .collect();
-        return x
+        let changes = doc.get_changes(&empty_heads);
+        changes.into_iter().map(|h| h.hash().into()).collect()
     }
 
     pub fn path(&self, obj: ObjId) -> Result<Vec<PathElement>, DocError> {

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -514,6 +514,19 @@ impl Doc {
             .collect()
     }
 
+    pub fn changes(&self) -> Vec<ChangeHash> {
+        let mut emptyHeads: Vec<am::ChangeHash> = Vec::new();
+        let mut doc = self.0.write().unwrap();
+        let changes = doc.get_changes(&emptyHeads);
+
+        let mut result = Vec::new();
+        let x = changes
+            .into_iter()
+            .map(|h| h.into())
+            .collect();
+        return x
+    }
+
     pub fn path(&self, obj: ObjId) -> Result<Vec<PathElement>, DocError> {
         let doc = self.0.read().unwrap();
         let obj = am::ObjId::from(obj);

--- a/rust/src/sync_state.rs
+++ b/rust/src/sync_state.rs
@@ -41,3 +41,9 @@ impl SyncState {
             .map(|heads| heads.iter().map(ChangeHash::from).collect())
     }
 }
+
+impl Default for SyncState {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
@alexjg I could use some Rust specific help - I've got a function stubbed, but with a likely obvious compilation error. I'm not very fluent with Rust internals, nor idiomatic rust - so help on both/either would be very appreciated.

I added a function on the wrapper `doc` called `changes()` with the idea of getting all changes by providing an empty vector to `get_changes()` in Automerge. 

I'm getting the changes Vec<&Change>, but I'm not clear on how to convert that into Vec<ChangeHash> and the relatively obvious path of hoping there was an `.into()` available that I could call doesn't seem to be correct.

I also wasn't sure about returning the raw vector vs. something like `Result<Vec<ChangeHash>, DocError>` - and where errors would populate up from within the sequence of code to be entirely sure if an error _could_ be thrown from within what I wrote.

related to #42 