### PR TITLE
adds binding of Automerge text on any invocation of encode

### DIFF
--- a/Sources/Automerge/Codable/AutomergeText.swift
+++ b/Sources/Automerge/Codable/AutomergeText.swift
@@ -78,7 +78,7 @@ public final class AutomergeText: Codable {
         doc != nil && objId != nil
     }
 
-    /// Binds a text reference instance info an Automerge document.
+    /// Binds a text reference instance info an Automerge document with the schema path you provide.
     ///
     /// If the instance has an initial value other than an empty string, binding update the string within the Automerge
     /// document.
@@ -92,6 +92,26 @@ public final class AutomergeText: Codable {
         if doc.objectType(obj: objId) == .Text {
             self.doc = doc
             self.objId = objId
+        } else {
+            throw BindingError.NotText
+        }
+        if !_unboundStorage.isEmpty {
+            try updateText(newText: _unboundStorage)
+            _unboundStorage = ""
+        }
+    }
+
+    /// Binds a text reference instance info an Automerge document at the object ID you provide.
+    ///
+    /// If the instance has an initial value other than an empty string, binding update the string within the Automerge
+    /// document.
+    /// - Parameters:
+    ///   - doc: The Automerge document associated with this reference.
+    ///   - path: A string path that represents a `Text` container within the Automerge document.
+    public func bind(doc: Document, id: ObjId) throws {
+        if doc.objectType(obj: id) == .Text {
+            self.doc = doc
+            objId = id
         } else {
             throw BindingError.NotText
         }
@@ -141,7 +161,7 @@ public final class AutomergeText: Codable {
 
     // MARK: Codable conformance
 
-    private enum CodingKeys: String, CodingKey {
+    public enum CodingKeys: String, CodingKey {
         case value
     }
 

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoder.swift
@@ -16,12 +16,23 @@ public struct AutomergeDecoder {
     /// Returns the type you specify, decoded from the Automerge document referenced by the decoder.
     /// - Parameter _: _ The type of the value to decode from the Automerge document.
     @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
-        let decoder = AutomergeDecoderImpl(
-            doc: doc,
-            userInfo: userInfo,
-            codingPath: []
-        )
-        return try decoder.decode(T.self)
+        if T.self == AutomergeText.self {
+            // Special case decoding AutomergeText - when it's the top level type being encoded,
+            // its content is placed as a keyed encoded location by the AutomergeEncoder
+            let decoder = AutomergeDecoderImpl(
+                doc: doc,
+                userInfo: userInfo,
+                codingPath: [AutomergeText.CodingKeys.value]
+            )
+            return try decoder.decode(T.self)
+        } else {
+            let decoder = AutomergeDecoderImpl(
+                doc: doc,
+                userInfo: userInfo,
+                codingPath: []
+            )
+            return try decoder.decode(T.self)
+        }
     }
 
     /// Returns the type you specify, decoded from the Automerge document referenced by the decoder.

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
@@ -29,8 +29,8 @@ import Foundation
     @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
         switch T.self {
         case is AutomergeText.Type:
-            let directContainer = try singleValueContainer()
-            return try directContainer.decode(T.self)
+            let container = try container(keyedBy: AutomergeText.CodingKeys.self)
+            return try container.decode(T.self, forKey: .value)
         case is Counter.Type:
             let directContainer = try singleValueContainer()
             return try directContainer.decode(T.self)

--- a/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeDecoderImpl.swift
@@ -29,8 +29,8 @@ import Foundation
     @inlinable public func decode<T: Decodable>(_: T.Type) throws -> T {
         switch T.self {
         case is AutomergeText.Type:
-            let container = try container(keyedBy: AutomergeText.CodingKeys.self)
-            return try container.decode(T.self, forKey: .value)
+            let directContainer = try singleValueContainer()
+            return try directContainer.decode(T.self)
         case is Counter.Type:
             let directContainer = try singleValueContainer()
             return try directContainer.decode(T.self)

--- a/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeEncoder.swift
@@ -53,7 +53,16 @@ public struct AutomergeEncoder {
             cautiousWrite: cautiousWrite,
             logLevel: logLevel
         )
-        try value.encode(to: encoder)
+        switch value {
+        // special case encoding AutomergeText directly - it has a default encoder implementation
+        // that would otherwise get missed as a top-level item to be encoded, and not encode "correctly"
+        // into an Automerge document.
+        case let value as AutomergeText:
+            var container = encoder.container(keyedBy: AutomergeText.CodingKeys.self)
+            try container.encode(value, forKey: .value)
+        default:
+            try value.encode(to: encoder)
+        }
         encoder.postencodeCleanup()
     }
 
@@ -87,7 +96,16 @@ public struct AutomergeEncoder {
             cautiousWrite: cautiousWrite,
             logLevel: logLevel
         )
-        try value.encode(to: encoder)
+        switch value {
+        // special case encoding AutomergeText directly - it has a default encoder implementation
+        // that would otherwise get missed as a top-level item to be encoded, and not encode "correctly"
+        // into an Automerge document.
+        case let value as AutomergeText:
+            var container = encoder.container(keyedBy: AutomergeText.CodingKeys.self)
+            try container.encode(value, forKey: .value)
+        default:
+            try value.encode(to: encoder)
+        }
         encoder.postencodeCleanup(below: path.map { AnyCodingKey($0) })
     }
 }

--- a/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeKeyedEncodingContainer.swift
@@ -349,8 +349,10 @@ struct AutomergeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProt
                         )
                 }
                 textNodeId = textId
+                try text.bind(doc: document, id: textNodeId)
             } else {
                 textNodeId = try document.putObject(obj: objectId, key: key.stringValue, ty: .Text)
+                try text.bind(doc: document, id: textNodeId)
             }
 
             // AutomergeText is a reference type that, when bound, writes directly into the

