### PR TITLE
Use millisecond semantic to match automerge-core

### DIFF
--- a/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
@@ -129,8 +129,8 @@ struct AutomergeKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProt
         switch T.self {
         case is Date.Type:
             let retrievedValue = try getValue(forKey: key)
-            if case let Value.Scalar(.Timestamp(intValue)) = retrievedValue {
-                return Date(timeIntervalSince1970: Double(intValue)) as! T
+            if case let Value.Scalar(.Timestamp(date)) = retrievedValue {
+                return date as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeSingleValueDecodingContainer.swift
@@ -139,8 +139,8 @@ struct AutomergeSingleValueDecodingContainer: SingleValueDecodingContainer {
     func decode<T>(_: T.Type) throws -> T where T: Decodable {
         switch T.self {
         case is Date.Type:
-            if case let .Scalar(.Timestamp(intValue)) = value {
-                return Date(timeIntervalSince1970: Double(intValue)) as! T
+            if case let .Scalar(.Timestamp(date)) = value {
+                return date as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeUnkeyedDecodingContainer.swift
@@ -121,9 +121,9 @@ struct AutomergeUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         switch T.self {
         case is Date.Type:
             let retrievedValue = try getNextValue(ofType: Date.self)
-            if case let Value.Scalar(.Timestamp(intValue)) = retrievedValue {
+            if case let Value.Scalar(.Timestamp(date)) = retrievedValue {
                 currentIndex += 1
-                return Date(timeIntervalSince1970: Double(intValue)) as! T
+                return date as! T
             } else {
                 throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: codingPath,

--- a/Sources/Automerge/ScalarValue.swift
+++ b/Sources/Automerge/ScalarValue.swift
@@ -17,7 +17,7 @@ public enum ScalarValue: Equatable, Hashable, Sendable {
     case F64(Double)
     /// An integer counter.
     case Counter(Int64)
-    /// A 64-bit signed integer representing milliseconds since the unix epoch
+    /// A 64-bit signed integer that represents the number of milliseconds since the UNIX epoch.
     case Timestamp(Date)
     /// A Boolean value.
     case Boolean(Bool)

--- a/Sources/Automerge/ScalarValue.swift
+++ b/Sources/Automerge/ScalarValue.swift
@@ -17,8 +17,8 @@ public enum ScalarValue: Equatable, Hashable, Sendable {
     case F64(Double)
     /// An integer counter.
     case Counter(Int64)
-    /// A timestamp represented by the number of seconds since UNIX epoch (Jan 1st, 1970, 00:00 UTC).
-    case Timestamp(Int64)
+    /// A 64-bit signed integer representing milliseconds since the unix epoch
+    case Timestamp(Date)
     /// A Boolean value.
     case Boolean(Bool)
     /// An unknown, raw scalar type.
@@ -42,8 +42,8 @@ public enum ScalarValue: Equatable, Hashable, Sendable {
             return .f64(value: d)
         case let .Counter(i):
             return .counter(value: i)
-        case let .Timestamp(i):
-            return .timestamp(value: i)
+        case let .Timestamp(date):
+            return .timestamp(value: Int64(date.timeIntervalSince1970 * 1000))
         case let .Boolean(v):
             return .boolean(value: v)
         case let .Unknown(t, d):
@@ -68,7 +68,7 @@ public enum ScalarValue: Equatable, Hashable, Sendable {
         case let .counter(value):
             return .Counter(value)
         case let .timestamp(value):
-            return .Timestamp(value)
+            return .Timestamp(Date(timeIntervalSince1970: Double(value) / 1000))
         case let .boolean(value):
             return .Boolean(value)
         case let .unknown(typeCode, data):

--- a/Sources/Automerge/ScalarValueRepresentable.swift
+++ b/Sources/Automerge/ScalarValueRepresentable.swift
@@ -646,7 +646,7 @@ extension Date: ScalarValueRepresentable {
     public static func fromValue(_ val: Value) -> Result<Date, TimestampScalarConversionError> {
         switch val {
         case let .Scalar(.Timestamp(d)):
-            return .success(Date(timeIntervalSince1970: TimeInterval(d)))
+            return .success(d)
         default:
             return .failure(TimestampScalarConversionError.notTimetampValue(val))
         }
@@ -655,13 +655,13 @@ extension Date: ScalarValueRepresentable {
     public static func fromScalarValue(_ val: ScalarValue) -> Result<Date, TimestampScalarConversionError> {
         switch val {
         case let .Timestamp(d):
-            return .success(Date(timeIntervalSince1970: TimeInterval(d)))
+            return .success(d)
         default:
             return .failure(TimestampScalarConversionError.notTimetampScalarValue(val))
         }
     }
 
     public func toScalarValue() -> ScalarValue {
-        .Timestamp(Int64(timeIntervalSince1970))
+        .Timestamp(self)
     }
 }

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -15,7 +15,7 @@ final class AutomergeDecoderTests: XCTestCase {
         try! doc.put(obj: ObjId.ROOT, key: "count", value: .Int(5))
         try! doc.put(obj: ObjId.ROOT, key: "uuid", value: .String("99CEBB16-1062-4F21-8837-CF18EC09DCD7"))
         try! doc.put(obj: ObjId.ROOT, key: "url", value: .String("http://url.com"))
-        try! doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
+        try! doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(Date(timeIntervalSince1970: 0)))
         try! doc.put(obj: ObjId.ROOT, key: "data", value: .Bytes(Data("hello".utf8)))
 
         let text = try! doc.putObject(obj: ObjId.ROOT, key: "notes", ty: .Text)
@@ -66,8 +66,7 @@ final class AutomergeDecoderTests: XCTestCase {
         let expectedUUID = UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!
         XCTAssertEqual(decodedStruct.uuid, expectedUUID)
 
-        let dateFormatter = ISO8601DateFormatter()
-        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
+        let earlyDate = Date(timeIntervalSince1970: 0)
         XCTAssertEqual(earlyDate, decodedStruct.date)
         XCTAssertEqual(Data("hello".utf8), decodedStruct.data)
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeEncoderTests.swift
@@ -33,15 +33,13 @@ final class AutomergeEncoderTests: XCTestCase {
         }
         let automergeEncoder = AutomergeEncoder(doc: doc)
 
-        let dateFormatter = ISO8601DateFormatter()
-        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
 
         let sample = SimpleStruct(
             name: "henry",
             duration: 3.14159,
             flag: true,
             count: 5,
-            date: earlyDate,
+            date: Date(timeIntervalSince1970: 0),
             data: Data("hello".utf8),
             uuid: UUID(uuidString: "99CEBB16-1062-4F21-8837-CF18EC09DCD7")!,
             url: URL(string: "http://url.com")!,
@@ -75,7 +73,7 @@ final class AutomergeEncoderTests: XCTestCase {
         }
 
         if case let .Scalar(.Timestamp(timestamp_value)) = try doc.get(obj: ObjId.ROOT, key: "date") {
-            XCTAssertEqual(timestamp_value, -905182980)
+            XCTAssertEqual(timestamp_value, Date(timeIntervalSince1970: 0))
         } else {
             try XCTFail("Didn't find: \(String(describing: doc.get(obj: ObjId.ROOT, key: "date")))")
         }

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -197,12 +197,11 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
     }
 
     func testSimpleKeyEncode_Date() throws {
-        let dateFormatter = ISO8601DateFormatter()
-        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
+        let earlyDate = Date(timeIntervalSince1970: 0)
         try singleValueContainer.encode(earlyDate)
-        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(-905182980)))
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Timestamp(Date(timeIntervalSince1970: 0))))
 
-        let anotherDate = dateFormatter.date(from: "1942-04-26T08:17:00Z")!
+        let anotherDate = Date(timeIntervalSince1970: 10)
         try cautiousSingleValueContainer.encode(anotherDate)
     }
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -82,9 +82,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
-        let dateFormatter = ISO8601DateFormatter()
-        let earlyDate = dateFormatter.date(from: "1941-04-26T08:17:00Z")!
-        try doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(-905182980))
+        let earlyDate = Date(timeIntervalSince1970: 0)
+        try doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(earlyDate))
 
         let automergeDecoder = AutomergeDecoder(doc: doc)
         let decodedDate = try automergeDecoder.decode(Date.self, from: [AnyCodingKey("date")])

--- a/Tests/AutomergeTests/TestScalarValueConversions.swift
+++ b/Tests/AutomergeTests/TestScalarValueConversions.swift
@@ -68,12 +68,12 @@ class TestScalarValueConversions: XCTestCase {
     func testScalarTimestampConversion() throws {
         let myDate = Date(timeIntervalSince1970: 1679517444)
 
-        let initial: Value = .Scalar(.Timestamp(1679517444))
+        let initial: Value = .Scalar(.Timestamp(myDate))
         let converted: Date = try Date.fromValue(initial).get()
         XCTAssertEqual(myDate, converted)
 
         XCTAssertThrowsError(try Bool.fromValue(.Scalar(.Uint(1))).get())
 
-        XCTAssertEqual(myDate.toScalarValue(), ScalarValue.Timestamp(1679517444))
+        XCTAssertEqual(myDate.toScalarValue(), .Timestamp(myDate))
     }
 }


### PR DESCRIPTION
This changes timestamp to use milliseconds as documented [here](https://automerge.org/automerge-binary-format-spec/#_value) and discussed in #139 . Date is now used to represent a timestamp, to prevent mistakes when encoding/decoding. Converting Date to FFI representation is now in a single file 