### PR TITLE
minor re-org on documentation

### DIFF
--- a/Sources/AutomergeUtilities/AutomergeUtilities.docc/AutomergeUtilities.md
+++ b/Sources/AutomergeUtilities/AutomergeUtilities.docc/AutomergeUtilities.md
@@ -8,12 +8,19 @@ Automerge Utilities extends Automerge's `Document` type to make it easier to par
 
 ## Topics
 
-### Walking and Parsing Automerge documents
+### Inspecting Automerge documents
 
 - ``Automerge/Document/isEmpty()``
-- ``Automerge/Document/parseToSchema(_:from:)``
 - ``Automerge/Document/schema()``
 - ``AutomergeUtilities/AutomergeValue``
+
+### Parsing the contents of an Automerge document
+
+- ``Automerge/Document/parseToSchema(_:from:)``
+
+### Comparing the contents of Automerge documents
+
+- ``Automerge/Document/equivalentContents(_:)``
 
 ### Debugging Methods
 

--- a/Sources/AutomergeUtilities/Document+equivalentContents.swift
+++ b/Sources/AutomergeUtilities/Document+equivalentContents.swift
@@ -1,0 +1,14 @@
+import Automerge
+
+public extension Document {
+    /// Returns a Boolean value that indicates whether the latest contents another document are equivalent.
+    func equivalentContents(_ anotherDoc: Document) -> Bool {
+        do {
+            let doc1Contents = try self.parseToSchema(self, from: .ROOT)
+            let doc2Contents = try anotherDoc.parseToSchema(anotherDoc, from: .ROOT)
+            return doc1Contents == doc2Contents
+        } catch {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
adding a method to AutomergeUtilities that can be used to compare the latest version of two Automerge documents for equivalency.
