### PR TITLE
renaming Text to AutomergeText for ergonomics in consumption

### DIFF
--- a/Sources/Automerge/Automerge.docc/Automerge.md
+++ b/Sources/Automerge/Automerge.docc/Automerge.md
@@ -56,7 +56,7 @@ See the documentation of ``Document`` for more details on the individual methods
 ## Saving, loading, and syncing
 
 An Automerge document can be saved using ``Document/save()``. 
-This will produce a compressed encoding of the document which is extremely efficient and which can be loaded using ``Document/init(_:)``. 
+This will produce a compressed encoding of the document which is extremely efficient and which can be loaded using ``Document/init(_:logLevel:)``. 
 In many cases you know that the other end already has some set of changes and you just want to send "new" changes. 
 You can obtain these changes using ``Document/encodeNewChanges()`` and ``Document/encodeChangesSince(heads:)``. 
 On the other end of the wire you can apply changes using ``Document/applyEncodedChanges(encoded:)``.
@@ -98,7 +98,7 @@ Any document method which accepts remote changes has a `*WithPatches` variant wh
 - ``Automerge/AutomergeDecoder``
 - ``Automerge/AnyCodingKey``
 - ``Automerge/Counter``
-- ``Automerge/Text``
+- ``Automerge/AutomergeText``
 - ``Automerge/SchemaStrategy``
 - ``Automerge/CodingKeyLookupError``
 - ``Automerge/PathParseError``

--- a/Sources/Automerge/Automerge.docc/Document.md
+++ b/Sources/Automerge/Automerge.docc/Document.md
@@ -4,8 +4,8 @@
 
 ### Creating or loading a document
 
-- ``init()``
-- ``init(_:)``
+- ``init(logLevel:)``
+- ``init(_:logLevel:)``
 
 ### Inspecting Documents
 

