### PR TITLE
Text as a reference type instead of a value type for performance of updates

### DIFF
--- a/Sources/Automerge/Codable/AutomergeText.swift
+++ b/Sources/Automerge/Codable/AutomergeText.swift
@@ -1,24 +1,196 @@
+import Combine
 import Foundation
+import struct SwiftUI.Binding
 
-/// A type that presents a string backed by a Sequential CRDT
-public struct AutomergeText: Hashable, Codable {
-    public var value: String
+// NOTE(heckj): The version Automerge after 2.0 is adding support for "marks"
+// that apply to runs of text within the .Text primitive. This should map
+// reasonably well to AttributedStrings. When it's merged, this type
+// should be a reasonable placeholder from which to derive `AttributedString` and
+// the flat `String` variations from the underlying data source in Automerge.
 
-    // NOTE(heckj): The version Automerge after 2.0 is adding support for "marks"
-    // that apply to runs of text within the .Text primitive. This should map
-    // reasonably well to AttributedStrings. When it's merged, this type
-    // should be a reasonable placeholder from which to derive `AttributedString` and
-    // the flat `String` variations from the underlying data source in Automerge.
+/// A reference to a Text object within an Automerge document.
+public final class AutomergeText: ObservableObject, Codable {
+    var doc: Document?
+    var objId: ObjId?
+    var _unboundStorage: String
 
-    /// Creates a new Text instance with the string value you provide.
-    /// - Parameter value: The value for the text.
-    public init(_ value: String) {
-        self.value = value
+    // MARK: Initializers and Bind
+
+    /// Creates a new, unbound text reference instance.
+    /// - Parameter initialValue: An initial string value for the text reference.
+    public init(_ initialValue: String = "") {
+        _unboundStorage = initialValue
+    }
+
+    /// Creates a new text reference instance bound within an Automerge document.
+    /// - Parameters:
+    ///   - doc: The Automerge document associated with this reference.
+    ///   - path: A string path that represents a `Text` container within the Automerge document.
+    ///   - initialValue: An initial string value for the text reference.
+    public convenience init(_ initialValue: String = "", doc: Document, path: String) throws {
+        self.init(initialValue)
+        try bind(doc: doc, path: path)
+    }
+
+    /// Binds a text reference instance info an Automerge document.
+    ///
+    /// If the instance has an initial value other than an empty string, binding update the string within the Automerge
+    /// document.
+    /// - Parameters:
+    ///   - doc: The Automerge document associated with this reference.
+    ///   - path: A string path that represents a `Text` container within the Automerge document.
+    public func bind(doc: Document, path: String) throws {
+        guard let objId = try doc.lookupPath(path: path) else {
+            throw BindingError.InvalidPath(path)
+        }
+        if doc.objectType(obj: objId) == .Text {
+            self.doc = doc
+            self.objId = objId
+        } else {
+            throw BindingError.NotText
+        }
+        if !_unboundStorage.isEmpty {
+            try updateText(newText: _unboundStorage)
+            _unboundStorage = ""
+        }
+    }
+
+    // MARK: Exposing String value and Binding<String>
+
+    /// The string value of the text reference in an Automerge document.
+    public var value: String {
+        get {
+            guard let doc, let objId else {
+                return _unboundStorage
+            }
+            do {
+                return try doc.text(obj: objId)
+            } catch {
+                fatalError("Error attempting to read text value from objectId \(objId): \(error)")
+            }
+        }
+        set {
+            guard let objId, doc != nil else {
+                _unboundStorage = newValue
+                return
+            }
+            do {
+                try updateText(newText: newValue)
+            } catch {
+                fatalError("Error attempting to write '\(newValue)' to objectId \(objId): \(error)")
+            }
+        }
+    }
+
+    /// Returns a binding to the string value of a text object within an Automerge document.
+    public func textBinding() -> Binding<String> {
+        Binding(
+            get: { () -> String in
+                guard let doc = self.doc, let objId = self.objId else {
+                    return self._unboundStorage
+                }
+                do {
+                    return try doc.text(obj: objId)
+                } catch {
+                    fatalError("Error attempting to read text value from objectId \(objId): \(error)")
+                }
+            },
+            set: { (newValue: String) in
+                guard let objId = self.objId, self.doc != nil else {
+                    self._unboundStorage = newValue
+                    return
+                }
+                do {
+                    try self.updateText(newText: newValue)
+                } catch {
+                    fatalError("Error attempting to write '\(newValue)' to objectId \(objId): \(error)")
+                }
+            }
+        )
+    }
+
+    private func updateText(newText: String) throws {
+        guard let objId, let doc else {
+            throw BindingError.Unbound
+        }
+        let current = try! doc.text(obj: objId).utf8
+        let diff: CollectionDifference<String.UTF8View.Element> = newText.utf8.difference(from: current)
+        var updated = false
+        for change in diff {
+            updated = true
+            switch change {
+            case let .insert(offset, element, _):
+                let index = offset
+                let char = String(bytes: [element], encoding: .utf8)
+                try! doc.spliceText(obj: objId, start: UInt64(index), delete: 0, value: char)
+            case let .remove(offset, _, _):
+                let index = offset
+                try! doc.spliceText(obj: objId, start: UInt64(index), delete: 1)
+            }
+        }
+        if updated {
+            objectWillChange.send()
+        }
+    }
+
+    // MARK: Codable conformance
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(value, forKey: .value)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        _unboundStorage = try container.decode(String.self, forKey: .value)
+    }
+}
+
+extension AutomergeText: Equatable {
+    public static func == (lhs: AutomergeText, rhs: AutomergeText) -> Bool {
+        lhs.objId == rhs.objId
+    }
+}
+
+extension AutomergeText: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(objId)
+        hasher.combine(_unboundStorage)
     }
 }
 
 extension AutomergeText: CustomStringConvertible {
     public var description: String {
         value
+    }
+}
+
+/// Binding errors
+public enum BindingError: LocalizedError, Equatable {
+    public static func == (lhs: BindingError, rhs: BindingError) -> Bool {
+        lhs.errorDescription == rhs.errorDescription
+    }
+
+    /// The path provided was invalid to bind into the Automerge document.
+    case InvalidPath(String)
+    /// The Automerge object at the path provided was not a Text object.
+    case NotText
+    /// The instance is not bound to an Automerge Document.
+    case Unbound
+
+    /// A localized message describing the error.
+    public var errorDescription: String? {
+        switch self {
+        case let .InvalidPath(path):
+            return "Attempted to bind to an invalid path within the Automerge document: \(path)"
+        case .NotText:
+            return "Path location was not an Automerge Text object."
+        case .Unbound:
+            return "The object does not yet reference an Automerge Text object."
+        }
     }
 }

