### PR TITLE
test that illustrates failure scenario for issue #54

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Automerge.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Automerge.xcscheme
@@ -34,6 +34,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AutomergeUniffi"
+               BuildableName = "AutomergeUniffi"
+               BlueprintName = "AutomergeUniffi"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.swift
+++ b/Package.swift
@@ -35,26 +35,26 @@ let FFIbinaryTarget: PackageDescription.Target
 //
 // The script `./scripts/build-xcframework.sh` _does_ expect that you have Rust
 // installed locally in order to function.
-if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
-    // We are using a local file reference to an XCFramework, which is functional
-    // on the tags for this package because the XCFramework.zip file is committed with
-    // those specific release points. This does, however, cause a few awkward issues,
-    // in particular it means that swift-docc-plugin doesn't operate correctly as the
-    // process to retrieve the symbols from this and the XCFramework fails within
-    // Swift Package Manager. Building documentation within Xcode works perfectly fine,
-    // but if you're attempting to generate HTML documentation, use the script
-    // `./scripts/build-ghpages-docs.sh`.
-    FFIbinaryTarget = .binaryTarget(
-        name: "automergeFFI",
-        path: "./automergeFFI.xcframework.zip"
-    )
-} else {
-    FFIbinaryTarget = .binaryTarget(
-        name: "automergeFFI",
-        url: "https://github.com/automerge/automerge-swift/releases/download/0.3.0/automergeFFI.xcframework.zip",
-        checksum: "8cf0b680ccbf7f97b8efac3d3defa84a06f3b3869d5c23e4535905d0f9c70e58"
-    )
-}
+// if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
+// We are using a local file reference to an XCFramework, which is functional
+// on the tags for this package because the XCFramework.zip file is committed with
+// those specific release points. This does, however, cause a few awkward issues,
+// in particular it means that swift-docc-plugin doesn't operate correctly as the
+// process to retrieve the symbols from this and the XCFramework fails within
+// Swift Package Manager. Building documentation within Xcode works perfectly fine,
+// but if you're attempting to generate HTML documentation, use the script
+// `./scripts/build-ghpages-docs.sh`.
+FFIbinaryTarget = .binaryTarget(
+    name: "automergeFFI",
+    path: "./automergeFFI.xcframework.zip"
+)
+// } else {
+//    FFIbinaryTarget = .binaryTarget(
+//        name: "automergeFFI",
+//        url: "https://github.com/automerge/automerge-swift/releases/download/0.3.0/automergeFFI.xcframework.zip",
+//        checksum: "8cf0b680ccbf7f97b8efac3d3defa84a06f3b3869d5c23e4535905d0f9c70e58"
+//    )
+// }
 
 let package = Package(
     name: "Automerge",

--- a/Package.swift
+++ b/Package.swift
@@ -35,26 +35,26 @@ let FFIbinaryTarget: PackageDescription.Target
 //
 // The script `./scripts/build-xcframework.sh` _does_ expect that you have Rust
 // installed locally in order to function.
-// if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
-// We are using a local file reference to an XCFramework, which is functional
-// on the tags for this package because the XCFramework.zip file is committed with
-// those specific release points. This does, however, cause a few awkward issues,
-// in particular it means that swift-docc-plugin doesn't operate correctly as the
-// process to retrieve the symbols from this and the XCFramework fails within
-// Swift Package Manager. Building documentation within Xcode works perfectly fine,
-// but if you're attempting to generate HTML documentation, use the script
-// `./scripts/build-ghpages-docs.sh`.
-FFIbinaryTarget = .binaryTarget(
-    name: "automergeFFI",
-    path: "./automergeFFI.xcframework.zip"
-)
-// } else {
-//    FFIbinaryTarget = .binaryTarget(
-//        name: "automergeFFI",
-//        url: "https://github.com/automerge/automerge-swift/releases/download/0.3.0/automergeFFI.xcframework.zip",
-//        checksum: "8cf0b680ccbf7f97b8efac3d3defa84a06f3b3869d5c23e4535905d0f9c70e58"
-//    )
-// }
+if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
+    // We are using a local file reference to an XCFramework, which is functional
+    // on the tags for this package because the XCFramework.zip file is committed with
+    // those specific release points. This does, however, cause a few awkward issues,
+    // in particular it means that swift-docc-plugin doesn't operate correctly as the
+    // process to retrieve the symbols from this and the XCFramework fails within
+    // Swift Package Manager. Building documentation within Xcode works perfectly fine,
+    // but if you're attempting to generate HTML documentation, use the script
+    // `./scripts/build-ghpages-docs.sh`.
+    FFIbinaryTarget = .binaryTarget(
+        name: "automergeFFI",
+        path: "./automergeFFI.xcframework.zip"
+    )
+} else {
+    FFIbinaryTarget = .binaryTarget(
+        name: "automergeFFI",
+        url: "https://github.com/automerge/automerge-swift/releases/download/0.3.0/automergeFFI.xcframework.zip",
+        checksum: "8cf0b680ccbf7f97b8efac3d3defa84a06f3b3869d5c23e4535905d0f9c70e58"
+    )
+}
 
 let package = Package(
     name: "Automerge",

--- a/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
@@ -36,6 +36,7 @@ public struct AutomergeEncoder {
             logLevel: logLevel
         )
         try value.encode(to: encoder)
+        encoder.postencodeCleanup()
     }
 
     public func encode<T: Encodable>(_ value: T, at path: [CodingKey]) throws {
@@ -48,5 +49,6 @@ public struct AutomergeEncoder {
             logLevel: logLevel
         )
         try value.encode(to: encoder)
+        encoder.postencodeCleanup()
     }
 }