--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -336,12 +336,15 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
                         )
                 }
                 textNodeId = textId
+                try text.bind(doc: document, id: textNodeId)
             } else {
                 // no existing value is there, so create a Text node
                 if let indexToWrite = codingkey.intValue {
                     textNodeId = try document.putObject(obj: objectId, index: UInt64(indexToWrite), ty: .Text)
+                    try text.bind(doc: document, id: textNodeId)
                 } else {
                     textNodeId = try document.putObject(obj: objectId, key: codingkey.stringValue, ty: .Text)
+                    try text.bind(doc: document, id: textNodeId)
                 }
             }
 

--- a/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeUnkeyedEncodingContainer.swift
@@ -160,8 +160,10 @@ struct AutomergeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
                         )
                 }
                 textNodeId = textId
+                try text.bind(doc: document, id: textNodeId)
             } else {
                 textNodeId = try document.insertObject(obj: objectId, index: UInt64(count), ty: .Text)
+                try text.bind(doc: document, id: textNodeId)
             }
 
             // AutomergeText is a reference type that, when bound, writes directly into the

--- a/Tests/AutomergeTests/CodableTests/AutomergeTextEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTextEncodeDecodeTests.swift
@@ -106,4 +106,51 @@ final class EncodeDecodeBugTests: XCTestCase {
         XCTAssertEqual(secondEncodeCheck.notes[1].value, "")
         XCTAssertTrue(secondEncodeCheck.notes[1].isBound)
     }
+
+    func testBindOnEncodeList() throws {
+        let encoder = AutomergeEncoder(doc: doc)
+
+        var collection = RawNoteCollection(notes: [])
+        collection.notes.append(AutomergeText("hello world"))
+        collection.notes.append(AutomergeText(""))
+        XCTAssertFalse(collection.notes[0].isBound)
+        XCTAssertFalse(collection.notes[1].isBound)
+
+        try encoder.encode(collection)
+        XCTAssertTrue(collection.notes[0].isBound)
+        XCTAssertTrue(collection.notes[1].isBound)
+    }
+
+    func testBindOnEncodeNested() throws {
+        let encoder = AutomergeEncoder(doc: doc)
+
+        var collection = NoteCollection(notes: [])
+        let note1 = Note(title: "one", discussion: AutomergeText("hello world"))
+        let note2 = Note(title: "", discussion: AutomergeText())
+        collection.notes.append(note1)
+        collection.notes.append(note2)
+        XCTAssertFalse(note1.discussion.isBound)
+        XCTAssertFalse(note2.discussion.isBound)
+
+        try encoder.encode(collection)
+        XCTAssertTrue(note1.discussion.isBound)
+        XCTAssertTrue(note2.discussion.isBound)
+    }
+
+    func testBindOnEncodeDecodeDirect() throws {
+        let encoder = AutomergeEncoder(doc: doc)
+        let decoder = AutomergeDecoder(doc: doc)
+
+        let note = AutomergeText("something")
+        XCTAssertFalse(note.isBound)
+
+        try encoder.encode(note)
+        XCTAssertTrue(note.isBound)
+
+        let decodeCheck = try decoder.decode(AutomergeText.self)
+        XCTAssertEqual(decodeCheck.value, "something")
+        XCTAssertTrue(decodeCheck.isBound)
+
+        try doc.walk()
+    }
 }


### PR DESCRIPTION
- exposes a new bind() method on AutomergeText that takes an ObjId for convenience
- switches AutomergeText.CodingKeys to public
- special cases encoding _just_ an instance of AutomergeText into an AutomergeDocument
  - now correctly encoding the contents as .Text() instead of as a string Value
  - updated special case decode logic to accomodate the same, allowing it to be the top-level type stored into an Automerge document.

- fixes #145
- fixes #100