### PR TITLE
ExpressibleBy Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Now you can create a document and do all sorts of Automerge things with it
 ```swift
 let doc = Document()
 let list = try! doc.putObject(obj: ObjId.ROOT, key: "colours", ty: .List)
-try! doc.insert(obj: list, index: 0, value: .String("blue"))
-try! doc.insert(obj: list, index: 1, value: .String("red"))
+try! doc.insert(obj: list, index: 0, value: "blue")
+try! doc.insert(obj: list, index: 1, value: "red")
 
 let doc2 = doc.fork()
-try! doc2.insert(obj: list, index: 0, value: .String("green"))
+try! doc2.insert(obj: list, index: 0, value: "green")
 
 try! doc.delete(obj: list, index: 0)
 

--- a/Sources/Automerge/ScalarValue.swift
+++ b/Sources/Automerge/ScalarValue.swift
@@ -121,3 +121,22 @@ extension ScalarValue: CustomStringConvertible {
         }
     }
 }
+
+extension ScalarValue: ExpressibleByStringLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByNilLiteral {
+
+    public init(stringLiteral value: StringLiteralType) {
+        self = .String(value)
+    }
+
+    public init(booleanLiteral value: BooleanLiteralType) {
+        self = .Boolean(value)
+    }
+
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .Int(Int64(value))
+    }
+
+    public init(nilLiteral: ()) {
+        self = .Null
+    }
+}

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -9,12 +9,12 @@ final class AutomergeDecoderTests: XCTestCase {
         setupCache = [:]
         doc = Document()
 
-        try! doc.put(obj: ObjId.ROOT, key: "name", value: .String("Joe"))
+        try! doc.put(obj: ObjId.ROOT, key: "name", value: "Joe")
         try! doc.put(obj: ObjId.ROOT, key: "duration", value: .F64(3.14159))
-        try! doc.put(obj: ObjId.ROOT, key: "flag", value: .Boolean(true))
-        try! doc.put(obj: ObjId.ROOT, key: "count", value: .Int(5))
-        try! doc.put(obj: ObjId.ROOT, key: "uuid", value: .String("99CEBB16-1062-4F21-8837-CF18EC09DCD7"))
-        try! doc.put(obj: ObjId.ROOT, key: "url", value: .String("http://url.com"))
+        try! doc.put(obj: ObjId.ROOT, key: "flag", value: true)
+        try! doc.put(obj: ObjId.ROOT, key: "count", value: 5)
+        try! doc.put(obj: ObjId.ROOT, key: "uuid", value: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")
+        try! doc.put(obj: ObjId.ROOT, key: "url", value: "http://url.com")
         try! doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
         try! doc.put(obj: ObjId.ROOT, key: "data", value: .Bytes(Data("hello".utf8)))
 
@@ -24,9 +24,9 @@ final class AutomergeDecoderTests: XCTestCase {
 
         let votes = try! doc.putObject(obj: ObjId.ROOT, key: "votes", ty: .List)
         setupCache["votes"] = votes
-        try! doc.insert(obj: votes, index: 0, value: .Int(3))
-        try! doc.insert(obj: votes, index: 1, value: .Int(4))
-        try! doc.insert(obj: votes, index: 2, value: .Int(5))
+        try! doc.insert(obj: votes, index: 0, value: 3)
+        try! doc.insert(obj: votes, index: 1, value: 4)
+        try! doc.insert(obj: votes, index: 2, value: 5)
 
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
         setupCache["list"] = list

--- a/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
@@ -101,7 +101,7 @@ final class AutomergeEncoderTests: XCTestCase {
             try XCTFail("Didn't find an object at \(String(describing: doc.get(obj: ObjId.ROOT, key: "notes")))")
         }
 
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "url"), .Scalar(.String("http://url.com")))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "url"), .Scalar("http://url.com"))
         try debugPrint(doc.get(obj: ObjId.ROOT, key: "notes") as Any)
     }
 
@@ -157,7 +157,7 @@ final class AutomergeEncoderTests: XCTestCase {
             } else {
                 try XCTFail("Didn't find: \(String(describing: doc.get(obj: container_id, key: "count")))")
             }
-            XCTAssertEqual(try doc.get(obj: container_id, key: "url"), .Scalar(.String("http://url.com")))
+            XCTAssertEqual(try doc.get(obj: container_id, key: "url"), .Scalar("http://url.com"))
         } else {
             try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "example")))")
         }
@@ -176,9 +176,9 @@ final class AutomergeEncoderTests: XCTestCase {
 
         if case let .Object(container_id, container_type) = try doc.get(obj: ObjId.ROOT, key: "numbers") {
             XCTAssertEqual(container_type, ObjType.List)
-            XCTAssertEqual(try doc.get(obj: container_id, index: 0), .Scalar(.Int(1)))
-            XCTAssertEqual(try doc.get(obj: container_id, index: 1), .Scalar(.Int(2)))
-            XCTAssertEqual(try doc.get(obj: container_id, index: 2), .Scalar(.Int(3)))
+            XCTAssertEqual(try doc.get(obj: container_id, index: 0), .Scalar(1))
+            XCTAssertEqual(try doc.get(obj: container_id, index: 1), .Scalar(2))
+            XCTAssertEqual(try doc.get(obj: container_id, index: 2), .Scalar(3))
         } else {
             try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "example")))")
         }

--- a/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeKeyEncoderImplTests.swift
@@ -35,14 +35,14 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Bool() throws {
         try rootKeyedContainer.encode(true, forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(true))
 
         try cautiousKeyedContainer.encode(false, forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(false))
     }
 
     func testSimpleKeyEncode_Bool_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: 4)
         XCTAssertThrowsError(
             try cautiousKeyedContainer.encode(false, forKey: .value)
         )
@@ -86,7 +86,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Float_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(4))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: 4)
         XCTAssertThrowsError(
             try cautiousKeyedContainer.encode(Float(4.0), forKey: .value)
         )
@@ -97,7 +97,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int8() throws {
         try rootKeyedContainer.encode(Int8(4), forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousKeyedContainer.encode(Int8(5), forKey: .value)
     }
@@ -111,7 +111,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int16() throws {
         try rootKeyedContainer.encode(Int16(4), forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousKeyedContainer.encode(Int16(5), forKey: .value)
     }
@@ -125,7 +125,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int32() throws {
         try rootKeyedContainer.encode(Int32(4), forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try rootKeyedContainer.encode(Int32(5), forKey: .value)
     }
@@ -139,7 +139,7 @@ final class AutomergeKeyEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int64() throws {
         try rootKeyedContainer.encode(Int64(4), forKey: .value)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousKeyedContainer.encode(Int64(5), forKey: .value)
     }

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -34,10 +34,10 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Bool() throws {
         try singleValueContainer.encode(true)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(true))
 
         try cautiousSingleValueContainer.encode(false)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(false)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(false))
     }
 
     func testSimpleKeyEncode_Bool_CautiousFailure() throws {
@@ -76,7 +76,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Double_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .Int(40))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: 40)
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(Double(3.4))
         )
@@ -88,14 +88,14 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int8() throws {
         try singleValueContainer.encode(Int8(4))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousSingleValueContainer.encode(Int8(5))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(5))
     }
 
     func testSimpleKeyEncode_Int_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: "40")
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(Int(4))
         )
@@ -115,26 +115,26 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
 
     func testSimpleKeyEncode_Int16() throws {
         try singleValueContainer.encode(Int16(4))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousSingleValueContainer.encode(Int16(5))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(5))
     }
 
     func testSimpleKeyEncode_Int32() throws {
         try singleValueContainer.encode(Int32(4))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousSingleValueContainer.encode(Int32(5))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(5))
     }
 
     func testSimpleKeyEncode_Int64() throws {
         try singleValueContainer.encode(Int64(4))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(4)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(4))
 
         try cautiousSingleValueContainer.encode(Int64(5))
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Int(5)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(5))
     }
 
     func testSimpleKeyEncode_UInt() throws {
@@ -178,7 +178,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_UInt_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: "40")
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(UInt(4))
         )
@@ -207,7 +207,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Date_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: "40")
         let dateFormatter = ISO8601DateFormatter()
         let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
         XCTAssertThrowsError(
@@ -224,7 +224,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Data_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: "40")
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(Data("World".utf8))
         )
@@ -248,7 +248,7 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Counter_CautiousFailure() throws {
-        try doc.put(obj: ObjId.ROOT, key: "value", value: .String("40"))
+        try doc.put(obj: ObjId.ROOT, key: "value", value: "40")
         XCTAssertThrowsError(
             try cautiousSingleValueContainer.encode(Counter(443))
         )

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -107,7 +107,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
-        try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
+        try doc.put(obj: ObjId.ROOT, key: "int", value: 34)
 
         let automergeDecoder = AutomergeDecoder(doc: doc)
 
@@ -149,7 +149,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
-        try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
+        try doc.put(obj: ObjId.ROOT, key: "int", value: 34)
 
         let automergeDecoder = AutomergeDecoder(doc: doc)
 

--- a/Tests/AutomergeTests/CodableTests/Document+retrieveObjectIdTests.swift
+++ b/Tests/AutomergeTests/CodableTests/Document+retrieveObjectIdTests.swift
@@ -9,7 +9,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         setupCache = [:]
         doc = Document()
 
-        let _ = try! doc.put(obj: ObjId.ROOT, key: "name", value: .String("joe"))
+        let _ = try! doc.put(obj: ObjId.ROOT, key: "name", value: "joe")
 
         let topMap = try! doc.putObject(obj: ObjId.ROOT, key: "topMap", ty: .Map)
         setupCache["topMap"] = topMap
@@ -26,7 +26,7 @@ final class RetrieveObjectIdTests: XCTestCase {
         let nestedText = try! doc.insertObject(obj: list, index: 1, ty: .Text)
         setupCache["nestedText"] = nestedText
 
-        let _ = try! doc.insert(obj: list, index: 2, value: .String("alex"))
+        let _ = try! doc.insert(obj: list, index: 2, value: "alex")
 
         try! doc.put(obj: nestedMap, key: "image", value: .Bytes(Data()))
         let deeplyNestedText = try! doc.putObject(obj: nestedMap, key: "notes", ty: .Text)

--- a/Tests/AutomergeTests/TestCrud.swift
+++ b/Tests/AutomergeTests/TestCrud.swift
@@ -4,15 +4,15 @@ import XCTest
 class CrudTests: XCTestCase {
     func testCreateAndPutGetInRoot() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value"))
-        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key")!, .Scalar(.String("value")))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value")
+        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key")!, .Scalar("value"))
     }
 
     func testMapCrud() {
         let doc = Document()
         let map = try! doc.putObject(obj: ObjId.ROOT, key: "map", ty: .Map)
-        try! doc.put(obj: map, key: "nested", value: .String("nested"))
-        XCTAssertEqual(try! doc.get(obj: map, key: "nested")!, .Scalar(.String("nested")))
+        try! doc.put(obj: map, key: "nested", value: "nested")
+        XCTAssertEqual(try! doc.get(obj: map, key: "nested")!, .Scalar("nested"))
 
         try! doc.delete(obj: map, key: "nested")
         XCTAssertEqual(try! doc.get(obj: map, key: "nested"), nil)
@@ -28,12 +28,12 @@ class CrudTests: XCTestCase {
     func testListCrud() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
-        try! doc.insert(obj: list, index: 0, value: .String("elem1"))
-        XCTAssertEqual(try! doc.get(obj: list, index: 0)!, .Scalar(.String("elem1")))
+        try! doc.insert(obj: list, index: 0, value: "elem1")
+        XCTAssertEqual(try! doc.get(obj: list, index: 0)!, .Scalar("elem1"))
 
         let nested = try! doc.insertObject(obj: list, index: 1, ty: .Map)
-        try! doc.put(obj: nested, key: "nested", value: .String("nested"))
-        XCTAssertEqual(try! doc.get(obj: nested, key: "nested"), .Scalar(.String("nested")))
+        try! doc.put(obj: nested, key: "nested", value: "nested")
+        XCTAssertEqual(try! doc.get(obj: nested, key: "nested"), .Scalar("nested"))
 
         try! doc.delete(obj: list, index: 1)
         XCTAssertEqual(try! doc.get(obj: list, index: 1), nil)

--- a/Tests/AutomergeTests/TestEncodeAndApplyNewChanges.swift
+++ b/Tests/AutomergeTests/TestEncodeAndApplyNewChanges.swift
@@ -4,30 +4,30 @@ import XCTest
 class EncodeAndApplyNewChangesTestCase: XCTestCase {
     func testEncodeAndApplyNew() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
 
         let doc2 = Document()
         let changes1 = doc.encodeNewChanges()
         try! doc2.applyEncodedChanges(encoded: changes1)
-        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("one")))
+        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("one"))
 
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "two")
         let changes2 = doc.encodeNewChanges()
         try! doc2.applyEncodedChanges(encoded: changes2)
-        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("two")))
+        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("two"))
     }
 
     func testEncodeAndApplyChangesSince() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
         let doc2 = doc.fork()
 
         let heads = doc.heads()
 
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "two")
 
         let changes = try! doc.encodeChangesSince(heads: heads)
         try! doc2.applyEncodedChanges(encoded: changes)
-        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("two")))
+        XCTAssertEqual(try! doc2.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("two"))
     }
 }

--- a/Tests/AutomergeTests/TestForkAndMerge.swift
+++ b/Tests/AutomergeTests/TestForkAndMerge.swift
@@ -4,35 +4,35 @@ import XCTest
 class ForkAndMergeTestCase: XCTestCase {
     func testForkAndMerge() throws {
         let doc = Document()
-        try doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
 
         let doc2 = doc.fork()
         // verify the forked document has a different ActorId
         XCTAssertNotEqual(doc2.actor, doc.actor)
 
-        try doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("two"))
+        try doc2.put(obj: ObjId.ROOT, key: "key2", value: "two")
 
-        try doc.put(obj: ObjId.ROOT, key: "key3", value: .String("three"))
+        try doc.put(obj: ObjId.ROOT, key: "key3", value: "three")
 
         try doc.merge(other: doc2)
 
-        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("one")))
-        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key2")!, .Scalar(.String("two")))
-        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key3")!, .Scalar(.String("three")))
+        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("one"))
+        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key2")!, .Scalar("two"))
+        XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key3")!, .Scalar("three"))
     }
 
     func testForkAt() throws {
         let doc = Document()
-        try doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
-        try doc.put(obj: ObjId.ROOT, key: "key2", value: .String("two"))
+        try doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
+        try doc.put(obj: ObjId.ROOT, key: "key2", value: "two")
 
         let heads = doc.heads()
 
-        try doc.put(obj: ObjId.ROOT, key: "key2", value: .String("three"))
+        try doc.put(obj: ObjId.ROOT, key: "key2", value: "three")
 
         let forked = try! doc.forkAt(heads: heads)
 
-        XCTAssertEqual(try! forked.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("one")))
-        XCTAssertEqual(try! forked.get(obj: ObjId.ROOT, key: "key2")!, .Scalar(.String("two")))
+        XCTAssertEqual(try! forked.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("one"))
+        XCTAssertEqual(try! forked.get(obj: ObjId.ROOT, key: "key2")!, .Scalar("two"))
     }
 }

--- a/Tests/AutomergeTests/TestGetAll.swift
+++ b/Tests/AutomergeTests/TestGetAll.swift
@@ -4,67 +4,67 @@ import XCTest
 class GetAllTestCase: XCTestCase {
     func testGetAllInMap() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value1")
 
         let doc2 = doc.fork()
-        try! doc2.put(obj: ObjId.ROOT, key: "key", value: .String("value2"))
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value3"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key", value: "value2")
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value3")
 
         try! doc.merge(other: doc2)
 
         let values = try! doc.getAll(obj: ObjId.ROOT, key: "key")
-        XCTAssertEqual(values, Set([.Scalar(.String("value2")), .Scalar(.String("value3"))]))
+        XCTAssertEqual(values, Set([.Scalar("value2"), .Scalar("value3")]))
     }
 
     func testGetAllInList() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
-        try! doc.insert(obj: list, index: 0, value: .String("value1"))
+        try! doc.insert(obj: list, index: 0, value: "value1")
 
         let doc2 = doc.fork()
-        try! doc2.put(obj: list, index: 0, value: .String("value2"))
-        try! doc.put(obj: list, index: 0, value: .String("value3"))
+        try! doc2.put(obj: list, index: 0, value: "value2")
+        try! doc.put(obj: list, index: 0, value: "value3")
 
         try! doc.merge(other: doc2)
 
         let values = try! doc.getAll(obj: list, index: 0)
-        XCTAssertEqual(values, Set([.Scalar(.String("value2")), .Scalar(.String("value3"))]))
+        XCTAssertEqual(values, Set([.Scalar("value2"), .Scalar("value3")]))
     }
 
     func testGetAllAtInMap() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value1")
 
         let doc2 = doc.fork()
-        try! doc2.put(obj: ObjId.ROOT, key: "key", value: .String("value2"))
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value3"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key", value: "value2")
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value3")
 
         try! doc.merge(other: doc2)
 
         let heads = doc.heads()
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value4"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value4")
 
         let values = try! doc.getAllAt(obj: ObjId.ROOT, key: "key", heads: heads)
-        XCTAssertEqual(values, Set([.Scalar(.String("value2")), .Scalar(.String("value3"))]))
+        XCTAssertEqual(values, Set([.Scalar("value2"), .Scalar("value3")]))
     }
 
     func testGetAllAtInList() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
-        try! doc.insert(obj: list, index: 0, value: .String("value1"))
+        try! doc.insert(obj: list, index: 0, value: "value1")
 
         let doc2 = doc.fork()
-        try! doc2.put(obj: list, index: 0, value: .String("value2"))
-        try! doc.put(obj: list, index: 0, value: .String("value3"))
+        try! doc2.put(obj: list, index: 0, value: "value2")
+        try! doc.put(obj: list, index: 0, value: "value3")
 
         try! doc.merge(other: doc2)
 
         let heads = doc.heads()
 
-        try! doc.put(obj: list, index: 0, value: .String("value4"))
+        try! doc.put(obj: list, index: 0, value: "value4")
 
         let values = try! doc.getAllAt(obj: list, index: 0, heads: heads)
-        XCTAssertEqual(values, Set([.Scalar(.String("value2")), .Scalar(.String("value3"))]))
+        XCTAssertEqual(values, Set([.Scalar("value2"), .Scalar("value3")]))
     }
 }

--- a/Tests/AutomergeTests/TestGetAt.swift
+++ b/Tests/AutomergeTests/TestGetAt.swift
@@ -4,27 +4,27 @@ import XCTest
 class GetAtTests: XCTestCase {
     func testGetAtInMap() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "one")
 
         let heads = doc.heads()
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "two")
 
         let result = try! doc.getAt(obj: ObjId.ROOT, key: "key", heads: heads)
-        XCTAssertEqual(result!, .Scalar(.String("one")))
+        XCTAssertEqual(result!, .Scalar("one"))
     }
 
     func testGetAtInList() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
 
-        try! doc.insert(obj: list, index: 0, value: .String("one"))
+        try! doc.insert(obj: list, index: 0, value: "one")
 
         let heads = doc.heads()
 
-        try! doc.put(obj: list, index: 0, value: .String("two"))
+        try! doc.put(obj: list, index: 0, value: "two")
 
         let result = try! doc.getAt(obj: list, index: 0, heads: heads)
-        XCTAssertEqual(result!, .Scalar(.String("one")))
+        XCTAssertEqual(result!, .Scalar("one"))
     }
 }

--- a/Tests/AutomergeTests/TestHistory.swift
+++ b/Tests/AutomergeTests/TestHistory.swift
@@ -4,10 +4,10 @@ import XCTest
 class HistoryTests: XCTestCase {
     func testHeadsDuringChanges() throws {
         let doc = Document()
-        try doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+        try doc.put(obj: ObjId.ROOT, key: "key", value: "one")
         XCTAssertEqual(doc.heads().count, 1)
 
-        try doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        try doc.put(obj: ObjId.ROOT, key: "key", value: "two")
         XCTAssertEqual(doc.heads().count, 1)
 
         let replicaDoc = doc.fork()
@@ -15,8 +15,8 @@ class HistoryTests: XCTestCase {
         XCTAssertEqual(replicaDoc.heads().count, 1)
         XCTAssertEqual(doc.heads(), replicaDoc.heads())
 
-        try doc.put(obj: ObjId.ROOT, key: "newkey", value: .String("beta"))
-        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: .String("alpha"))
+        try doc.put(obj: ObjId.ROOT, key: "newkey", value: "beta")
+        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: "alpha")
         XCTAssertEqual(doc.heads().count, 1)
         XCTAssertEqual(replicaDoc.heads().count, 1)
         XCTAssertNotEqual(doc.heads(), replicaDoc.heads())
@@ -33,22 +33,22 @@ class HistoryTests: XCTestCase {
 
     func testChangeCountsInHeadsAndChanges() throws {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "one")
         XCTAssertEqual(doc.getHistory().count, 1)
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "two")
         XCTAssertEqual(doc.getHistory().count, 2)
 
         let replicaDoc = doc.fork()
         XCTAssertEqual(doc.heads(), replicaDoc.heads())
         XCTAssertEqual(doc.getHistory(), replicaDoc.getHistory())
 
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("three"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "three")
         XCTAssertEqual(doc.getHistory().count, 3)
         XCTAssertEqual(replicaDoc.getHistory().count, 2)
 
-        try doc.put(obj: ObjId.ROOT, key: "newkey", value: .String("beta"))
-        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: .String("alpha"))
+        try doc.put(obj: ObjId.ROOT, key: "newkey", value: "beta")
+        try replicaDoc.put(obj: ObjId.ROOT, key: "newkey", value: "alpha")
         XCTAssertEqual(doc.getHistory().count, 4)
         XCTAssertEqual(replicaDoc.getHistory().count, 3)
 

--- a/Tests/AutomergeTests/TestLength.swift
+++ b/Tests/AutomergeTests/TestLength.swift
@@ -5,8 +5,8 @@ class LengthTestCase: XCTestCase {
     func testLength() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
-        try! doc.insert(obj: list, index: 0, value: .String("one"))
-        try! doc.insert(obj: list, index: 1, value: .String("two"))
+        try! doc.insert(obj: list, index: 0, value: "one")
+        try! doc.insert(obj: list, index: 1, value: "two")
 
         XCTAssertEqual(doc.length(obj: list), 2)
     }
@@ -14,12 +14,12 @@ class LengthTestCase: XCTestCase {
     func testLengthAt() {
         let doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
-        try! doc.insert(obj: list, index: 0, value: .String("one"))
-        try! doc.insert(obj: list, index: 1, value: .String("two"))
+        try! doc.insert(obj: list, index: 0, value: "one")
+        try! doc.insert(obj: list, index: 1, value: "two")
 
         let heads = doc.heads()
 
-        try! doc.insert(obj: list, index: 2, value: .String("three"))
+        try! doc.insert(obj: list, index: 2, value: "three")
 
         XCTAssertEqual(doc.lengthAt(obj: list, heads: heads), 2)
     }

--- a/Tests/AutomergeTests/TestMapEntries.swift
+++ b/Tests/AutomergeTests/TestMapEntries.swift
@@ -4,20 +4,20 @@ import XCTest
 class MapEntriesTests: XCTestCase {
     func testMapEntries() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
         try! doc.put(obj: ObjId.ROOT, key: "key2", value: .Uint(1))
 
         let result = try! doc.mapEntries(obj: ObjId.ROOT)
         XCTAssert(
             result.elementsEqual(
-                [("key1", .Scalar(.String("one"))), ("key2", .Scalar(.Uint(1)))], by: ==
+                [("key1", .Scalar("one")), ("key2", .Scalar(.Uint(1)))], by: ==
             )
         )
     }
 
     func testMapEntriesAt() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
         try! doc.put(obj: ObjId.ROOT, key: "key2", value: .Uint(1))
 
         let heads = doc.heads()
@@ -27,7 +27,7 @@ class MapEntriesTests: XCTestCase {
         let result = try! doc.mapEntriesAt(obj: ObjId.ROOT, heads: heads)
         XCTAssert(
             result.elementsEqual(
-                [("key1", .Scalar(.String("one"))), ("key2", .Scalar(.Uint(1)))], by: ==
+                [("key1", .Scalar("one")), ("key2", .Scalar(.Uint(1)))], by: ==
             )
         )
     }

--- a/Tests/AutomergeTests/TestMapKeys.swift
+++ b/Tests/AutomergeTests/TestMapKeys.swift
@@ -4,8 +4,8 @@ import XCTest
 class MapKeysTests: XCTestCase {
     func testMapKeys() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
-        try! doc.put(obj: ObjId.ROOT, key: "key2", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
+        try! doc.put(obj: ObjId.ROOT, key: "key2", value: "two")
 
         let keys = doc.keys(obj: ObjId.ROOT)
         XCTAssertEqual(keys, ["key1", "key2"])
@@ -13,12 +13,12 @@ class MapKeysTests: XCTestCase {
 
     func testMapKeysAt() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
-        try! doc.put(obj: ObjId.ROOT, key: "key2", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
+        try! doc.put(obj: ObjId.ROOT, key: "key2", value: "two")
 
         let heads = doc.heads()
 
-        try! doc.put(obj: ObjId.ROOT, key: "key3", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key3", value: "two")
         let keys = doc.keysAt(obj: ObjId.ROOT, heads: heads)
         XCTAssertEqual(keys, ["key1", "key2"])
     }

--- a/Tests/AutomergeTests/TestMarks.swift
+++ b/Tests/AutomergeTests/TestMarks.swift
@@ -12,11 +12,11 @@ class MarksTestCase: XCTestCase {
             end: 5,
             expand: ExpandMark.none,
             name: "bold",
-            value: ScalarValue.Boolean(true)
+            value: true
         )
         let marks = try! doc.marks(obj: text)
         let expectedMarks = [
-            Mark(start: 0, end: 5, name: "bold", value: Value.Scalar(ScalarValue.Boolean(true))),
+            Mark(start: 0, end: 5, name: "bold", value: .Scalar(true)),
         ]
         XCTAssertEqual(marks, expectedMarks)
 
@@ -24,7 +24,7 @@ class MarksTestCase: XCTestCase {
         let heads = doc.heads()
 
         // Now remove the mark
-        try! doc.mark(obj: text, start: 0, end: 5, expand: ExpandMark.none, name: "bold", value: ScalarValue.Null)
+        try! doc.mark(obj: text, start: 0, end: 5, expand: ExpandMark.none, name: "bold", value: nil)
         let marksAfterDelete = try! doc.marks(obj: text)
         XCTAssertEqual(marksAfterDelete.count, 0)
 
@@ -46,11 +46,11 @@ class MarksTestCase: XCTestCase {
             end: 5,
             expand: ExpandMark.none,
             name: "bold",
-            value: ScalarValue.Boolean(true)
+            value: true
         )
         let patches = try! doc.mergeWithPatches(other: fork)
         let expectedMarks = [
-            Mark(start: 0, end: 5, name: "bold", value: Value.Scalar(ScalarValue.Boolean(true))),
+            Mark(start: 0, end: 5, name: "bold", value: .Scalar(true)),
         ]
         XCTAssertEqual(patches, [Patch(
             action: .Marks(text, expectedMarks),
@@ -61,7 +61,7 @@ class MarksTestCase: XCTestCase {
         try! fork.spliceText(obj: text, start: 4, delete: 0, value: "oo")
         let patchesAfterSplice = try! doc.mergeWithPatches(other: fork)
         XCTAssertEqual(patchesAfterSplice, [Patch(
-            action: .SpliceText(obj: text, index: 4, value: "oo", marks: ["bold": .Scalar(.Boolean(true))]),
+            action: .SpliceText(obj: text, index: 4, value: "oo", marks: ["bold": .Scalar(true)]),
             path: [PathElement(obj: ObjId.ROOT, prop: .Key("text"))]
         )])
     }

--- a/Tests/AutomergeTests/TestPatches.swift
+++ b/Tests/AutomergeTests/TestPatches.swift
@@ -10,10 +10,10 @@ extension Data {
 class PatchesTestCase: XCTestCase {
     func testMergeReturningPatches() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value1")
 
         let doc2 = doc.fork()
-        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: "value2")
 
         let patches = try! doc.mergeWithPatches(other: doc2)
 
@@ -21,7 +21,7 @@ class PatchesTestCase: XCTestCase {
             patches,
             [
                 Patch(
-                    action: .Put(ObjId.ROOT, .Key("key2"), .Scalar(.String("value2"))),
+                    action: .Put(ObjId.ROOT, .Key("key2"), .Scalar("value2")),
                     path: []
                 ),
             ]
@@ -30,7 +30,7 @@ class PatchesTestCase: XCTestCase {
 
     func testReceiveSyncMessageWithPatches() throws {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value1")
 
         // create a second, identical, document
         let doc2 = doc.fork()
@@ -46,7 +46,7 @@ class PatchesTestCase: XCTestCase {
 
         let msg_before_update = doc2.generateSyncMessage(state: state2)
 
-        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: "value2")
         // now generate the message
         let optional_msg = doc2.generateSyncMessage(state: state2)
         XCTAssertNotEqual(msg_before_update, optional_msg)
@@ -70,7 +70,7 @@ class PatchesTestCase: XCTestCase {
                 patches,
                 [
                     Patch(
-                        action: .Put(ObjId.ROOT, .Key("key2"), .Scalar(.String("value2"))),
+                        action: .Put(ObjId.ROOT, .Key("key2"), .Scalar("value2")),
                         path: []
                     ),
                 ]
@@ -80,12 +80,12 @@ class PatchesTestCase: XCTestCase {
 
     func testApplyEncodedChangesWithPatches() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key", value: .String("value1"))
+        try! doc.put(obj: ObjId.ROOT, key: "key", value: "value1")
 
         let doc2 = doc.fork()
         let heads = doc2.heads()
 
-        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: "value2")
         let encoded = try! doc2.encodeChangesSince(heads: heads)
 
         let patches = try! doc.applyEncodedChangesWithPatches(encoded: encoded)
@@ -94,7 +94,7 @@ class PatchesTestCase: XCTestCase {
             patches,
             [
                 Patch(
-                    action: .Put(ObjId.ROOT, .Key("key2"), .Scalar(.String("value2"))),
+                    action: .Put(ObjId.ROOT, .Key("key2"), .Scalar("value2")),
                     path: []
                 ),
             ]

--- a/Tests/AutomergeTests/TestScalarValueConversions.swift
+++ b/Tests/AutomergeTests/TestScalarValueConversions.swift
@@ -3,23 +3,23 @@ import XCTest
 
 class TestScalarValueConversions: XCTestCase {
     func testScalarBooleanConversion() throws {
-        let initial: Value = .Scalar(.Boolean(true))
+        let initial: Value = .Scalar(true)
         let converted: Bool = try Bool.fromValue(initial).get()
         XCTAssertEqual(true, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try Bool.fromValue(.Scalar(1)).get())
 
-        XCTAssertEqual(true.toScalarValue(), ScalarValue.Boolean(true))
+        XCTAssertEqual(true.toScalarValue(), true)
     }
 
     func testScalarStringConversion() throws {
-        let initial: Value = .Scalar(.String("hello"))
+        let initial: Value = .Scalar("hello")
         let converted: String = try String.fromValue(initial).get()
         XCTAssertEqual("hello", converted)
 
-        XCTAssertThrowsError(try String.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try String.fromValue(.Scalar(1)).get())
 
-        XCTAssertEqual("hello".toScalarValue(), ScalarValue.String("hello"))
+        XCTAssertEqual("hello".toScalarValue(), "hello")
     }
 
     func testScalarBytesConversion() throws {
@@ -29,7 +29,7 @@ class TestScalarValueConversions: XCTestCase {
         let converted: Data = try Data.fromValue(initial).get()
         XCTAssertEqual(myData, converted)
 
-        XCTAssertThrowsError(try Data.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try Data.fromValue(.Scalar(1)).get())
 
         XCTAssertEqual(myData.toScalarValue(), ScalarValue.Bytes(myData))
     }
@@ -39,20 +39,20 @@ class TestScalarValueConversions: XCTestCase {
         let converted: UInt = try UInt.fromValue(initial).get()
         XCTAssertEqual(5, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try Bool.fromValue(.Scalar(1)).get())
 
         let explicitUInt: UInt = 5
         XCTAssertEqual(explicitUInt.toScalarValue(), ScalarValue.Uint(5))
     }
 
     func testScalarIntConversion() throws {
-        let initial: Value = .Scalar(.Int(5))
+        let initial: Value = .Scalar(5)
         let converted: Int = try Int.fromValue(initial).get()
         XCTAssertEqual(5, converted)
 
         XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Uint(1))).get())
 
-        XCTAssertEqual(5.toScalarValue(), ScalarValue.Int(5))
+        XCTAssertEqual(5.toScalarValue(), 5)
     }
 
     func testScalarDoubleConversion() throws {

--- a/Tests/AutomergeTests/TestSync.swift
+++ b/Tests/AutomergeTests/TestSync.swift
@@ -11,14 +11,14 @@ class SyncTests: XCTestCase {
         trackForMemoryLeak(instance: doc2)
         let syncState2 = SyncState()
 
-        try! doc1.put(obj: ObjId.ROOT, key: "key1", value: .String("value1"))
-        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
+        try! doc1.put(obj: ObjId.ROOT, key: "key1", value: "value1")
+        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: "value2")
 
         sync(doc1, syncState1, doc2, syncState2)
 
         for doc in [doc1, doc2] {
-            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("value1")))
-            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key2")!, .Scalar(.String("value2")))
+            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key1")!, .Scalar("value1"))
+            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key2")!, .Scalar("value2"))
         }
 
         XCTAssertNotNil(syncState1.theirHeads)

--- a/Tests/AutomergeTests/TestValues.swift
+++ b/Tests/AutomergeTests/TestValues.swift
@@ -4,26 +4,26 @@ import XCTest
 class ValuesTestCase: XCTestCase {
     func testValues() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
 
         XCTAssertEqual(
-            try! doc.values(obj: ObjId.ROOT), [.Scalar(.String("one")), .Object(list, .List)]
+            try! doc.values(obj: ObjId.ROOT), [.Scalar("one"), .Object(list, .List)]
         )
     }
 
     func testValuesAt() {
         let doc = Document()
-        try! doc.put(obj: ObjId.ROOT, key: "key1", value: .String("one"))
+        try! doc.put(obj: ObjId.ROOT, key: "key1", value: "one")
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)
 
         let heads = doc.heads()
 
-        try! doc.put(obj: ObjId.ROOT, key: "key2", value: .String("two"))
+        try! doc.put(obj: ObjId.ROOT, key: "key2", value: "two")
 
         XCTAssertEqual(
             try! doc.valuesAt(obj: ObjId.ROOT, heads: heads),
-            [.Scalar(.String("one")), .Object(list, .List)]
+            [.Scalar("one"), .Object(list, .List)]
         )
     }
 }


### PR DESCRIPTION
Not sure if you like this. By implementing the ExpressibleBy we can get rid of a lot of explicit boilerplate code. Tests get much more easy to read and write. Most application code won't get any better because it relies on dynamic behavior.

. Some prefer to  to write the following:
 `let value: Value = Value.Scalar.String("string")`

I would prefer the following:
`let value: Value = "string"`

Most application code:
`let value: Value = .Scalar(.String(someDynamicVariable))`

What do you think?