--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -292,18 +292,6 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         // can set this "newPath", we don't have the deets to create (if needed) a new objectId until we
         // initialize a specific container type.
 
-        let newEncoder = AutomergeEncoderImpl(
-            userInfo: impl.userInfo,
-            codingPath: newPath,
-            doc: document,
-            strategy: impl.schemaStrategy,
-            cautiousWrite: impl.cautiousWrite,
-            logLevel: impl.reportingLogLevel
-        )
-        // Create a link from the current AutomergeEncoderImpl to the child, which
-        // will be referenced from future containers and updated with status.
-        impl.childEncoders.append(newEncoder)
-
         switch T.self {
         case is Date.Type:
             // Capture and override the default encodable pathing for Date since
@@ -364,6 +352,18 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             }
             impl.mapKeysWritten.append(key.stringValue)
         default:
+            let newEncoder = AutomergeEncoderImpl(
+                userInfo: impl.userInfo,
+                codingPath: newPath,
+                doc: document,
+                strategy: impl.schemaStrategy,
+                cautiousWrite: impl.cautiousWrite,
+                logLevel: impl.reportingLogLevel
+            )
+            // Create a link from the current AutomergeEncoderImpl to the child, which
+            // will be referenced from future containers and updated with status.
+            impl.childEncoders.append(newEncoder)
+
             try value.encode(to: newEncoder)
             impl.mapKeysWritten.append(key.stringValue)
         }

--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -52,6 +52,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
         ) {
         case let .success(objId):
             objectId = objId
+            impl.objectIdForContainer = objId
             lookupError = nil
         case let .failure(capturedError):
             objectId = nil
@@ -100,6 +101,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             throw reportBestError()
         }
         try document.put(obj: objectId, key: key.stringValue, value: .Null)
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Bool, forKey key: Self.Key) throws {
@@ -110,6 +112,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bool)
         }
         try document.put(obj: objectId, key: key.stringValue, value: .Boolean(value))
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: String, forKey key: Self.Key) throws {
@@ -120,6 +123,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .string)
         }
         try document.put(obj: objectId, key: key.stringValue, value: .String(value))
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Double, forKey key: Self.Key) throws {
@@ -136,6 +140,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Float, forKey key: Self.Key) throws {
@@ -152,6 +157,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .double)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Int, forKey key: Self.Key) throws {
@@ -162,6 +168,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Int8, forKey key: Self.Key) throws {
@@ -172,6 +179,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Int16, forKey key: Self.Key) throws {
@@ -182,6 +190,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Int32, forKey key: Self.Key) throws {
@@ -192,6 +201,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: Int64, forKey key: Self.Key) throws {
@@ -202,6 +212,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .int)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: UInt, forKey key: Self.Key) throws {
@@ -212,6 +223,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: UInt8, forKey key: Self.Key) throws {
@@ -222,6 +234,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: UInt16, forKey key: Self.Key) throws {
@@ -232,6 +245,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: UInt32, forKey key: Self.Key) throws {
@@ -242,6 +256,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode(_ value: UInt64, forKey key: Self.Key) throws {
@@ -252,6 +267,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
             try checkTypeMatch(value: value, objectId: objectId, key: key, type: .uint)
         }
         try document.put(obj: objectId, key: key.stringValue, value: value.toScalarValue())
+        impl.mapKeysWritten.append(key.stringValue)
     }
 
     mutating func encode<T: Encodable>(_ value: T, forKey key: Self.Key) throws {
@@ -297,6 +313,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 try checkTypeMatch(value: value, objectId: objectId, key: key, type: .timestamp)
             }
             try document.put(obj: objectId, key: key.stringValue, value: downcastDate.toScalarValue())