--- a/Sources/Automerge/Codable/AutomergeText.swift
+++ b/Sources/Automerge/Codable/AutomergeText.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type that presents a string backed by a Sequential CRDT
-public struct Text: Hashable, Codable {
+public struct AutomergeText: Hashable, Codable {
     public var value: String
 
     // NOTE(heckj): The version Automerge after 2.0 is adding support for "marks"
@@ -17,7 +17,7 @@ public struct Text: Hashable, Codable {
     }
 }
 
-extension Text: CustomStringConvertible {
+extension AutomergeText: CustomStringConvertible {
     public var description: String {
         value
     }

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
@@ -28,7 +28,7 @@ import Foundation
 
     @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
         switch T.self {
-        case is Text.Type:
+        case is AutomergeText.Type:
             let directContainer = try singleValueContainer()
             return try directContainer.decode(T.self)
         case is Counter.Type:

--- a/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
@@ -148,11 +148,11 @@ struct AutomergeKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProt
                     debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.counter`."
                 ))
             }
-        case is Text.Type:
+        case is AutomergeText.Type:
             let retrievedValue = try getValue(forKey: key)
             if case let Value.Object(objectId, .Text) = retrievedValue {
                 let stringValue = try impl.doc.text(obj: objectId)
-                return Text(stringValue) as! T
+                return AutomergeText(stringValue) as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
@@ -165,9 +165,9 @@ struct AutomergeSingleValueDecodingContainer: SingleValueDecodingContainer {
                     debugDescription: "Expected to decode \(T.self) from \(value), but it wasn't a `.counter`."
                 ))
             }
-        case is Text.Type:
+        case is AutomergeText.Type:
             if case let .Scalar(.String(stringValue)) = value {
-                return Text(stringValue) as! T
+                return AutomergeText(stringValue) as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
@@ -152,12 +152,12 @@ struct AutomergeUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                     debugDescription: "Expected to decode \(T.self) from \(retrievedValue), but it wasn't a `.counter`."
                 ))
             }
-        case is Text.Type:
-            let retrievedValue = try getNextValue(ofType: Text.self)
+        case is AutomergeText.Type:
+            let retrievedValue = try getNextValue(ofType: AutomergeText.self)
             if case let Value.Object(objectId, .Text) = retrievedValue {
                 let stringValue = try impl.doc.text(obj: objectId)
                 currentIndex += 1
-                return Text(stringValue) as! T
+                return AutomergeText(stringValue) as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -309,10 +309,10 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 try checkTypeMatch(value: value, objectId: objectId, key: key, type: .counter)
             }
             try document.put(obj: objectId, key: key.stringValue, value: downcastCounter.toScalarValue())
-        case is Text.Type:
+        case is AutomergeText.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
-            let downcastText = value as! Text
+            let downcastText = value as! AutomergeText
             let textNodeId: ObjId
             if let existingNode = try document.get(obj: objectId, key: key.stringValue) {
                 guard case let .Object(textId, .Text) = existingNode else {

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -278,7 +278,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                 }
                 try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
-        case is Text.Type:
+        case is AutomergeText.Type:
             guard let codingkey = codingkey else {
                 throw CodingKeyLookupError
                     .NoPathForSingleValue(
@@ -287,7 +287,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
             }
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
-            let downcastText = value as! Text
+            let downcastText = value as! AutomergeText
 
             let existingValue: Value?
             // get any existing value - type of `get` based on the key type

--- a/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -130,10 +130,10 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                 )
             }
             try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
-        case is Text.Type:
+        case is AutomergeText.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
-            let downcastText = value as! Text
+            let downcastText = value as! AutomergeText
 
             let textNodeId: ObjId
             if let existingNode = try document.get(obj: objectId, index: UInt64(count)) {

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -47,7 +47,7 @@ final class AutomergeDecoderTests: XCTestCase {
             let date: Date
             let data: Data
             let uuid: UUID
-            let notes: Text
+            let notes: AutomergeText
         }
         let decoder = AutomergeDecoder(doc: doc)
 
@@ -129,7 +129,7 @@ final class AutomergeDecoderTests: XCTestCase {
         try doc.spliceText(obj: text1, start: 0, delete: 0, value: "Hello!")
 
         struct ListOfText: Codable {
-            let list: [Text]
+            let list: [AutomergeText]
         }
 
         let decoder = AutomergeDecoder(doc: doc)

--- a/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
@@ -28,7 +28,7 @@ final class AutomergeEncoderTests: XCTestCase {
             let date: Date
             let data: Data
             let uuid: UUID
-            let notes: Text
+            let notes: AutomergeText
         }
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
@@ -43,7 +43,7 @@ final class AutomergeEncoderTests: XCTestCase {
             date: earlyDate,
             data: Data("hello".utf8),
             uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
-            notes: Text("Something wicked this way comes.")
+            notes: AutomergeText("Something wicked this way comes.")
         )
 
         try automergeEncoder.encode(sample)
@@ -240,9 +240,9 @@ final class AutomergeEncoderTests: XCTestCase {
     func testTextUpdateWithEncoding_Object() throws {
         let doc = Document()
         struct TestModel: Codable {
-            var notes: Text
+            var notes: AutomergeText
         }
-        var model = TestModel(notes: Text("Hello"))
+        var model = TestModel(notes: AutomergeText("Hello"))
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
         try automergeEncoder.encode(model)
@@ -254,7 +254,7 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
 
-        model.notes = Text("Hello World!")
+        model.notes = AutomergeText("Hello World!")
         try automergeEncoder.encode(model)
 
         if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
@@ -264,7 +264,7 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
 
-        model.notes = Text("Wassup World?")
+        model.notes = AutomergeText("Wassup World?")
         try automergeEncoder.encode(model)
 
         if case let .Object(textNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes") {
@@ -278,9 +278,9 @@ final class AutomergeEncoderTests: XCTestCase {
     func testTextUpdateWithEncoding_List() throws {
         let doc = Document()
         struct TestModel: Codable {
-            var notes: [Text]
+            var notes: [AutomergeText]
         }
-        var model = TestModel(notes: [Text("Hello")])
+        var model = TestModel(notes: [AutomergeText("Hello")])
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
         try automergeEncoder.encode(model)
@@ -294,7 +294,7 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
 
-        model.notes = [Text("Hello World!")]
+        model.notes = [AutomergeText("Hello World!")]
         try automergeEncoder.encode(model)
 
         if case let .Object(listNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes"),
@@ -306,7 +306,7 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
 
-        model.notes = [Text("Wassup World?")]
+        model.notes = [AutomergeText("Wassup World?")]
         try automergeEncoder.encode(model)
 
         if case let .Object(listNode, nodeType) = try doc.get(obj: ObjId.ROOT, key: "notes"),
@@ -327,12 +327,12 @@ final class AutomergeEncoderTests: XCTestCase {
             var notes: String
         }
         struct UpdatedTestModel: Codable {
-            var notes: Text
+            var notes: AutomergeText
         }
 
         let model = InitialTestModel(notes: "Hello")
         try automergeEncoder.encode(model)
-        let followupModel = UpdatedTestModel(notes: Text("Hello"))
+        let followupModel = UpdatedTestModel(notes: AutomergeText("Hello"))
 
         XCTAssertThrowsError(
             try automergeEncoder.encode(followupModel),
@@ -350,12 +350,12 @@ final class AutomergeEncoderTests: XCTestCase {
             var notes: [String]
         }
         struct UpdatedTestModel: Codable {
-            var notes: [Text]
+            var notes: [AutomergeText]
         }
 
         let model = InitialTestModel(notes: ["Hello"])
         try automergeEncoder.encode(model)
-        let followupModel = UpdatedTestModel(notes: [Text("Hello")])
+        let followupModel = UpdatedTestModel(notes: [AutomergeText("Hello")])
 
         XCTAssertThrowsError(
             try automergeEncoder.encode(followupModel),

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyedEncoderDecoderTests.swift
@@ -21,7 +21,7 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             let date: Date
             let data: Data
             let uuid: UUID
-            let notes: Text
+            let notes: AutomergeText
         }
 
         let dateFormatter = ISO8601DateFormatter()
@@ -35,7 +35,7 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
             date: earlyDate,
             data: Data("hello".utf8),
             uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
-            notes: Text("Something wicked this way comes.")
+            notes: AutomergeText("Something wicked this way comes.")
         )
 
         try encoder.encode(sample)
@@ -242,10 +242,10 @@ final class AutomergeKeyedEncoderDecoderTests: XCTestCase {
 
     func testSimpleTextEncodeDecode() throws {
         struct WrapperStruct: Codable, Equatable {
-            let thing: Text
+            let thing: AutomergeText
         }
 
-        let topLevel = WrapperStruct(thing: Text("hi"))
+        let topLevel = WrapperStruct(thing: AutomergeText("hi"))
 
         try encoder.encode(topLevel)
         let decodedStruct = try decoder.decode(WrapperStruct.self)

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -231,7 +231,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Text() throws {
-        try singleValueContainer.encode(Text("hi"))
+        try singleValueContainer.encode(AutomergeText("hi"))
         let value = try doc.get(obj: ObjId.ROOT, key: "value")
         if case let .Object(objectId, .Text) = value {
             XCTAssertEqual(try doc.text(obj: objectId), "hi")
@@ -433,7 +433,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
             logLevel: .errorOnly
         )
         singleValueContainer = impl.singleValueContainer()
-        XCTAssertThrowsError(try singleValueContainer.encode(Text("hi")))
+        XCTAssertThrowsError(try singleValueContainer.encode(AutomergeText("hi")))
     }
 
     func testErrorEncode_Date() throws {

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -11,7 +11,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
     func testSimpleKeyEncode() throws {
         struct SimpleStruct: Codable, Equatable {
             let name: String
-            let notes: Text
+            let notes: AutomergeText
         }
 
         let automergeEncoder = AutomergeEncoder(doc: doc)
@@ -19,7 +19,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
 
         let sample = SimpleStruct(
             name: "henry",
-            notes: Text("Something wicked this way comes.")
+            notes: AutomergeText("Something wicked this way comes.")
         )
 
         let pathToTry: [AnyCodingKey] = [
@@ -39,7 +39,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
     func testTargetedSingleValueDecode() throws {
         struct SimpleStruct: Codable, Equatable {
             let name: String
-            let notes: Text
+            let notes: AutomergeText
         }
 
         let automergeEncoder = AutomergeEncoder(doc: doc)
@@ -47,7 +47,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
 
         let sample = SimpleStruct(
             name: "henry",
-            notes: Text("Something wicked this way comes.")
+            notes: AutomergeText("Something wicked this way comes.")
         )
 
         let pathToTry: [AnyCodingKey] = [
@@ -59,7 +59,10 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         let decoded1 = try automergeDecoder.decode(String.self, from: AnyCodingKey.parsePath("example.[0].name"))
         XCTAssertEqual(decoded1, "henry")
 
-        let decoded2 = try automergeDecoder.decode(Text.self, from: AnyCodingKey.parsePath("example.[0].notes"))
+        let decoded2 = try automergeDecoder.decode(
+            AutomergeText.self,
+            from: AnyCodingKey.parsePath("example.[0].notes")
+        )
         XCTAssertEqual(decoded2.value, "Something wicked this way comes.")
     }
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
@@ -25,7 +25,7 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             let date: Date
             let data: Data
             let uuid: UUID
-            let notes: Text
+            let notes: AutomergeText
         }
 
         let dateFormatter = ISO8601DateFormatter()
@@ -39,7 +39,7 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
             date: earlyDate,
             data: Data("hello".utf8),
             uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
-            notes: Text("Something wicked this way comes.")
+            notes: AutomergeText("Something wicked this way comes.")
         )
         let topLevel = WrapperStruct(list: [sample])
 
@@ -236,10 +236,10 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
 
     func testListOfTextEncodeDecode() throws {
         struct WrapperStruct: Codable, Equatable {
-            let list: [Text]
+            let list: [AutomergeText]
         }
 
-        let topLevel = WrapperStruct(list: [Text("hi")])
+        let topLevel = WrapperStruct(list: [AutomergeText("hi")])
 
         try encoder.encode(topLevel)
         let decodedStruct = try decoder.decode(WrapperStruct.self)

--- a/notes/automerge-codable.md
+++ b/notes/automerge-codable.md
@@ -66,7 +66,7 @@ The default strategy when dealing with this dynamic schema is `createWhenNeeded`
 
 One thing to note: when you call encode on a type, the Codable protocol is set up to "hand control" over to code provided by the type (or synthesized by the compiler) that has the details of _how_ to encode that type.
 In a few cases, this was surprising, and especially to support some of the specific Automerge primitives, the encoder adds special casing to use it's own logic - instead of the type's logic - for storing values into Automerge.
-This can be seen within the generic encode methods on the encoder, which switches over the type provided looking for the Automerge types of Text or Counter, or the foundational types of Date or Data.
+This can be seen within the generic encode methods on the encoder, which switches over the type provided looking for the Automerge types of AutomergeText or Counter, or the foundational types of Date or Data.
 Each of keyed container, unkeyed container, and single-value container need to contain consistent logic for these scenarios.
 
 ### Type Checking an Automerge content


### PR DESCRIPTION
`Text` as a type - in actual usage - conflicts far too much with the SwiftUI type of the same name. Since the "quick result" is a need to specify by package name "Automerge.Text" at the declaration sites in use, it seemed far easier to switch this up to `AutomergeText` and skip the compiler confusion about which `Text` you intended to use.

resolves #45