### PR TITLE
partial work to consistently reproduce #82

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ jobs:
           profile: minimal
           toolchain: 1.66.0
           default: true
+      - name: get xcode information
+        run: |
+         xcodebuild -version
+         swift --version
       - name: build xcframework
         run: ./scripts/build-xcframework.sh
       - name: Swift tests

--- a/Tests/AutomergeTests/TestPatches.swift
+++ b/Tests/AutomergeTests/TestPatches.swift
@@ -22,7 +22,13 @@ class PatchesTestCase: XCTestCase {
         )
     }
 
-    func testReceiveSyncMessageWithPatches() {
+    func testPatchesInLoop() {
+        for _ in 1...100 {
+            _testReceiveSyncMessageWithPatches()
+        }
+    }
+    
+    func _testReceiveSyncMessageWithPatches() {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
 

--- a/Tests/AutomergeTests/TestPatches.swift
+++ b/Tests/AutomergeTests/TestPatches.swift
@@ -23,7 +23,8 @@ class PatchesTestCase: XCTestCase {
     }
 
     func testPatchesInLoop() {
-        for _ in 1...100 {
+        for iteration in 1...1000 {
+            print("Checking iteration \(iteration)")
             _testReceiveSyncMessageWithPatches()
         }
     }
@@ -32,6 +33,7 @@ class PatchesTestCase: XCTestCase {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
 
+        // create a second, identical, document
         let doc2 = doc.fork()
 
         // get in sync so that the next message we generate is the one which contains the next change
@@ -39,6 +41,9 @@ class PatchesTestCase: XCTestCase {
         let state2 = SyncState()
 
         sync(doc, state1, doc2, state2)
+        let doc1_serialized = doc.save()
+        let doc2_serialized = doc2.save()
+        XCTAssertEqual(doc1_serialized, doc2_serialized)
 
         try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
         // now generate the message

--- a/Tests/AutomergeTests/TestPatches.swift
+++ b/Tests/AutomergeTests/TestPatches.swift
@@ -1,6 +1,12 @@
 @testable import Automerge
 import XCTest
 
+extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02hhx", $0) }.joined()
+    }
+}
+
 class PatchesTestCase: XCTestCase {
     func testMergeReturningPatches() {
         let doc = Document()
@@ -22,14 +28,7 @@ class PatchesTestCase: XCTestCase {
         )
     }
 
-    func testPatchesInLoop() {
-        for iteration in 1...1000 {
-            print("Checking iteration \(iteration)")
-            _testReceiveSyncMessageWithPatches()
-        }
-    }
-    
-    func _testReceiveSyncMessageWithPatches() {
+    func testReceiveSyncMessageWithPatches() throws {
         let doc = Document()
         try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
 
@@ -45,22 +44,38 @@ class PatchesTestCase: XCTestCase {
         let doc2_serialized = doc2.save()
         XCTAssertEqual(doc1_serialized, doc2_serialized)
 
+        let msg_before_update = doc2.generateSyncMessage(state: state2)
+
         try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
         // now generate the message
-        let msg = doc2.generateSyncMessage(state: state2)!
+        let optional_msg = doc2.generateSyncMessage(state: state2)
+        XCTAssertNotEqual(msg_before_update, optional_msg)
 
-        let patches = try! doc.receiveSyncMessageWithPatches(state: state1, message: msg)
+        // The important thing to verify is that the message isn't nil - which
+        // indicates that there are changes pending. With this single change
+        // scenario, there's a roughly 1:100 chance that the sync message _will not_
+        // include the patches to bring everything up to speed, since it's a probabilistic
+        // scenario (bloom filter under the covers)
+        XCTAssertNotNil(optional_msg)
 
-        // CI Note: noticed a failed test at this point, but can't reproduce locally
-        XCTAssertEqual(
-            patches,
-            [
-                Patch(
-                    action: .Put(ObjId.ROOT, .Key("key2"), .Scalar(.String("value2"))),
-                    path: []
-                ),
-            ]
-        )
+        let msg = try XCTUnwrap(optional_msg)
+        // print("  Sync Msg: \(msg.count) bytes: \(msg.hexEncodedString())")
+
+        let patches = try doc.receiveSyncMessageWithPatches(state: state1, message: msg)
+
+        let within_expected_count_values = (patches.isEmpty || patches.count == 1)
+        XCTAssertTrue(within_expected_count_values)
+        if patches.count == 1 {
+            XCTAssertEqual(
+                patches,
+                [
+                    Patch(
+                        action: .Put(ObjId.ROOT, .Key("key2"), .Scalar(.String("value2"))),
+                        path: []
+                    ),
+                ]
+            )
+        }
     }
 
     func testApplyEncodedChangesWithPatches() {


### PR DESCRIPTION
resolves flaky test - incorrect expectations led to roughly 1% failure rate. Updated expectations and documented the details in the test.

fixes: #82 