### PR TITLE
Improve Semantic of ScalarValueRepresentable

### DIFF
--- a/Sources/Automerge/ScalarValueRepresentable.swift
+++ b/Sources/Automerge/ScalarValueRepresentable.swift
@@ -25,16 +25,6 @@ public protocol ScalarValueRepresentable {
     associatedtype ConvertError: LocalizedError
 
     /// Converts the Automerge representation to a local type, or returns a failure.
-    /// - Parameter val: The Automerge ``Value`` to be converted as a scalar value into a local type.
-    /// - Returns: The type, converted to a local type, or an error indicating the reason for the failure to convert.
-    ///
-    /// The protocol accepts defines a function to accept a ``Value`` primarily for convenience.
-    /// ``Value`` is a higher level enumeration that also includes object types such as ``ObjType/List``,
-    /// ``ObjType/Map``,
-    /// and ``ObjType/Text``.
-    static func fromValue(_ val: Value) -> Result<Self, ConvertError>
-
-    /// Converts the Automerge representation to a local type, or returns a failure.
     /// - Parameter val: The Automerge ``ScalarValue`` to be converted into a local type.
     /// - Returns: The local type, or an error indicating the reason for the failure to convert.
     static func fromScalarValue(_ val: ScalarValue) -> Result<Self, ConvertError>
@@ -48,14 +38,11 @@ public protocol ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a Boolean representation.
 public enum BooleanScalarConversionError: LocalizedError {
-    case notboolValue(_ val: Value)
     case notboolScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notboolValue(val):
-            return "Failed to read the value \(val) as a Boolean."
         case let .notboolScalarValue(val):
             return "Failed to read the scalar value \(val) as a Boolean."
         }
@@ -66,23 +53,13 @@ public enum BooleanScalarConversionError: LocalizedError {
 }
 
 extension Bool: ScalarValueRepresentable {
-    public typealias ConvertError = BooleanScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Self, BooleanScalarConversionError> {
-        switch val {
-        case let .Scalar(.Boolean(b)):
-            return .success(b)
-        default:
-            return .failure(BooleanScalarConversionError.notboolValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Bool, BooleanScalarConversionError> {
         switch val {
         case let .Boolean(b):
             return .success(b)
         default:
-            return .failure(BooleanScalarConversionError.notboolScalarValue(val))
+            return .failure(.notboolScalarValue(val))
         }
     }
 
@@ -95,7 +72,6 @@ extension Bool: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a Boolean representation.
 public enum URLScalarConversionError: LocalizedError {
-    case notStringValue(_ val: Value)
     case notStringScalarValue(_ val: ScalarValue)
     case notMatchingURLScheme(String)
 
@@ -104,8 +80,6 @@ public enum URLScalarConversionError: LocalizedError {
         switch self {
         case .notStringScalarValue(let scalarValue):
             return "Failed to read the scalar value \(scalarValue) as a String before converting to URL."
-        case .notStringValue(let value):
-            return "Failed to read the value \(value) as a String before converting to URL."
         case .notMatchingURLScheme(let string):
             return "Failed to convert the string \(string) to URL."
         }
@@ -116,18 +90,6 @@ public enum URLScalarConversionError: LocalizedError {
 }
 
 extension URL: ScalarValueRepresentable {
-
-    public static func fromValue(_ value: Value) -> Result<Self, URLScalarConversionError> {
-        if case .Scalar(.String(let urlString)) = value {
-            if let url = URL(string: urlString) {
-                return .success(url)
-            } else {
-                return .failure(.notMatchingURLScheme(urlString))
-            }
-        } else {
-            return .failure(.notStringValue(value))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<URL, URLScalarConversionError> {
         switch val {
@@ -152,14 +114,11 @@ extension URL: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a String representation.
 public enum StringScalarConversionError: LocalizedError {
-    case notstringValue(_ val: Value)
     case notstringScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notstringValue(val):
-            return "Failed to read the value \(val) as a String."
         case let .notstringScalarValue(val):
             return "Failed to read the scalar value \(val) as a String."
         }
@@ -170,23 +129,13 @@ public enum StringScalarConversionError: LocalizedError {
 }
 
 extension String: ScalarValueRepresentable {
-    public typealias ConvertError = StringScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<String, StringScalarConversionError> {
-        switch val {
-        case let .Scalar(.String(s)):
-            return .success(s)
-        default:
-            return .failure(StringScalarConversionError.notstringValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<String, StringScalarConversionError> {
         switch val {
         case let .String(s):
             return .success(s)
         default:
-            return .failure(StringScalarConversionError.notstringScalarValue(val))
+            return .failure(.notstringScalarValue(val))
         }
     }
 
@@ -199,14 +148,11 @@ extension String: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a byte representation.
 public enum BytesScalarConversionError: LocalizedError {
-    case notbytesValue(_ val: Value)
     case notbytesScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notbytesValue(val):
-            return "Failed to read the value \(val) as a bytes."
         case let .notbytesScalarValue(val):
             return "Failed to read the scalar value \(val) as a bytes."
         }
@@ -217,16 +163,6 @@ public enum BytesScalarConversionError: LocalizedError {
 }
 
 extension Data: ScalarValueRepresentable {
-    public typealias ConvertError = BytesScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Data, BytesScalarConversionError> {
-        switch val {
-        case let .Scalar(.Bytes(d)):
-            return .success(d)
-        default:
-            return .failure(BytesScalarConversionError.notbytesValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Data, BytesScalarConversionError> {
         switch val {
@@ -246,14 +182,11 @@ extension Data: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from an unsigned integer representation.
 public enum UIntScalarConversionError: LocalizedError {
-    case notUIntValue(_ val: Value)
     case notUIntScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notUIntValue(val):
-            return "Failed to read the value \(val) as an unsigned integer."
         case let .notUIntScalarValue(val):
             return "Failed to read the scalar value \(val) as an unsigned integer."
         }
@@ -264,16 +197,6 @@ public enum UIntScalarConversionError: LocalizedError {
 }
 
 extension UInt: ScalarValueRepresentable {
-    public typealias ConvertError = UIntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<UInt, UIntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Uint(d)):
-            return .success(UInt(d))
-        default:
-            return .failure(UIntScalarConversionError.notUIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt, UIntScalarConversionError> {
         switch val {
@@ -293,14 +216,11 @@ extension UInt: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a signed integer representation.
 public enum IntScalarConversionError: LocalizedError {
-    case notIntValue(_ val: Value)
     case notIntScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notIntValue(val):
-            return "Failed to read the value \(val) as a signed integer."
         case let .notIntScalarValue(val):
             return "Failed to read the scalar value \(val) as a signed integer."
         }
@@ -311,16 +231,6 @@ public enum IntScalarConversionError: LocalizedError {
 }
 
 extension Int: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Int, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(Int(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Int, IntScalarConversionError> {
         switch val {
@@ -337,16 +247,6 @@ extension Int: ScalarValueRepresentable {
 }
 
 extension Int8: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Int8, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(Int8(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Int8, IntScalarConversionError> {
         switch val {
@@ -363,16 +263,6 @@ extension Int8: ScalarValueRepresentable {
 }
 
 extension Int16: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Int16, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(Int16(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Int16, IntScalarConversionError> {
         switch val {
@@ -389,16 +279,6 @@ extension Int16: ScalarValueRepresentable {
 }
 
 extension Int32: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Int32, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(Int32(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Int32, IntScalarConversionError> {
         switch val {
@@ -415,16 +295,6 @@ extension Int32: ScalarValueRepresentable {
 }
 
 extension Int64: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Int64, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(Int64(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Int64, IntScalarConversionError> {
         switch val {
@@ -443,16 +313,6 @@ extension Int64: ScalarValueRepresentable {
 // MARK: UInt types
 
 extension UInt8: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<UInt8, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Uint(d)):
-            return .success(UInt8(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt8, IntScalarConversionError> {
         switch val {
@@ -469,16 +329,6 @@ extension UInt8: ScalarValueRepresentable {
 }
 
 extension UInt16: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<UInt16, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Uint(d)):
-            return .success(UInt16(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt16, IntScalarConversionError> {
         switch val {
@@ -495,16 +345,6 @@ extension UInt16: ScalarValueRepresentable {
 }
 
 extension UInt32: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<UInt32, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Uint(d)):
-            return .success(UInt32(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt32, IntScalarConversionError> {
         switch val {
@@ -521,16 +361,6 @@ extension UInt32: ScalarValueRepresentable {
 }
 
 extension UInt64: ScalarValueRepresentable {
-    public typealias ConvertError = IntScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<UInt64, IntScalarConversionError> {
-        switch val {
-        case let .Scalar(.Int(d)):
-            return .success(UInt64(d))
-        default:
-            return .failure(IntScalarConversionError.notIntValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<UInt64, IntScalarConversionError> {
         switch val {
@@ -550,14 +380,11 @@ extension UInt64: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a 64-bit floating-point value representation.
 public enum FloatingPointScalarConversionError: LocalizedError {
-    case notF64Value(_ val: Value)
     case notF64ScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notF64Value(val):
-            return "Failed to read the value \(val) as a 64-bit floating-point value."
         case let .notF64ScalarValue(val):
             return "Failed to read the scalar value \(val) as a 64-bit floating-point value."
         }
@@ -569,15 +396,6 @@ public enum FloatingPointScalarConversionError: LocalizedError {
 
 extension Double: ScalarValueRepresentable {
     public typealias ConvertError = FloatingPointScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Double, FloatingPointScalarConversionError> {
-        switch val {
-        case let .Scalar(.F64(d)):
-            return .success(Double(d))
-        default:
-            return .failure(FloatingPointScalarConversionError.notF64Value(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Double, FloatingPointScalarConversionError> {
         switch val {
@@ -595,15 +413,6 @@ extension Double: ScalarValueRepresentable {
 
 extension Float: ScalarValueRepresentable {
     public typealias ConvertError = FloatingPointScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Float, FloatingPointScalarConversionError> {
-        switch val {
-        case let .Scalar(.F64(d)):
-            return .success(Float(d))
-        default:
-            return .failure(FloatingPointScalarConversionError.notF64Value(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Float, FloatingPointScalarConversionError> {
         switch val {
@@ -623,14 +432,11 @@ extension Float: ScalarValueRepresentable {
 
 /// A failure to convert an Automerge scalar value to or from a timestamp representation.
 public enum TimestampScalarConversionError: LocalizedError {
-    case notTimetampValue(_ val: Value)
     case notTimetampScalarValue(_ val: ScalarValue)
 
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
-        case let .notTimetampValue(val):
-            return "Failed to read the value \(val) as a timestamp value."
         case let .notTimetampScalarValue(val):
             return "Failed to read the scalar value \(val) as a timestamp value."
         }
@@ -641,16 +447,6 @@ public enum TimestampScalarConversionError: LocalizedError {
 }
 
 extension Date: ScalarValueRepresentable {
-    public typealias ConvertError = TimestampScalarConversionError
-
-    public static func fromValue(_ val: Value) -> Result<Date, TimestampScalarConversionError> {
-        switch val {
-        case let .Scalar(.Timestamp(d)):
-            return .success(Date(timeIntervalSince1970: TimeInterval(d)))
-        default:
-            return .failure(TimestampScalarConversionError.notTimetampValue(val))
-        }
-    }
 
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Date, TimestampScalarConversionError> {
         switch val {

--- a/Tests/AutomergeTests/TestScalarValueConversions.swift
+++ b/Tests/AutomergeTests/TestScalarValueConversions.swift
@@ -3,77 +3,77 @@ import XCTest
 
 class TestScalarValueConversions: XCTestCase {
     func testScalarBooleanConversion() throws {
-        let initial: Value = .Scalar(.Boolean(true))
-        let converted: Bool = try Bool.fromValue(initial).get()
+        let initial: ScalarValue = .Boolean(true)
+        let converted: Bool = try Bool.fromScalarValue(initial).get()
         XCTAssertEqual(true, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try Bool.fromScalarValue(.Int(1)).get())
 
-        XCTAssertEqual(true.toScalarValue(), ScalarValue.Boolean(true))
+        XCTAssertEqual(true.toScalarValue(), .Boolean(true))
     }
 
     func testScalarStringConversion() throws {
-        let initial: Value = .Scalar(.String("hello"))
-        let converted: String = try String.fromValue(initial).get()
+        let initial: ScalarValue = .String("hello")
+        let converted: String = try String.fromScalarValue(initial).get()
         XCTAssertEqual("hello", converted)
 
-        XCTAssertThrowsError(try String.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try String.fromScalarValue(.Int(1)).get())
 
-        XCTAssertEqual("hello".toScalarValue(), ScalarValue.String("hello"))
+        XCTAssertEqual("hello".toScalarValue(), .String("hello"))
     }
 
     func testScalarBytesConversion() throws {
         let myData = "Hello There!".data(using: .utf8)!
 
-        let initial: Value = .Scalar(.Bytes(myData))
-        let converted: Data = try Data.fromValue(initial).get()
+        let initial: ScalarValue = .Bytes(myData)
+        let converted: Data = try Data.fromScalarValue(initial).get()
         XCTAssertEqual(myData, converted)
 
-        XCTAssertThrowsError(try Data.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try Data.fromScalarValue(.Int(1)).get())
 
         XCTAssertEqual(myData.toScalarValue(), ScalarValue.Bytes(myData))
     }
 
     func testScalarUIntConversion() throws {
-        let initial: Value = .Scalar(.Uint(5))
-        let converted: UInt = try UInt.fromValue(initial).get()
+        let initial: ScalarValue = .Uint(5)
+        let converted: UInt = try UInt.fromScalarValue(initial).get()
         XCTAssertEqual(5, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Int(1))).get())
+        XCTAssertThrowsError(try UInt.fromScalarValue(.String("1")).get())
 
         let explicitUInt: UInt = 5
         XCTAssertEqual(explicitUInt.toScalarValue(), ScalarValue.Uint(5))
     }
 
     func testScalarIntConversion() throws {
-        let initial: Value = .Scalar(.Int(5))
-        let converted: Int = try Int.fromValue(initial).get()
+        let initial: ScalarValue = .Int(5)
+        let converted: Int = try Int.fromScalarValue(initial).get()
         XCTAssertEqual(5, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Uint(1))).get())
+        XCTAssertThrowsError(try Int.fromScalarValue(.String("1")).get())
 
-        XCTAssertEqual(5.toScalarValue(), ScalarValue.Int(5))
+        XCTAssertEqual(5.toScalarValue(), .Int(5))
     }
 
     func testScalarDoubleConversion() throws {
-        let initial: Value = .Scalar(.F64(5))
-        let converted: Double = try Double.fromValue(initial).get()
+        let initial: ScalarValue = .F64(5)
+        let converted: Double = try Double.fromScalarValue(initial).get()
         XCTAssertEqual(5.0, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Uint(1))).get())
+        XCTAssertThrowsError(try Double.fromScalarValue(.String("1")).get())
 
-        XCTAssertEqual(5.0.toScalarValue(), ScalarValue.F64(5))
+        XCTAssertEqual(5.0.toScalarValue(), .F64(5))
     }
 
     func testScalarTimestampConversion() throws {
         let myDate = Date(timeIntervalSince1970: 1679517444)
 
-        let initial: Value = .Scalar(.Timestamp(1679517444))
-        let converted: Date = try Date.fromValue(initial).get()
+        let initial: ScalarValue = .Timestamp(1679517444)
+        let converted: Date = try Date.fromScalarValue(initial).get()
         XCTAssertEqual(myDate, converted)
 
-        XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Uint(1))).get())
+        XCTAssertThrowsError(try Date.fromScalarValue(.String("1")).get())
 
-        XCTAssertEqual(myDate.toScalarValue(), ScalarValue.Timestamp(1679517444))
+        XCTAssertEqual(myDate.toScalarValue(), .Timestamp(1679517444))
     }
 }


### PR DESCRIPTION
As the name describes ScalarValueRepresentable is all about Scalars, so I removed the value stuff. 