### PR TITLE
SplitText operation seems not using UTF-8 encoding

### DIFF
--- a/Tests/AutomergeTests/TestText.swift
+++ b/Tests/AutomergeTests/TestText.swift
@@ -79,4 +79,14 @@ class TextTestCase: XCTestCase {
         // flaky assertion, don't do it :: because length is in UTF-8 codepoints, not!!! grapheme clusters.
         // XCTAssertEqual(stringLength, 5)
     }
+
+    func testEmojiInsertUTF8Length() throws {
+        let emoji = "👨‍👩‍👧"
+        let doc = Automerge.Document()
+        let textId = try doc.putObject(obj: ObjId.ROOT, key: "text", ty: .Text)
+
+        try doc.spliceText(obj: textId, start: 0, delete: 0, value: emoji)
+        let stringLength = doc.length(obj: textId)
+        XCTAssertEqual(stringLength, UInt64(emoji.utf8.count))
+    }
 }


### PR DESCRIPTION
> Maybe I am not consuming the API as it is expected.

Insert a single text `👨‍👩‍👧` into a new Automerge.Document is expected to have a length equal to `👨‍👩‍👧.utf8.count`. But it is retrieving a non-expected length.

After doing some checks I can confirm the next:
- Swift.UTF-8 👨‍👩‍👧 = 18 bytes; received: 5
- Swift.UTF-8 👩‍👩‍👧‍👦 = 25 bytes; received: 7
- Swift.UTF-8 🕰️ = 7 bytes; received: 2