### PR TITLE
Fix error when decoding int as double

### DIFF
--- a/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
+++ b/Sources/Automerge/Codable/Decoding/AutomergeKeyedDecodingContainer.swift
@@ -256,15 +256,21 @@ extension AutomergeKeyedDecodingContainer {
     ) throws -> T {
         let value = try getValue(forKey: key)
 
-        guard case let .Scalar(.F64(number)) = value else {
+        let description: String
+        switch value {
+        case let .Scalar(.F64(number)):
+            description = number.description
+        case let .Scalar(.Int(number)):
+            description = number.description
+        default:
             throw createTypeMismatchError(type: T.self, forKey: key, value: value)
         }
 
-        guard let floatingPoint = T(number.description) else {
+        guard let floatingPoint = T(description) else {
             throw DecodingError.dataCorruptedError(
                 forKey: key,
                 in: self,
-                debugDescription: "Parsed Automerge number <\(number)> does not fit in \(T.self)."
+                debugDescription: "Parsed Automerge number <\(description)> does not fit in \(T.self)."
             )
         }
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeDecoderTests.swift
@@ -121,6 +121,19 @@ final class AutomergeDecoderTests: XCTestCase {
         XCTAssertEqual(decodedStruct.votes, [3, 4, 5])
     }
 
+    func testIntToDoubleDecode() throws {
+        struct StructWithDouble: Codable {
+            let count: Double
+        }
+        let decoder = AutomergeDecoder(doc: doc)
+
+        XCTAssertNoThrow(try decoder.decode(StructWithDouble.self))
+
+        let decodedStruct = try decoder.decode(StructWithDouble.self)
+
+        XCTAssertEqual(decodedStruct.count, 5)
+    }
+
     func testListOfTextDecode() throws {
         doc = Document()
         let list = try! doc.putObject(obj: ObjId.ROOT, key: "list", ty: .List)


### PR DESCRIPTION
I found that if I create an Automerge document in Javascript with a field being defined as a `number`, assign an integer value into it, and then try to load that document in Swift, I get an error saying `Expected to decode Double but found ScalarValue<Int(5)> instead.`. I would expect the decoder to just handle casting ints to doubles, as this is what the Swift JSON decoder does. This PR updates the behavior to match that expectation.