### PR TITLE
Added public initializer to ActorId and tests to validate setting `actor` property

### DIFF
--- a/Sources/Automerge/ActorId.swift
+++ b/Sources/Automerge/ActorId.swift
@@ -8,6 +8,17 @@ import Foundation
 public struct ActorId: Equatable, Hashable, Sendable {
     var data: Data
 
+    // Creates a new, random actor.
+    public init() {
+        self.init(uuid: UUID())
+    }
+
+    // Creates an actor from a UUID.
+    public init(uuid: UUID) {
+        data = withUnsafeBytes(of: uuid.uuid, { Data($0) })
+    }
+
+    // Creates an actor from data.
     public init(data: Data) {
         self.data = data
     }

--- a/Sources/Automerge/ActorId.swift
+++ b/Sources/Automerge/ActorId.swift
@@ -6,6 +6,10 @@ import AutomergeUniffi
 /// If you create your own `ActorId`, no concurrent changes should ever be made with the same `ActorId`.
 public struct ActorId: Equatable, Hashable, Sendable {
     var bytes: [UInt8]
+
+    public init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
 }
 
 extension ActorId: CustomStringConvertible {

--- a/Sources/Automerge/ActorId.swift
+++ b/Sources/Automerge/ActorId.swift
@@ -8,6 +8,10 @@ import Foundation
 public struct ActorId: Equatable, Hashable, Sendable {
     var data: Data
 
+    init(ffi: AutomergeUniffi.ActorId) {
+        data = Data(ffi)
+    }
+
     // Creates a new, random actor.
     public init() {
         self.init(uuid: UUID())
@@ -19,7 +23,10 @@ public struct ActorId: Equatable, Hashable, Sendable {
     }
 
     // Creates an actor from data.
-    public init(data: Data) {
+    public init?(data: Data) {
+        guard data.count <= 128 else {
+            return nil
+        }
         self.data = data
     }
 }

--- a/Sources/Automerge/ActorId.swift
+++ b/Sources/Automerge/ActorId.swift
@@ -1,19 +1,20 @@
 import AutomergeUniffi
+import Foundation
 
 /// The identifier for collaborators contributing to an Automerge document.
 ///
 /// Each separate instance of an Automerge document should have it's own, unique, `ActorId`.
 /// If you create your own `ActorId`, no concurrent changes should ever be made with the same `ActorId`.
 public struct ActorId: Equatable, Hashable, Sendable {
-    var bytes: [UInt8]
+    var data: Data
 
-    public init(bytes: [UInt8]) {
-        self.bytes = bytes
+    public init(data: Data) {
+        self.data = data
     }
 }
 
 extension ActorId: CustomStringConvertible {
     public var description: String {
-        bytes.map { Swift.String(format: "%02hhx", $0) }.joined().uppercased()
+        data.map { String(format: "%02hhX", $0) }.joined()
     }
 }

--- a/Sources/Automerge/Change.swift
+++ b/Sources/Automerge/Change.swift
@@ -19,7 +19,7 @@ public struct Change: Equatable {
     public let hash: ChangeHash
 
     init(_ ffi: FfiChange) {
-        actorId = ActorId(bytes: ffi.actorId)
+        actorId = ActorId(data: Data(ffi.actorId))
         message = ffi.message
         deps = ffi.deps.map(ChangeHash.init(bytes:))
         timestamp = Date(timeIntervalSince1970: TimeInterval(ffi.timestamp))

--- a/Sources/Automerge/Change.swift
+++ b/Sources/Automerge/Change.swift
@@ -19,7 +19,7 @@ public struct Change: Equatable {
     public let hash: ChangeHash
 
     init(_ ffi: FfiChange) {
-        actorId = ActorId(data: Data(ffi.actorId))
+        actorId = ActorId(ffi: ffi.actorId)
         message = ffi.message
         deps = ffi.deps.map(ChangeHash.init(bytes:))
         timestamp = Date(timeIntervalSince1970: TimeInterval(ffi.timestamp))

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -32,12 +32,12 @@ public final class Document: @unchecked Sendable {
     public var actor: ActorId {
         get {
             sync {
-                ActorId(bytes: self.doc.wrapErrors { $0.actorId() })
+                ActorId(data: self.doc.wrapErrors { Data($0.actorId()) })
             }
         }
         set {
             sync {
-                self.doc.wrapErrors { $0.setActor(actor: newValue.bytes) }
+                self.doc.wrapErrors { $0.setActor(actor: [UInt8](newValue.data)) }
             }
         }
     }

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -32,7 +32,7 @@ public final class Document: @unchecked Sendable {
     public var actor: ActorId {
         get {
             sync {
-                ActorId(data: self.doc.wrapErrors { Data($0.actorId()) })
+                ActorId(ffi: self.doc.wrapErrors { $0.actorId() })
             }
         }
         set {

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -300,10 +300,14 @@ final class AutomergeDocTests: XCTestCase {
             var age: Int
         }
 
-        let actor1 = ActorId(data: Data([0x00, 0x11, 0x22, 0x33]))
-        XCTAssertEqual(actor1.description, "00112233")
-        let actor2 = ActorId(data: Data([0xaa, 0xbb, 0xcc, 0xdd]))
-        XCTAssertEqual(actor2.description, "AABBCCDD")
+        let actor1 = ActorId(data: Data([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
+        ]))
+        XCTAssertEqual(actor1.description, "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F")
+        let uuidActor2 = UUID(uuidString: "06a2b97e-69c9-4036-a97f-d4167a2bb779")!
+        let actor2 = ActorId(uuid: uuidActor2)
+        XCTAssertEqual(actor2.description, "06A2B97E69C94036A97FD4167A2BB779")
 
         // Create the document
         let doc = Document()

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -21,6 +21,12 @@ final class AutomergeDocTests: XCTestCase {
         doc = Document()
     }
 
+    func testActor() throws {
+        let doc = Document()
+        doc.actor = ActorId(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        XCTAssertEqual(doc.actor.description, "000102030405060708090A0B0C0D0E0F")
+    }
+
     func testNoteEncodeDecode() throws {
         struct Note: Codable, Equatable {
             let created: Date

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -300,8 +300,10 @@ final class AutomergeDocTests: XCTestCase {
             var age: Int
         }
 
-        let actor1 = ActorId(bytes: [0x00, 0x11, 0x22, 0x33])
-        let actor2 = ActorId(bytes: [0x44, 0x55, 0x66, 0x77])
+        let actor1 = ActorId(data: Data([0x00, 0x11, 0x22, 0x33]))
+        XCTAssertEqual(actor1.description, "00112233")
+        let actor2 = ActorId(data: Data([0xaa, 0xbb, 0xcc, 0xdd]))
+        XCTAssertEqual(actor2.description, "AABBCCDD")
 
         // Create the document
         let doc = Document()

--- a/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
+++ b/Tests/AutomergeTests/DocTests/AutomergeDocTests.swift
@@ -300,11 +300,17 @@ final class AutomergeDocTests: XCTestCase {
             var age: Int
         }
 
+        // Actor ID which is too long (150 bytes)
+        XCTAssertNil(ActorId(data: Data(repeating: 0, count: 150)))
+
+        // Valid 32-byte actor ID
         let actor1 = ActorId(data: Data([
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
-        ]))
+        ]))!
         XCTAssertEqual(actor1.description, "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F")
+
+        // Actor ID from a UUID
         let uuidActor2 = UUID(uuidString: "06a2b97e-69c9-4036-a97f-d4167a2bb779")!
         let actor2 = ActorId(uuid: uuidActor2)
         XCTAssertEqual(actor2.description, "06A2B97E69C94036A97FD4167A2BB779")


### PR DESCRIPTION
Regarding the use-case for this, we set the actorId by concatenating the user ID with a globally-unique device ID. We leverage this heavily in our internal tooling to browse document history for debugging various issues. Here's an example where can see who made each change by looking up the user ID. This is very helpful both for development to figure out issues with our sync protocol, as well as customer support in figuring out what made what change to a document.

<img width="1156" alt="Screenshot_2024-03-15_at_4 46 26_PM" src="https://github.com/automerge/automerge-swift/assets/283884/9f704429-933e-438d-86b8-255f8b36b34d">
