### PR TITLE
Added commitWith() method to specify message/timestamp and exposing changes via changeByHash()

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -506,6 +506,8 @@ public protocol DocProtocol: AnyObject {
 
     func save() -> [UInt8]
 
+    func saveWithOptions(msg: String, time: Int64)  -> [UInt8]
+
     func setActor(actor: ActorId)
 
     func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue]) throws
@@ -521,6 +523,7 @@ public protocol DocProtocol: AnyObject {
     func values(obj: ObjId) throws -> [Value]
 
     func valuesAt(obj: ObjId, heads: [ChangeHash]) throws -> [Value]
+
 }
 
 public class Doc:
@@ -564,6 +567,7 @@ public class Doc:
             )
         })
     }
+
 
     public func actorId() -> ActorId {
         try! FfiConverterTypeActorId.lift(
@@ -1227,6 +1231,19 @@ public class Doc:
                     uniffi_uniffi_automerge_fn_method_doc_save(
                         self.uniffiClonePointer(),
                         $0
+                    )
+                }
+        )
+    }
+
+    public func saveWithOptions(msg: String, time: Int64)  -> [UInt8] {
+        try! FfiConverterSequenceUInt8.lift(
+            try!
+                rustCall {
+                    uniffi_uniffi_automerge_fn_method_doc_save_with_options(
+                        self.uniffiClonePointer(),
+                        FfiConverterString.lower(msg),
+                        FfiConverterInt64.lower(time),$0
                     )
                 }
         )
@@ -2968,6 +2985,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_save() != 20308 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_uniffi_automerge_checksum_method_doc_save_with_options() != 11279 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_set_actor() != 64337 {

--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -420,6 +420,8 @@ public protocol DocProtocol: AnyObject {
 
     func changeByHash(hash: ChangeHash) -> Change?
 
+    func commitWith(msg: String?, time: Int64)
+
     func cursor(obj: ObjId, position: UInt64) throws -> Cursor
 
     func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash]) throws -> Cursor
@@ -507,8 +509,6 @@ public protocol DocProtocol: AnyObject {
     func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws -> [Patch]
 
     func save() -> [UInt8]
-
-    func saveWithOptions(msg: String, time: Int64) -> [UInt8]
 
     func setActor(actor: ActorId)
 
@@ -1238,6 +1238,18 @@ public class Doc:
             }
         )
     }
