### PR TITLE
Cursor main

### DIFF
--- a/AutomergeUniffi/automergeFFI.h
+++ b/AutomergeUniffi/automergeFFI.h
@@ -191,6 +191,14 @@ void uniffi_automerge_fn_method_doc_apply_encoded_changes(void*_Nonnull ptr, Rus
 );
 RustBuffer uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(void*_Nonnull ptr, RustBuffer changes, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_automerge_fn_method_doc_cursor(void*_Nonnull ptr, RustBuffer obj, uint64_t position, RustCallStatus *_Nonnull out_status
+);
+RustBuffer uniffi_automerge_fn_method_doc_cursor_at(void*_Nonnull ptr, RustBuffer obj, uint64_t position, RustBuffer heads, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_automerge_fn_method_doc_cursor_position(void*_Nonnull ptr, RustBuffer obj, RustBuffer cursor, RustCallStatus *_Nonnull out_status
+);
+uint64_t uniffi_automerge_fn_method_doc_cursor_position_at(void*_Nonnull ptr, RustBuffer obj, RustBuffer cursor, RustBuffer heads, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_automerge_fn_func_root(RustCallStatus *_Nonnull out_status
     
 );
@@ -365,6 +373,18 @@ uint16_t uniffi_automerge_checksum_method_doc_apply_encoded_changes(void
     
 );
 uint16_t uniffi_automerge_checksum_method_doc_apply_encoded_changes_with_patches(void
+    
+);
+uint16_t uniffi_automerge_checksum_method_doc_cursor(void
+    
+);
+uint16_t uniffi_automerge_checksum_method_doc_cursor_at(void
+    
+);
+uint16_t uniffi_automerge_checksum_method_doc_cursor_position(void
+    
+);
+uint16_t uniffi_automerge_checksum_method_doc_cursor_position_at(void
     
 );
 uint16_t uniffi_automerge_checksum_constructor_syncstate_new(void

--- a/Sources/Automerge/Cursor.swift
+++ b/Sources/Automerge/Cursor.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mateusz Lapsa-Malawski on 09/08/2023.
+//
+
+import Foundation
+
+public struct Cursor: Equatable, Hashable, Sendable {
+    internal var bytes: [UInt8]
+}
+
+extension Cursor: CustomStringConvertible {
+    public var description: String {
+        bytes.map { Swift.String(format: "%02hhx", $0) }.joined().uppercased()
+    }
+}

--- a/Sources/Automerge/Cursor.swift
+++ b/Sources/Automerge/Cursor.swift
@@ -1,17 +1,18 @@
-//
-//  File.swift
-//  
-//
-//  Created by Mateusz Lapsa-Malawski on 09/08/2023.
-//
-
 import Foundation
 
+/// A opaque type that represents a location within an array or text object that adjusts with insertions and deletes to
+/// maintain its relative position.
+///
+/// Set a cursor using ``Document/cursor(obj:position:)``, or ``Document/cursorAt(obj:position:heads:)`` to place a
+/// cursor at a previous point in time.
+/// Retrieve the cursor position from the document using ``Document/cursorPosition(obj:cursor:)``, or use
+/// ``Document/cursorPositionAt(obj:cursor:heads:)`` to get the cursor position at a previous point in time.
 public struct Cursor: Equatable, Hashable, Sendable {
-    internal var bytes: [UInt8]
+    var bytes: [UInt8]
 }
 
 extension Cursor: CustomStringConvertible {
+    /// The bytes that describe the cursor.
     public var description: String {
         bytes.map { Swift.String(format: "%02hhx", $0) }.joined().uppercased()
     }

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -322,6 +322,38 @@ public class Document: @unchecked Sendable {
             try self.doc.wrapErrors { try $0.textAt(obj: obj.bytes, heads: heads.map(\.bytes)) }
         }
     }
+    
+    /// Get the `cursor` structure for a specific `position` in text object `obj`
+    public func cursor(obj: ObjId, position: UInt64) throws -> Cursor {
+        try queue.sync {
+            Cursor(bytes: try self.doc.wrapErrors { try $0.cursor(obj: obj.bytes, position: position)})
+        }
+    }
+
+    /// Get the `cursor` structure for a specific `position` in text object `obj` at `heads`
+    public func cursorAt(obj: ObjId, position: UInt64, heads: Set<ChangeHash>) throws -> Cursor {
+        try queue.sync {
+            Cursor(bytes: try self.doc.wrapErrors { try $0.cursorAt(obj: obj.bytes, position: position, heads: heads.map(\.bytes))})
+        }
+    }
+
+    /// Get the UInt64 position for a specific `cursor` in text object `obj`
+    public func cursorPosition(obj: ObjId, cursor: Cursor) throws -> UInt64 {
+        try queue.sync {
+            try self.doc.wrapErrors {
+                try $0.cursorPosition(obj: obj.bytes, cursor: cursor.bytes)
+            }
+        }
+    }
+
+    /// Get the UInt64 position for a specific `cursor` in text object `obj` at `heads`
+    public func cursorPositionAt(obj: ObjId, cursor: Cursor, heads: Set<ChangeHash>) throws -> UInt64 {
+        try queue.sync {
+            try self.doc.wrapErrors {
+                try $0.cursorPositionAt(obj: obj.bytes, cursor: cursor.bytes, heads: heads.map(\.bytes))
+            }
+        }
+    }
 
     /// Splice into the list `obj`
     ///

--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -17,7 +17,7 @@ class TextTestCase: XCTestCase {
         let heads = doc.heads()
 
         let doc2 = doc.fork()
-
+        
         try! doc2.spliceText(obj: text, start: 6, delete: 0, value: "wonderful ")
         try! doc.spliceText(obj: text, start: 0, delete: 5, value: "Greetings")
 
@@ -27,6 +27,28 @@ class TextTestCase: XCTestCase {
         XCTAssertEqual(try! doc.textAt(obj: text, heads: heads), "hello world!")
     }
 
+    func testTextCursor() {
+        let doc = Document()
+        let text = try! doc.putObject(obj: ObjId.ROOT, key: "text", ty: .Text)
+        try! doc.spliceText(obj: text, start: 0, delete: 0, value: "hello world!")
+        
+        let c_hello = try! doc.cursor(obj: text, position: 0)
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_hello), 0)
+
+        let c_world = try! doc.cursor(obj: text, position: 6)
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_world), 6)
+
+        try! doc.spliceText(obj: text, start: 6, delete: 0, value: "wonderful ")
+        XCTAssertEqual(try! doc.text(obj: text), "hello wonderful world!")
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_hello), 0)
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_world), 16)
+
+        try! doc.spliceText(obj: text, start: 0, delete: 5, value: "Greetings")
+        XCTAssertEqual(try! doc.text(obj: text), "Greetings wonderful world!")
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_hello), 9)
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_world), 20)
+    }
+    
     func testRepeatedTextInsertion() throws {
         let characterCollection: [String] =
             "a bcdef ghijk lmnop qrstu vwxyz ABCD EFGHI JKLMN OPQRS TUVWX YZ😀😎🤓⚁ ♛⛺︎🕰️⏰⏲️ ⏱️🧭".map { char in

--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -32,6 +32,8 @@ class TextTestCase: XCTestCase {
         let text = try! doc.putObject(obj: ObjId.ROOT, key: "text", ty: .Text)
         try! doc.spliceText(obj: text, start: 0, delete: 0, value: "hello world!")
         
+        let heads = doc.heads()
+
         let c_hello = try! doc.cursor(obj: text, position: 0)
         XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_hello), 0)
 
@@ -47,6 +49,12 @@ class TextTestCase: XCTestCase {
         XCTAssertEqual(try! doc.text(obj: text), "Greetings wonderful world!")
         XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_hello), 9)
         XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_world), 20)
