### PR TITLE
updating to latest released crate of the core Rust library for automerge

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "automerge"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01e49bfe4b5de9f8687a6f7a4a76fbe16270a978e1c4e784eb35f6665e8a4f"
+checksum = "031f1f3a660cb495b55487d7b594b37df7b9f423dd1484fc51af249fa343ed22"
 dependencies = [
  "flate2",
  "fxhash",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ path = "uniffi-bindgen.rs"
 required-features = ["uniffi/cli"]
 
 [dependencies]
-automerge = "0.5.0"
+automerge = "0.5.2"
 thiserror = "1.0.38"
 uniffi = "0.24.1"
 


### PR DESCRIPTION
Automerge 0.5.0 -> 0.5.2

For patch notes, this updates expands the Rust API and fixes a few notable bugs:
- Fix a bug where sync messages were not generated even though sync was not complete
- Fix a bug where adding a mark to the last character in a text string failed to produce a patch