+    public func commitWith(msg: String?, time: Int64) {
+        try!
+            rustCall {
+                uniffi_uniffi_automerge_fn_method_doc_commit_with(
+                    self.uniffiClonePointer(),
+
+                    FfiConverterOptionString.lower(msg),
+                    FfiConverterInt64.lower(time),
+                    $0
+                )
+        }
+    }
 
     public func save() -> [UInt8] {
         try! FfiConverterSequenceUInt8.lift(
@@ -1246,19 +1258,6 @@ public class Doc:
                     uniffi_uniffi_automerge_fn_method_doc_save(
                         self.uniffiClonePointer(),
                         $0
-                    )
-                }
-        )
-    }
-
-    public func saveWithOptions(msg: String, time: Int64) -> [UInt8] {
-        try! FfiConverterSequenceUInt8.lift(
-            try!
-                rustCall {
-                    uniffi_uniffi_automerge_fn_method_doc_save_with_options(
-                        self.uniffiClonePointer(),
-                        FfiConverterString.lower(msg),
-                        FfiConverterInt64.lower(time),$0
                     )
                 }
         )
@@ -3005,6 +3004,9 @@ private var initializationResult: InitializationResult {
     if uniffi_uniffi_automerge_checksum_method_doc_changes() != 1878 {
         return InitializationResult.apiChecksumMismatch
     }
+    if uniffi_uniffi_automerge_checksum_method_doc_commit_with() != 65319 {
+        return InitializationResult.apiChecksumMismatch
+    }
     if uniffi_uniffi_automerge_checksum_method_doc_cursor() != 18441 {
         return InitializationResult.apiChecksumMismatch
     }
@@ -3135,9 +3137,6 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_save() != 20308 {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if uniffi_uniffi_automerge_checksum_method_doc_save_with_options() != 11279 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_set_actor() != 64337 {

--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -418,6 +418,8 @@ public protocol DocProtocol: AnyObject {
 
     func changes() -> [ChangeHash]
 
+    func changeByHash(hash: ChangeHash) -> Change?
+
     func cursor(obj: ObjId, position: UInt64) throws -> Cursor
 
     func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash]) throws -> Cursor
@@ -506,7 +508,7 @@ public protocol DocProtocol: AnyObject {
 
     func save() -> [UInt8]
 
-    func saveWithOptions(msg: String, time: Int64)  -> [UInt8]
+    func saveWithOptions(msg: String, time: Int64) -> [UInt8]
 
     func setActor(actor: ActorId)
 
@@ -568,7 +570,6 @@ public class Doc:
         })
     }
 
-
     public func actorId() -> ActorId {
         try! FfiConverterTypeActorId.lift(
             try!
@@ -612,6 +613,20 @@ public class Doc:
                 rustCall {
                     uniffi_uniffi_automerge_fn_method_doc_changes(
                         self.uniffiClonePointer(),
+                        $0
+                    )
+                }
+        )
+    }
+
+    public func changeByHash(hash: ChangeHash) -> Change? {
+        try! FfiConverterOptionTypeChange.lift(
+            try!
+                rustCall {
+                    uniffi_uniffi_automerge_fn_method_doc_change_by_hash(
+                        self.uniffiClonePointer(),
+
+                        FfiConverterTypeChangeHash.lower(hash),
                         $0
                     )
                 }
@@ -1236,7 +1251,7 @@ public class Doc:
         )
     }
 
-    public func saveWithOptions(msg: String, time: Int64)  -> [UInt8] {
+    public func saveWithOptions(msg: String, time: Int64) -> [UInt8] {
         try! FfiConverterSequenceUInt8.lift(
             try!
                 rustCall {
@@ -1510,6 +1525,96 @@ public func FfiConverterTypeSyncState_lift(_ pointer: UnsafeMutableRawPointer) t
 
 public func FfiConverterTypeSyncState_lower(_ value: SyncState) -> UnsafeMutableRawPointer {
     FfiConverterTypeSyncState.lower(value)
+}
+
+public struct Change {
+    public var actorId: ActorId
+    public var message: String?
+    public var deps: [ChangeHash]
+    public var timestamp: Int64
+    public var bytes: [UInt8]
+    public var hash: ChangeHash
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        actorId: ActorId,
+        message: String?,
+        deps: [ChangeHash],
+        timestamp: Int64,
+        bytes: [UInt8],
+        hash: ChangeHash
+    ) {
+        self.actorId = actorId
+        self.message = message
+        self.deps = deps
+        self.timestamp = timestamp
+        self.bytes = bytes
+        self.hash = hash
+    }
+}
+
+extension Change: Equatable, Hashable {
+    public static func == (lhs: Change, rhs: Change) -> Bool {
+        if lhs.actorId != rhs.actorId {
+            return false
+        }
+        if lhs.message != rhs.message {
+            return false
+        }
+        if lhs.deps != rhs.deps {
+            return false
+        }
+        if lhs.timestamp != rhs.timestamp {
+            return false
+        }
+        if lhs.bytes != rhs.bytes {
+            return false
+        }
+        if lhs.hash != rhs.hash {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(actorId)
+        hasher.combine(message)
+        hasher.combine(deps)
+        hasher.combine(timestamp)
+        hasher.combine(bytes)
+        hasher.combine(hash)
+    }
+}
+
+public struct FfiConverterTypeChange: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Change {
+        try Change(
+            actorId: FfiConverterTypeActorId.read(from: &buf),
+            message: FfiConverterOptionString.read(from: &buf),
+            deps: FfiConverterSequenceTypeChangeHash.read(from: &buf),
+            timestamp: FfiConverterInt64.read(from: &buf),
+            bytes: FfiConverterSequenceUInt8.read(from: &buf),
+            hash: FfiConverterTypeChangeHash.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Change, into buf: inout [UInt8]) {
+        FfiConverterTypeActorId.write(value.actorId, into: &buf)
+        FfiConverterOptionString.write(value.message, into: &buf)
+        FfiConverterSequenceTypeChangeHash.write(value.deps, into: &buf)
+        FfiConverterInt64.write(value.timestamp, into: &buf)
+        FfiConverterSequenceUInt8.write(value.bytes, into: &buf)
+        FfiConverterTypeChangeHash.write(value.hash, into: &buf)
+    }
+}
+
+public func FfiConverterTypeChange_lift(_ buf: RustBuffer) throws -> Change {
+    try FfiConverterTypeChange.lift(buf)
+}
+
+public func FfiConverterTypeChange_lower(_ value: Change) -> RustBuffer {
+    FfiConverterTypeChange.lower(value)
 }
 
 public struct KeyValue {
@@ -2408,6 +2513,48 @@ public func FfiConverterTypeValue_lower(_ value: Value) -> RustBuffer {
 
 extension Value: Equatable, Hashable {}
 
+private struct FfiConverterOptionString: FfiConverterRustBuffer {
+    typealias SwiftType = String?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterString.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterString.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+private struct FfiConverterOptionTypeChange: FfiConverterRustBuffer {
+    typealias SwiftType = Change?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeChange.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeChange.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
 private struct FfiConverterOptionTypeValue: FfiConverterRustBuffer {
     typealias SwiftType = Value?
 
@@ -2850,6 +2997,9 @@ private var initializationResult: InitializationResult {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes_with_patches() != 63928 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_uniffi_automerge_checksum_method_doc_change_by_hash() != 44577 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_uniffi_automerge_checksum_method_doc_changes() != 1878 {

--- a/Sources/Automerge/Change.swift
+++ b/Sources/Automerge/Change.swift
@@ -1,0 +1,22 @@
+import struct AutomergeUniffi.Change
+import Foundation
+
+typealias FfiChange = AutomergeUniffi.Change
+
+public struct Change: Equatable {
+    public let actorId: ActorId
+    public let message: String?
+    public let deps: [ChangeHash]
+    public let timestamp: Date
+    public let bytes: [UInt8]
+    public let hash: ChangeHash
+
+    init(_ ffi: FfiChange) {
+        actorId = ActorId(bytes: ffi.actorId)
+        message = ffi.message
+        deps = ffi.deps.map(ChangeHash.init(bytes:))
+        timestamp = Date(timeIntervalSince1970: TimeInterval(ffi.timestamp))
+        bytes = ffi.bytes
+        hash = .init(bytes: ffi.hash)
+    }
+}

--- a/Sources/Automerge/Change.swift
+++ b/Sources/Automerge/Change.swift
@@ -8,7 +8,7 @@ public struct Change: Equatable {
     public let message: String?
     public let deps: [ChangeHash]
     public let timestamp: Date
-    public let bytes: [UInt8]
+    public let bytes: Data
     public let hash: ChangeHash
 
     init(_ ffi: FfiChange) {
@@ -16,7 +16,7 @@ public struct Change: Equatable {
         message = ffi.message
         deps = ffi.deps.map(ChangeHash.init(bytes:))
         timestamp = Date(timeIntervalSince1970: TimeInterval(ffi.timestamp))
-        bytes = ffi.bytes
-        hash = .init(bytes: ffi.hash)
+        bytes = Data(ffi.bytes)
+        hash = ChangeHash(bytes: ffi.hash)
     }
 }

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -772,10 +772,7 @@ public final class Document: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - message: An optional message to attach to the auto-committed change (if any).
-    ///   - timestamp: An optional timestamp to attach to the auto-committed change (if any).
-    ///
-    /// The `commitWith` function also compacts the memory footprint of an Automerge document and increments the
-    /// result of ``heads()``, which indicates a specific point in time for the history of the document.
+    ///   - timestamp: A timestamp to attach to the auto-committed change (if any), defaulting to Date().
     public func commitWith(message: String? = nil, timestamp: Date = Date()) {
         sync {
             self.doc.wrapErrors {

--- a/Sources/_CAutomergeUniffi/include/automergeFFI.h
+++ b/Sources/_CAutomergeUniffi/include/automergeFFI.h
@@ -72,6 +72,8 @@ RustBuffer uniffi_uniffi_automerge_fn_method_doc_change_by_hash(void*_Nonnull pt
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_changes(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+void uniffi_uniffi_automerge_fn_method_doc_commit_with(void*_Nonnull ptr, RustBuffer msg, int64_t time, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_cursor(void*_Nonnull ptr, RustBuffer obj, uint64_t position, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_cursor_at(void*_Nonnull ptr, RustBuffer obj, uint64_t position, RustBuffer heads, RustCallStatus *_Nonnull out_status
@@ -159,8 +161,6 @@ void uniffi_uniffi_automerge_fn_method_doc_receive_sync_message(void*_Nonnull pt
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(void*_Nonnull ptr, void*_Nonnull state, RustBuffer msg, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_save(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
-);
-RustBuffer uniffi_uniffi_automerge_fn_method_doc_save_with_options(void*_Nonnull ptr, RustBuffer msg, int64_t time, RustCallStatus *_Nonnull out_status
 );
 void uniffi_uniffi_automerge_fn_method_doc_set_actor(void*_Nonnull ptr, RustBuffer actor, RustCallStatus *_Nonnull out_status
 );
@@ -326,6 +326,9 @@ uint16_t uniffi_uniffi_automerge_checksum_method_doc_change_by_hash(void
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_changes(void
     
 );
+uint16_t uniffi_uniffi_automerge_checksum_method_doc_commit_with(void
+    
+);
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_cursor(void
     
 );
@@ -456,9 +459,6 @@ uint16_t uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message_with_p
     
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_save(void
-    
-);
-uint16_t uniffi_uniffi_automerge_checksum_method_doc_save_with_options(void
     
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_set_actor(void

--- a/Sources/_CAutomergeUniffi/include/automergeFFI.h
+++ b/Sources/_CAutomergeUniffi/include/automergeFFI.h
@@ -158,6 +158,8 @@ RustBuffer uniffi_uniffi_automerge_fn_method_doc_receive_sync_message_with_patch
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_save(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_uniffi_automerge_fn_method_doc_save_with_options(void*_Nonnull ptr, RustBuffer msg, int64_t time, RustCallStatus *_Nonnull out_status
+);
 void uniffi_uniffi_automerge_fn_method_doc_set_actor(void*_Nonnull ptr, RustBuffer actor, RustCallStatus *_Nonnull out_status
 );
 void uniffi_uniffi_automerge_fn_method_doc_splice(void*_Nonnull ptr, RustBuffer obj, uint64_t start, int64_t delete, RustBuffer values, RustCallStatus *_Nonnull out_status
@@ -450,6 +452,9 @@ uint16_t uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message_with_p
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_save(void
     
+);
+uint16_t uniffi_uniffi_automerge_checksum_method_doc_save_with_options(void
+
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_set_actor(void
     

--- a/Sources/_CAutomergeUniffi/include/automergeFFI.h
+++ b/Sources/_CAutomergeUniffi/include/automergeFFI.h
@@ -68,6 +68,8 @@ void uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes(void*_Nonnull p
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(void*_Nonnull ptr, RustBuffer changes, RustCallStatus *_Nonnull out_status
 );
+RustBuffer uniffi_uniffi_automerge_fn_method_doc_change_by_hash(void*_Nonnull ptr, RustBuffer hash, RustCallStatus *_Nonnull out_status
+);
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_changes(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 RustBuffer uniffi_uniffi_automerge_fn_method_doc_cursor(void*_Nonnull ptr, RustBuffer obj, uint64_t position, RustCallStatus *_Nonnull out_status
@@ -318,6 +320,9 @@ uint16_t uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes(void
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes_with_patches(void
     
 );
+uint16_t uniffi_uniffi_automerge_checksum_method_doc_change_by_hash(void
+    
+);
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_changes(void
     
 );
@@ -454,7 +459,7 @@ uint16_t uniffi_uniffi_automerge_checksum_method_doc_save(void
     
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_save_with_options(void
-
+    
 );
 uint16_t uniffi_uniffi_automerge_checksum_method_doc_set_actor(void
     

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -239,4 +239,34 @@ final class AutomergeDocTests: XCTestCase {
         let text = try doc.text(obj: textId)
         XCTAssertEqual(text, "🇬🇧😀")
     }
+
+    func testSaveWithOptions() throws {
+        struct ColorList: Codable {
+            var colors: [String]
+        }
+
+        // Create the document
+        let doc = Document()
+        let encoder = AutomergeEncoder(doc: doc)
+
+        // Make an initial change
+        var myColors = ColorList(colors: ["blue", "red"])
+        try encoder.encode(myColors)
+        _ = doc.saveWithOptions(message: "Change 1", timestamp: Date(timeIntervalSince1970: 10))
+
+        // Make another change
+        myColors.colors.append("green")
+        try encoder.encode(myColors)
+        _ = doc.saveWithOptions(message: "Change 2", timestamp: Date(timeIntervalSince1970: 20))
+
+        let history = doc.getHistory()
+        XCTAssertEqual(history.count, 2)
+
+        let changes = history.map({ doc.change(hash: $0) })
+        XCTAssertEqual(changes.count, 2)
+        XCTAssertEqual(changes[0]?.message, "Change 1")
+        XCTAssertEqual(changes[0]?.timestamp, Date(timeIntervalSince1970: 10))
+        XCTAssertEqual(changes[1]?.message, "Change 2")
+        XCTAssertEqual(changes[1]?.timestamp, Date(timeIntervalSince1970: 20))
+    }
 }

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -240,33 +240,57 @@ final class AutomergeDocTests: XCTestCase {
         XCTAssertEqual(text, "🇬🇧😀")
     }
 
-    func testSaveWithOptions() throws {
-        struct ColorList: Codable {
-            var colors: [String]
+    func testCommitWith() throws {
+        struct Dog: Codable {
+            var name: String
+            var age: Int
         }
 
         // Create the document
         let doc = Document()
         let encoder = AutomergeEncoder(doc: doc)
 
-        // Make an initial change
-        var myColors = ColorList(colors: ["blue", "red"])
-        try encoder.encode(myColors)
-        _ = doc.saveWithOptions(message: "Change 1", timestamp: Date(timeIntervalSince1970: 10))
+        // Make an initial change with a message and timestamp
+        var myDog = Dog(name: "Fido", age: 1)
+        try encoder.encode(myDog)
+        doc.commitWith(message: "Change 1", timestamp: Date(timeIntervalSince1970: 10))
 
-        // Make another change
-        myColors.colors.append("green")
-        try encoder.encode(myColors)
-        _ = doc.saveWithOptions(message: "Change 2", timestamp: Date(timeIntervalSince1970: 20))
+        // Make another change with the default timestamp
+        myDog.age = 2
+        try encoder.encode(myDog)
+        doc.commitWith(message: "Change 2")
+        let change2Time = Date().timeIntervalSince1970
+
+        // Make another change with no message
+        myDog.age = 3
+        try encoder.encode(myDog)
+        doc.commitWith(message: nil, timestamp: Date(timeIntervalSince1970: 20))
+
+        // Make another change with no message and the default timestamp
+        myDog.age = 4
+        try encoder.encode(myDog)
+        doc.commitWith()
+        let change4Time = Date().timeIntervalSince1970
+
+        // Make another change by just calling save() (meaning no commit options will be set)
+        myDog.age = 5
+        try encoder.encode(myDog)
+        _ = doc.save()
 
         let history = doc.getHistory()
-        XCTAssertEqual(history.count, 2)
+        XCTAssertEqual(history.count, 5)
 
         let changes = history.map({ doc.change(hash: $0) })
-        XCTAssertEqual(changes.count, 2)
-        XCTAssertEqual(changes[0]?.message, "Change 1")
-        XCTAssertEqual(changes[0]?.timestamp, Date(timeIntervalSince1970: 10))
-        XCTAssertEqual(changes[1]?.message, "Change 2")
-        XCTAssertEqual(changes[1]?.timestamp, Date(timeIntervalSince1970: 20))
+        XCTAssertEqual(changes.count, 5)
+        XCTAssertEqual(changes[0]!.message, "Change 1")
+        XCTAssertEqual(changes[0]!.timestamp, Date(timeIntervalSince1970: 10))
+        XCTAssertEqual(changes[1]!.message, "Change 2")
+        XCTAssertEqual(changes[1]!.timestamp.timeIntervalSince1970, change2Time, accuracy: 3)
+        XCTAssertNil(changes[2]!.message)
+        XCTAssertEqual(changes[2]!.timestamp, Date(timeIntervalSince1970: 20))
+        XCTAssertNil(changes[3]!.message)
+        XCTAssertEqual(changes[3]!.timestamp.timeIntervalSince1970, change4Time, accuracy: 3)
+        XCTAssertNil(changes[4]!.message)
+        XCTAssertEqual(changes[4]!.timestamp.timeIntervalSince1970, 0)
     }
 }

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -223,6 +223,7 @@ interface Doc {
     sequence<ChangeHash> changes();
 
     sequence<u8> save();
+    sequence<u8> save_with_options(string msg, i64 time);
 
     [Throws=DocError]
     void merge(Doc other);

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -233,8 +233,9 @@ interface Doc {
 
     Change? change_by_hash(ChangeHash hash);
 
+    void commit_with(string? msg, i64 time);
+
     sequence<u8> save();
-    sequence<u8> save_with_options(string msg, i64 time);
 
     [Throws=DocError]
     void merge(Doc other);

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -103,6 +103,15 @@ dictionary PathElement {
     ObjId obj;
 };
 
+dictionary Change {
+    ActorId actor_id;
+    string? message;
+    sequence<ChangeHash> deps;
+    i64 timestamp;
+    sequence<u8> bytes;
+    ChangeHash hash;
+};
+
 dictionary Patch {
     sequence<PathElement> path;
     PatchAction action;
@@ -221,6 +230,8 @@ interface Doc {
     sequence<ChangeHash> heads();
 
     sequence<ChangeHash> changes();
+
+    Change? change_by_hash(ChangeHash hash);
 
     sequence<u8> save();
     sequence<u8> save_with_options(string msg, i64 time);

--- a/rust/src/change.rs
+++ b/rust/src/change.rs
@@ -36,6 +36,7 @@ pub enum DecodeChangeError {
     Internal(#[from] am::LoadChangeError),
 }
 
+#[allow(dead_code)]
 pub fn decode_change(bytes: Vec<u8>) -> Result<Change, DecodeChangeError> {
     am::Change::try_from(bytes.as_slice())
         .map(Change::from)

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -7,7 +7,7 @@ use automerge::{transaction::Transactable, ReadDoc};
 use crate::actor_id::ActorId;
 use crate::mark::{ExpandMark, Mark};
 use crate::patches::Patch;
-use crate::{ChangeHash, Cursor, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value};
+use crate::{Change, ChangeHash, Cursor, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocError {
@@ -579,6 +579,12 @@ impl Doc {
         let mut doc = self.0.write().unwrap();
         let changes = doc.get_changes(&empty_heads);
         changes.into_iter().map(|h| h.hash().into()).collect()
+    }
+
+    pub fn change_by_hash(&self, hash: ChangeHash) -> Option<Change> {
+        let doc = self.0.write().unwrap();
+        doc.get_change_by_hash(&am::ChangeHash::from(hash))
+            .map(|m| Change::from(m.clone()))
     }
 
     pub fn path(&self, obj: ObjId) -> Result<Vec<PathElement>, DocError> {

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -7,7 +7,9 @@ use automerge::{transaction::Transactable, ReadDoc};
 use crate::actor_id::ActorId;
 use crate::mark::{ExpandMark, Mark};
 use crate::patches::Patch;
-use crate::{Change, ChangeHash, Cursor, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value};
+use crate::{
+    Change, ChangeHash, Cursor, ObjId, ObjType, PathElement, ScalarValue, SyncState, Value
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DocError {

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -500,6 +500,14 @@ impl Doc {
         doc.save()
     }
 
+    pub fn save_with_options(&self, message: String, time: i64) -> Vec<u8> {
+        let mut doc = self.0.write().unwrap();
+        doc.commit_with(automerge::transaction::CommitOptions::default()
+            .with_message(message)
+            .with_time(time));
+        doc.save()
+    }
+
     pub fn load(bytes: Vec<u8>) -> Result<Self, LoadError> {
         let ac = automerge::AutoCommit::load(bytes.as_slice())?;
         Ok(Doc(RwLock::new(ac)))

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -495,16 +495,18 @@ impl Doc {
         })
     }
 
-    pub fn save(&self) -> Vec<u8> {
+    pub fn commit_with(&self, message: Option<String>, time: i64) {
         let mut doc = self.0.write().unwrap();
-        doc.save()
+        let mut options = automerge::transaction::CommitOptions::default();
+        options.set_time(time);
+        if let Some(message) = message {
+            options.set_message(message);
+        }
+        doc.commit_with(options);
     }
 
-    pub fn save_with_options(&self, message: String, time: i64) -> Vec<u8> {
+    pub fn save(&self) -> Vec<u8> {
         let mut doc = self.0.write().unwrap();
-        doc.commit_with(automerge::transaction::CommitOptions::default()
-            .with_message(message)
-            .with_time(time));
         doc.save()
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,8 @@ mod actor_id;
 use actor_id::ActorId;
 mod cursor;
 use cursor::Cursor;
+mod change;
+use change::Change;
 mod change_hash;
 use change_hash::ChangeHash;
 mod doc;


### PR DESCRIPTION
We currently (with the older version of the swift bindings) use the `timestamp` field of the changes in order to determine when a document was last modified for display to the user in our application. I was directed to #104 where this feature has also been discussed. While changes to the underlying `AutoCommit` type in the core automerge library would likely be better long-term, this PR aims to provide a more targeted solution for this swift library. In the normal usage of this library with an `AutomergeEncoder`, the underlying transaction is made at the point that save() is called. Therefore, we can make this transaction more explicit and pass through commit options (`message` / `timestamp`).

I also needed a way to retrieve these commit options later, so added a new `changeByHash(hash:)` method which grabs a full `Change` object from the underlying automerge document for a given hash. This way, we can easily get the timestamp for the latest changes by calling this method on each `head` of the document.

I added a new test which showcases both of these new APIs.

As an aside, when I ran the `build-xcframework.sh` script locally, I ended up with a ton of other local changes to the generated code (mostly style changes). I removed those from the PR but would be great to know if there's a way to make this less noisy moving forwards.