--- a/Sources/Automerge/Codable/AutomergeText.swift
+++ b/Sources/Automerge/Codable/AutomergeText.swift
@@ -32,6 +32,16 @@ public final class AutomergeText: ObservableObject, Codable {
         try bind(doc: doc, path: path)
     }
 
+    public convenience init(doc: Document, objId: ObjId) throws {
+        self.init()
+        if doc.objectType(obj: objId) == .Text {
+            self.doc = doc
+            self.objId = objId
+        } else {
+            throw BindingError.NotText
+        }
+    }
+
     /// Binds a text reference instance info an Automerge document.
     ///
     /// If the instance has an initial value other than an empty string, binding update the string within the Automerge
@@ -152,7 +162,11 @@ public final class AutomergeText: ObservableObject, Codable {
 
 extension AutomergeText: Equatable {
     public static func == (lhs: AutomergeText, rhs: AutomergeText) -> Bool {
-        lhs.objId == rhs.objId
+        if lhs.objId != nil, rhs.objId != nil {
+            return lhs.objId == rhs.objId
+        } else {
+            return lhs.value == rhs.value
+        }
     }
 }
 

--- a/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
@@ -151,8 +151,8 @@ struct AutomergeKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProt
         case is AutomergeText.Type:
             let retrievedValue = try getValue(forKey: key)
             if case let Value.Object(objectId, .Text) = retrievedValue {
-                let stringValue = try impl.doc.text(obj: objectId)
-                return AutomergeText(stringValue) as! T
+                let reference = try AutomergeText(doc: impl.doc, objId: objectId)
+                return reference as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
@@ -166,8 +166,9 @@ struct AutomergeSingleValueDecodingContainer: SingleValueDecodingContainer {
                 ))
             }
         case is AutomergeText.Type:
-            if case let .Scalar(.String(stringValue)) = value {
-                return AutomergeText(stringValue) as! T
+            if case .Scalar(.String(_)) = value {
+                let reference = try AutomergeText(doc: impl.doc, objId: objectId)
+                return reference as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
@@ -155,9 +155,9 @@ struct AutomergeUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         case is AutomergeText.Type:
             let retrievedValue = try getNextValue(ofType: AutomergeText.self)
             if case let Value.Object(objectId, .Text) = retrievedValue {
-                let stringValue = try impl.doc.text(obj: objectId)
                 currentIndex += 1
-                return AutomergeText(stringValue) as! T
+                let reference = try AutomergeText(doc: impl.doc, objId: objectId)
+                return reference as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -286,7 +286,8 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                         "No coding key was found from looking up path \(codingPath) when encoding \(type(of: T.self))."
                     )
             }
-            // Capture and override the default encodable pathing for Counter since
+
+            // Capture and override the default encodable pathing for AutomergeText since
             // Automerge supports it as a primitive value type.
             let downcastText = value as! AutomergeText
 
@@ -303,7 +304,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                 guard case let .Object(textId, .Text) = existingNode else {
                     throw CodingKeyLookupError
                         .MismatchedSchema(
-                            "Text Encoding on KeyedContainer at \(codingPath) exists and is \(existingNode), not Text."
+                            "Text object at \(codingPath) exists and is \(existingNode), not Text."
                         )
                 }
                 textNodeId = textId
@@ -316,19 +317,29 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                 }
             }
 
-            // Iterate through
-            let currentText = try! document.text(obj: textNodeId).utf8
-            let diff: CollectionDifference<String.UTF8View.Element> = downcastText.value.utf8
-                .difference(from: currentText)
-            for change in diff {
-                switch change {
-                case let .insert(offset, element, _):
-                    let char = String(bytes: [element], encoding: .utf8)
-                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
-                case let .remove(offset, _, _):
-                    try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
+            // AutomergeText is a reference type that, when bound, writes directly into the
+            // Automerge document, so no additional work is needed to write in the data unless
+            // the object is 'unbound' (for example, a new AutomergeText instance)
+            if downcastText.doc == nil || downcastText.objId == nil {
+                // instance is an unbound instance - implying a new reference into the Automerge
+                // document. Attempt to serialize the unboundStorage into place.
+                if !downcastText._unboundStorage.isEmpty {
+                    // Iterate through
+                    let currentText = try! document.text(obj: textNodeId).utf8
+                    let diff: CollectionDifference<String.UTF8View.Element> = downcastText._unboundStorage.utf8
+                        .difference(from: currentText)
+                    for change in diff {
+                        switch change {
+                        case let .insert(offset, element, _):
+                            let char = String(bytes: [element], encoding: .utf8)
+                            try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 0, value: char)
+                        case let .remove(offset, _, _):
+                            try document.spliceText(obj: textNodeId, start: UInt64(offset), delete: 1)
+                        }
+                    }
                 }
             }
+            impl.singleValueWritten = true
         default:
             try value.encode(to: impl)
             impl.singleValueWritten = true


### PR DESCRIPTION
Converts the type AutomergeText from a placeholder value type into a reference type. When initialized empty, it acts the same as AutomergeText (with the exception of being a reference type, of course) - and when bound to an Automerge document, it attempts to write any initial value into place, and otherwise provides an ObservableObject that can also vend a SwiftUI Binding<String> to update fields without having to incur a structural rebuild with a full decode cycle.

In short, it's an optimization for displaying Text through to a SwiftUI app.