+        XCTAssertEqual(try! doc.cursorPositionAt(obj: text, cursor: c_world, heads: heads), 6)
+
+        // let's time travel with cursor
+        let c_heads_world = try! doc.cursorAt(obj: text, position: 6, heads: heads)
+        XCTAssertEqual(try! doc.cursorPosition(obj: text, cursor: c_heads_world), 20)
+        XCTAssertEqual(c_heads_world.description, c_world.description)
     }
     
     func testRepeatedTextInsertion() throws {

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -11,6 +11,9 @@ typedef sequence<u8> ChangeHash;
 [Custom]
 typedef sequence<u8> ActorId;
 
+[Custom]
+typedef sequence<u8> Cursor;
+
 [Enum]
 interface ScalarValue {
     Bytes( sequence<u8> value);
@@ -237,5 +240,14 @@ interface Doc {
     void apply_encoded_changes(sequence<u8> changes);
     [Throws=DocError]
     sequence<Patch> apply_encoded_changes_with_patches(sequence<u8> changes);
-};
 
+    [Throws=DocError]
+    Cursor cursor(ObjId obj, u64 position);
+    [Throws=DocError]
+    Cursor cursor_at(ObjId obj, u64 position, sequence<ChangeHash> heads);
+    [Throws=DocError]
+    u64 cursor_position(ObjId obj, Cursor cursor);
+    [Throws=DocError]
+    u64 cursor_position_at(ObjId obj, Cursor cursor, sequence<ChangeHash> heads);
+
+};

--- a/rust/src/cursor.rs
+++ b/rust/src/cursor.rs
@@ -1,0 +1,32 @@
+use super::UniffiCustomTypeConverter;
+use automerge as am;
+
+pub struct Cursor(Vec<u8>);
+
+impl From<Cursor> for am::Cursor {
+    fn from(value: Cursor) -> Self {
+        am::Cursor::try_from(value.0).unwrap()
+    }
+}
+
+impl From<am::Cursor> for Cursor {
+    fn from(value: am::Cursor) -> Self {
+        Cursor(value.to_bytes())
+    }
+}
+
+impl UniffiCustomTypeConverter for Cursor {
+    type Builtin = Vec<u8>;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self(val))
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.0
+    }
+}
+

--- a/rust/src/cursor.rs
+++ b/rust/src/cursor.rs
@@ -29,4 +29,3 @@ impl UniffiCustomTypeConverter for Cursor {
         obj.0
     }
 }
