### PR TITLE
another slight (but significant) error fixed

### DIFF
--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -358,8 +358,8 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                         }
                     }
                 }
-                impl.mapKeysWritten.append(key.stringValue)
             }
+            impl.mapKeysWritten.append(key.stringValue)
         default:
             let newEncoder = AutomergeEncoderImpl(
                 userInfo: impl.userInfo,

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -185,6 +185,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                 }
                 try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
+            impl.singleValueWritten = true
         case is Data.Type:
             // Capture and override the default encodable pathing for Data since
             // Automerge supports it as a primitive value type.
@@ -233,6 +234,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
 
                 try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
+            impl.singleValueWritten = true
         case is Counter.Type:
             // Capture and override the default encodable pathing for Counter since
             // Automerge supports it as a primitive value type.
@@ -279,6 +281,7 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                 }
                 try document.put(obj: objectId, key: codingkey.stringValue, value: valueToWrite)
             }
+            impl.singleValueWritten = true
         case is AutomergeText.Type:
             guard let codingkey = codingkey else {
                 throw CodingKeyLookupError

--- a/Tests/AutomergeTests/CodableTests/AutomergeTextEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTextEncodeDecodeTests.swift
@@ -50,6 +50,26 @@ final class EncodeDecodeBugTests: XCTestCase {
         XCTAssertEqual(collectionAddedDecodeCheck.notes[0].discussion.value, "hello world")
         XCTAssertTrue(collectionAddedDecodeCheck.notes[0].discussion.isBound)
         XCTAssertTrue(collectionAddedDecodeCheck.notes[1].discussion.isBound)
+
+        // second encode - no change, verify it's all still there
+        let serialized = doc.save()
+
+        let newDoc = try Document(serialized)
+        let newDecoder = AutomergeDecoder(doc: newDoc)
+        var secondEncodeCheck = try newDecoder.decode(NoteCollection.self)
+        XCTAssertNotNil(secondEncodeCheck)
+        XCTAssertEqual(secondEncodeCheck.notes.count, 2)
+        XCTAssertEqual(secondEncodeCheck.notes[0].title, "one")
+        XCTAssertEqual(secondEncodeCheck.notes[0].discussion.value, "hello world")
+        XCTAssertTrue(secondEncodeCheck.notes[0].discussion.isBound)
+        XCTAssertTrue(secondEncodeCheck.notes[1].discussion.isBound)
+
+        secondEncodeCheck.notes[1].title = "fred"
+        secondEncodeCheck.notes[1].discussion.value = "new info here"
+        let newEncoder = AutomergeEncoder(doc: newDoc)
+        try newEncoder.encode(secondEncodeCheck)
+
+        let _ = try newDecoder.decode(NoteCollection.self)
     }
 
     func testNestedRawTextEncodeDecode() throws {
@@ -75,5 +95,15 @@ final class EncodeDecodeBugTests: XCTestCase {
         XCTAssertTrue(collectionAddedDecodeCheck.notes[0].isBound)
         XCTAssertEqual(collectionAddedDecodeCheck.notes[1].value, "")
         XCTAssertTrue(collectionAddedDecodeCheck.notes[1].isBound)
+
+        // second encode - no change, verify it's all still there
+        try encoder.encode(collection)
+        let secondEncodeCheck = try decoder.decode(RawNoteCollection.self)
+        XCTAssertNotNil(secondEncodeCheck)
+        XCTAssertEqual(secondEncodeCheck.notes.count, 2)
+        XCTAssertEqual(secondEncodeCheck.notes[0].value, "hello world")
+        XCTAssertTrue(secondEncodeCheck.notes[0].isBound)
+        XCTAssertEqual(secondEncodeCheck.notes[1].value, "")
+        XCTAssertTrue(secondEncodeCheck.notes[1].isBound)
     }
 }


### PR DESCRIPTION
Second encode when there weren't any changes would remove AutomergeText from the document as though it wasn't used and had been deleted. This verifies the issues and resolves it.