+            impl.mapKeysWritten.append(key.stringValue)
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
             // Automerge supports it as a primitive value type.
@@ -305,6 +322,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 try checkTypeMatch(value: value, objectId: objectId, key: key, type: .bytes)
             }
             try document.put(obj: objectId, key: key.stringValue, value: downcastData.toScalarValue())
+            impl.mapKeysWritten.append(key.stringValue)
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
@@ -313,6 +331,7 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                 try checkTypeMatch(value: value, objectId: objectId, key: key, type: .counter)
             }
             try document.put(obj: objectId, key: key.stringValue, value: downcastCounter.toScalarValue())
+            impl.mapKeysWritten.append(key.stringValue)
         case is AutomergeText.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
@@ -343,8 +362,10 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                     try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
                 }
             }
+            impl.mapKeysWritten.append(key.stringValue)
         default:
             try value.encode(to: newEncoder)
+            impl.mapKeysWritten.append(key.stringValue)
         }
     }
 

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -26,6 +26,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
         case let .success(objId):
             if let lastCodingKey = codingPath.last {
                 objectId = objId
+                impl.objectIdForContainer = objId
                 codingkey = AnyCodingKey(lastCodingKey)
                 lookupError = nil
             } else {

--- a/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -65,18 +65,6 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         guard let objectId = objectId else {
             throw reportBestError()
         }
-        let newPath = impl.codingPath + [AnyCodingKey(UInt64(count))]
-        let newEncoder = AutomergeEncoderImpl(
-            userInfo: impl.userInfo,
-            codingPath: newPath,
-            doc: document,
-            strategy: impl.schemaStrategy,
-            cautiousWrite: impl.cautiousWrite,
-            logLevel: impl.reportingLogLevel
-        )
-        // Create a link from the current AutomergeEncoderImpl to the child, which
-        // will be referenced from future containers and updated with status.
-        impl.childEncoders.append(newEncoder)
 
         switch T.self {
         case is Date.Type:
@@ -172,6 +160,19 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             }
             impl.highestUnkeyedIndexWritten = UInt64(count)
         default:
+            let newPath = impl.codingPath + [AnyCodingKey(UInt64(count))]
+            let newEncoder = AutomergeEncoderImpl(
+                userInfo: impl.userInfo,
+                codingPath: newPath,
+                doc: document,
+                strategy: impl.schemaStrategy,
+                cautiousWrite: impl.cautiousWrite,
+                logLevel: impl.reportingLogLevel
+            )
+            // Create a link from the current AutomergeEncoderImpl to the child, which
+            // will be referenced from future containers and updated with status.
+            impl.childEncoders.append(newEncoder)
+
             try value.encode(to: newEncoder)
             impl.highestUnkeyedIndexWritten = UInt64(count)
         }

--- a/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -27,6 +27,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         ) {
         case let .success(objId):
             objectId = objId
+            impl.objectIdForContainer = objId
             lookupError = nil
         case let .failure(capturedError):
             objectId = nil
@@ -97,6 +98,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                 )
             }
             try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+            impl.highestUnkeyedIndexWritten = UInt64(count)
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
             // Automerge supports it as a primitive value type.
@@ -117,6 +119,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
             }
 
             try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+            impl.highestUnkeyedIndexWritten = UInt64(count)
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
@@ -136,6 +139,7 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                 )
             }
             try document.insert(obj: objectId, index: UInt64(count), value: valueToWrite)
