### PR TITLE
adding dictionary tests to illustrate encoding/decoding Dictionaries

### DIFF
--- a/Sources/AutomergeUtilities/Document+schema.swift
+++ b/Sources/AutomergeUtilities/Document+schema.swift
@@ -33,8 +33,9 @@ public extension Document {
     func schema() throws -> AutomergeValue {
         try parseToSchema(self, from: ObjId.ROOT)
     }
-    
-    /// A function to walk an Automerge document from an initial object identifier that you provide, returning the schema below as a tree.
+
+    /// A function to walk an Automerge document from an initial object identifier that you provide, returning the
+    /// schema below as a tree.
     /// - Parameters:
     ///   - doc: The Automerge document to parse.
     ///   - objId: The object identifier at which to start the parse

--- a/Sources/AutomergeUtilities/Document+walk.swift
+++ b/Sources/AutomergeUtilities/Document+walk.swift
@@ -1,7 +1,8 @@
 import Automerge
 
 extension Document {
-    /// A testing function that prints the contents  of an Automerge document with annotations for the type associated with each object and/or value  for the purposes of debugging.
+    /// A testing function that prints the contents  of an Automerge document with annotations for the type associated
+    /// with each object and/or value  for the purposes of debugging.
     public func walk() throws {
         print("{")
         try walk(self, from: ObjId.ROOT)

--- a/Tests/AutomergeTests/CodableTests/AutomergeDictionaryEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDictionaryEncodeDecodeTests.swift
@@ -1,0 +1,48 @@
+import Automerge
+import AutomergeUtilities
+import XCTest
+
+final class AutomergeDictionaryEncodeDecodeTests: XCTestCase {
+    var doc: Document!
+    var setupCache: [String: ObjId] = [:]
+
+    override func setUp() {
+        setupCache = [:]
+        doc = Document()
+    }
+
+    func testFailingDictionaryEncodeDecode() throws {
+        // example of Dictionary with keys other than a string
+
+        struct Wrapper: Codable, Equatable {
+            var exampleDictionary: [Int: String] = [:]
+        }
+
+        let encoder = AutomergeEncoder(doc: doc)
+        let decoder = AutomergeDecoder(doc: doc)
+
+        var wrapper = Wrapper()
+        wrapper.exampleDictionary[1] = "one"
+        wrapper.exampleDictionary[2] = "two"
+
+        XCTExpectFailure("Automerge encoder can't encode keys other than strings.")
+        try encoder.encode(wrapper)
+
+        let replica = try decoder.decode(Wrapper.self)
+        XCTAssertEqual(replica, wrapper)
+    }
+
+    func testEmptyDictionaryEncode() throws {
+        var exampleDictionary: [String: Int] = [:]
+
+        exampleDictionary["one"] = 1
+
+        let encoder = AutomergeEncoder(doc: doc)
+        let decoder = AutomergeDecoder(doc: doc)
+
+        try encoder.encode(exampleDictionary)
+
+        let replica = try decoder.decode([String: Int].self)
+        XCTAssertEqual(replica, exampleDictionary)
+    }
+}


### PR DESCRIPTION
- showing encoding/decoding a raw dictionary into a Document, using Strings as keys
- shows that encoding anything other than string-based keys currently fails (expected failure)