-

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -7,7 +7,7 @@ use automerge::{transaction::Transactable, ReadDoc};
 use crate::actor_id::ActorId;
 use crate::mark::{ExpandMark, Mark};
 use crate::patches::Patch;
-use crate::{ChangeHash, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value};
+use crate::{ChangeHash, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value, Cursor};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocError {
@@ -331,6 +331,38 @@ impl Doc {
         let obj = am::ObjId::from(obj);
         let doc = self.0.read().unwrap();
         doc.object_type(obj).unwrap().into()
+    }
+
+    pub fn cursor(&self, obj: ObjId, position: u64) -> Result<Cursor, DocError> {
+        let obj = am::ObjId::from(obj);
+        let doc = self.0.read().unwrap();
+        Ok(doc.get_cursor(obj, position as usize, None)?.into())
+    }
+
+    pub fn cursor_at(&self, obj: ObjId, position: u64, heads: Vec<ChangeHash>) -> Result<Cursor, DocError> {
+        let obj = am::ObjId::from(obj);
+        let doc = self.0.read().unwrap();
+        let heads = heads
+            .into_iter()
+            .map(am::ChangeHash::from)
+            .collect::<Vec<_>>();
+        Ok(doc.get_cursor(obj, position as usize, Some(&heads))?.into())
+    }
+    
+    pub fn cursor_position(&self, obj: ObjId, cursor: Cursor) -> Result<u64, DocError> {
+        let obj = am::ObjId::from(obj);
+        let doc = self.0.read().unwrap();
+        Ok(doc.get_cursor_position(obj, &cursor.into(), None).unwrap() as u64)
+    }
+
+    pub fn cursor_position_at(&self, obj: ObjId, cursor: Cursor, heads: Vec<ChangeHash>) -> Result<u64, DocError> {
+        let obj = am::ObjId::from(obj);
+        let doc = self.0.read().unwrap();
+        let heads = heads
+            .into_iter()
+            .map(am::ChangeHash::from)
+            .collect::<Vec<_>>();
+        Ok(doc.get_cursor_position(obj, &cursor.into(), Some(&heads)).unwrap() as u64)
     }
 
     pub fn text(&self, obj: ObjId) -> Result<String, DocError> {

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -7,7 +7,7 @@ use automerge::{transaction::Transactable, ReadDoc};
 use crate::actor_id::ActorId;
 use crate::mark::{ExpandMark, Mark};
 use crate::patches::Patch;
-use crate::{ChangeHash, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value, Cursor};
+use crate::{ChangeHash, Cursor, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocError {
@@ -339,7 +339,12 @@ impl Doc {
         Ok(doc.get_cursor(obj, position as usize, None)?.into())
     }
 
-    pub fn cursor_at(&self, obj: ObjId, position: u64, heads: Vec<ChangeHash>) -> Result<Cursor, DocError> {
+    pub fn cursor_at(
+        &self,
+        obj: ObjId,
+        position: u64,
+        heads: Vec<ChangeHash>,
+    ) -> Result<Cursor, DocError> {
         let obj = am::ObjId::from(obj);
         let doc = self.0.read().unwrap();
         let heads = heads
@@ -348,21 +353,28 @@ impl Doc {
             .collect::<Vec<_>>();
         Ok(doc.get_cursor(obj, position as usize, Some(&heads))?.into())
     }
-    
+
     pub fn cursor_position(&self, obj: ObjId, cursor: Cursor) -> Result<u64, DocError> {
         let obj = am::ObjId::from(obj);
         let doc = self.0.read().unwrap();
         Ok(doc.get_cursor_position(obj, &cursor.into(), None).unwrap() as u64)
     }
 
-    pub fn cursor_position_at(&self, obj: ObjId, cursor: Cursor, heads: Vec<ChangeHash>) -> Result<u64, DocError> {
+    pub fn cursor_position_at(
+        &self,
+        obj: ObjId,
+        cursor: Cursor,
+        heads: Vec<ChangeHash>,
+    ) -> Result<u64, DocError> {
         let obj = am::ObjId::from(obj);
         let doc = self.0.read().unwrap();
         let heads = heads
             .into_iter()
             .map(am::ChangeHash::from)
             .collect::<Vec<_>>();
-        Ok(doc.get_cursor_position(obj, &cursor.into(), Some(&heads)).unwrap() as u64)
+        Ok(doc
+            .get_cursor_position(obj, &cursor.into(), Some(&heads))
+            .unwrap() as u64)
     }
 
     pub fn text(&self, obj: ObjId) -> Result<String, DocError> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,8 @@ uniffi::include_scaffolding!("automerge");
 
 mod actor_id;
 use actor_id::ActorId;
+mod cursor;
+use cursor::Cursor;
 mod change_hash;
 use change_hash::ChangeHash;
 mod doc;


### PR DESCRIPTION
exposing Cursor

originally opened as #69, this pull request includes the previous commits, adds documentation for Cursor and getting cursor from a document. It also applies `swiftformat` to the swift code, and `cargo fmt` to the rust code.