+            impl.highestUnkeyedIndexWritten = UInt64(count)
         case is AutomergeText.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
@@ -166,8 +170,10 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                     try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
                 }
             }
+            impl.highestUnkeyedIndexWritten = UInt64(count)
         default:
             try value.encode(to: newEncoder)
+            impl.highestUnkeyedIndexWritten = UInt64(count)
         }
         count += 1
     }

--- a/Tests/AutomergeTests/CodableTests/AutomergeArrayEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeArrayEncodeDecodeTests.swift
@@ -1,0 +1,39 @@
+import Automerge
+import XCTest
+
+final class AutomergeArrayEncodeDecodeTests: XCTestCase {
+    var doc: Document!
+    var setupCache: [String: ObjId] = [:]
+
+    override func setUp() {
+        setupCache = [:]
+        doc = Document()
+    }
+
+    func testSimpleKeyDecode() throws {
+        // illustrates https://github.com/automerge/automerge-swift/issues/54
+        
+        struct StructWithArray: Codable, Equatable {
+            var names: [String] = []
+        }
+        
+        let encoder = AutomergeEncoder(doc: doc)
+        let decoder = AutomergeDecoder(doc: doc)
+        var sample = StructWithArray()
+        sample.names.append("one")
+        sample.names.append("two")
+        
+        try encoder.encode(sample)
+        let replica = try decoder.decode(StructWithArray.self)
+        XCTAssertEqual(replica, sample)
+        
+        _ = sample.names.popLast()
+        try encoder.encode(sample)
+        let secondReplica = try decoder.decode(StructWithArray.self)
+        XCTAssertEqual(secondReplica, sample)
+        // XCTAssertEqual failed:
+        // ("StructWithArray(names: ["one", "one", "two"])") is not equal to
+        // ("StructWithArray(names: ["one"])")
+    }
+
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeArrayEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeArrayEncodeDecodeTests.swift
@@ -10,23 +10,23 @@ final class AutomergeArrayEncodeDecodeTests: XCTestCase {
         doc = Document()
     }
 
-    func testSimpleKeyDecode() throws {
+    func testArrayShrinkingEncode() throws {
         // illustrates https://github.com/automerge/automerge-swift/issues/54
-        
+
         struct StructWithArray: Codable, Equatable {
             var names: [String] = []
         }
-        
+
         let encoder = AutomergeEncoder(doc: doc)
         let decoder = AutomergeDecoder(doc: doc)
         var sample = StructWithArray()
         sample.names.append("one")
         sample.names.append("two")
-        
+
         try encoder.encode(sample)
         let replica = try decoder.decode(StructWithArray.self)
         XCTAssertEqual(replica, sample)
-        
+
         _ = sample.names.popLast()
         try encoder.encode(sample)
         let secondReplica = try decoder.decode(StructWithArray.self)
@@ -35,5 +35,4 @@ final class AutomergeArrayEncodeDecodeTests: XCTestCase {
         // ("StructWithArray(names: ["one", "one", "two"])") is not equal to
         // ("StructWithArray(names: ["one"])")
     }
-
 }

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
@@ -479,12 +479,15 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
                 }
                 XCTAssertNotNil(encoderImpl.highestUnkeyedIndexWritten)
                 XCTAssertTrue(encoderImpl.mapKeysWritten.isEmpty)
+                XCTAssertNotNil(encoderImpl.objectIdForContainer)
             case .some(.Key):
                 if shouldPrint { print("\(prefix)KEY ---> \(compactCodingPath) keys: \(encoderImpl.mapKeysWritten)") }
                 XCTAssertNil(encoderImpl.highestUnkeyedIndexWritten)
                 XCTAssertFalse(encoderImpl.mapKeysWritten.isEmpty)
+                XCTAssertNotNil(encoderImpl.objectIdForContainer)
             case .some(.Value):
                 if shouldPrint { print("\(prefix)VALUE -> \(compactCodingPath)") }
+                XCTAssertNotNil(encoderImpl.objectIdForContainer)
             }
             for child in encoderImpl.childEncoders {
                 walk(encoderImpl: child, indent: indent + 1, shouldPrint: shouldPrint)

--- a/Tests/AutomergeTests/InteropTests.swift
+++ b/Tests/AutomergeTests/InteropTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @available(macOS 12, *)
 class InteropTests: XCTestCase {
     var markdownData: Data? = nil
-    
+
     // DEVNOTE(heckj): Bundle based approaches for finding fixture files
     // work reasonably well with regular targets, but fail (or more specifically,
     // don't work as the docs assert) with resources embedded in test targets.
@@ -49,7 +49,7 @@ class InteropTests: XCTestCase {
         // print(fancy) // A basic print() provides a loose idea of runs within the multi-line output.
         let enc = JSONEncoder()
         let jsonencode = try enc.encode(fancy)
-        print(String(bytes: jsonencode, encoding: .utf8))
+        print(String(bytes: jsonencode, encoding: .utf8) as Any)
         // custom encoders built in to foundation:
         // fancy.encode(to: Encoder, configuration: AttributeScopeCodableConfiguration)
         // see: https://developer.apple.com/documentation/foundation/decodableattributedstringkey
@@ -59,7 +59,7 @@ class InteropTests: XCTestCase {
         // https://developer.apple.com/documentation/foundation/inlinepresentationintent includes
         // code, emphasis, line-break, strike-through, strong, etc.
     }
-    
+
     func testDescribeExistingPresentationIntents() throws {
         let foundation_presentation_types = [
             PresentationIntent.Kind.blockQuote,
@@ -68,12 +68,14 @@ class InteropTests: XCTestCase {
             PresentationIntent.Kind.listItem(ordinal: 1),
             PresentationIntent.Kind.orderedList,
             PresentationIntent.Kind.paragraph,
-            PresentationIntent.Kind.table(columns:
+            PresentationIntent.Kind.table(
+                columns:
                 [
-                PresentationIntent.TableColumn(alignment: .left),
-                PresentationIntent.TableColumn(alignment: .center),
-                PresentationIntent.TableColumn(alignment: .right)
-                ]),
+                    PresentationIntent.TableColumn(alignment: .left),
+                    PresentationIntent.TableColumn(alignment: .center),
+                    PresentationIntent.TableColumn(alignment: .right),
+                ]
+            ),
             PresentationIntent.Kind.tableCell(columnIndex: 1),
             PresentationIntent.Kind.tableHeaderRow,
             PresentationIntent.Kind.tableRow(rowIndex: 1),
@@ -85,23 +87,21 @@ class InteropTests: XCTestCase {
             let encoded = try encoder.encode(type)
             print("type: \(type.debugDescription) JSONencoded: \(String(data: encoded, encoding: .utf8) ?? "??")")
         }
-        
-        
+
         let inline_intents = [
             "blockHTML":
-            InlinePresentationIntent.blockHTML,
-            "code":InlinePresentationIntent.code,
-            "emphasized":InlinePresentationIntent.emphasized,
-            "inlineHTML":InlinePresentationIntent.inlineHTML,
-            "lineBreak":InlinePresentationIntent.lineBreak,
-            "softBreak":InlinePresentationIntent.softBreak,
-            "strikethrough":InlinePresentationIntent.strikethrough,
-            "stronglyEmphasized":InlinePresentationIntent.stronglyEmphasized
-            ]
+                InlinePresentationIntent.blockHTML,
+            "code": InlinePresentationIntent.code,
+            "emphasized": InlinePresentationIntent.emphasized,
+            "inlineHTML": InlinePresentationIntent.inlineHTML,
+            "lineBreak": InlinePresentationIntent.lineBreak,
+            "softBreak": InlinePresentationIntent.softBreak,
+            "strikethrough": InlinePresentationIntent.strikethrough,
+            "stronglyEmphasized": InlinePresentationIntent.stronglyEmphasized,
+        ]
         print("Inline Presentation Types")
         for (name, type) in inline_intents {
             print("type: \(name) rawValue: \(type.rawValue)")
         }
-
     }
 }


### PR DESCRIPTION
Resolves #54

Captures the encoding tree as the encoder works between local code and synthesized or provided Codable implementations for types, capturing the details of what containers were written - max index positions and keys written/updated. Post-encode walks that tree and removes any extra values - which allows for keys to be removed from maps, and arrays to shrink to encoded positions.