### PR TITLE
Isolated change signal

### DIFF
--- a/Sources/Automerge/BoundTypes/AutomergeText.swift
+++ b/Sources/Automerge/BoundTypes/AutomergeText.swift
@@ -37,9 +37,9 @@ import Foundation
 public final class AutomergeText: Codable {
     var doc: Document?
     var objId: ObjId?
+    var _hashOfCurrentValue: Int
     #if canImport(Combine)
     var observerHandle: AnyCancellable?
-    var _hashOfCurrentValue: Int
     #endif
     var _unboundStorage: String
 

--- a/Sources/Automerge/BoundTypes/AutomergeText.swift
+++ b/Sources/Automerge/BoundTypes/AutomergeText.swift
@@ -39,6 +39,7 @@ public final class AutomergeText: Codable {
     var objId: ObjId?
     #if canImport(Combine)
     var observerHandle: AnyCancellable?
+    var _hashOfCurrentValue: Int
     #endif
     var _unboundStorage: String
 
@@ -48,6 +49,7 @@ public final class AutomergeText: Codable {
     /// - Parameter initialValue: An initial string value for the text reference.
     public init(_ initialValue: String = "") {
         _unboundStorage = initialValue
+        _hashOfCurrentValue = initialValue.hashValue
     }
 
     /// Creates a new text reference instance bound within an Automerge document.
@@ -230,12 +232,15 @@ public final class AutomergeText: Codable {
         // outrageous overhead, and this code is the easiest (most localized) to put in place to a
         // change signal properly operational.
         observerHandle = doc.objectWillChange.sink(receiveValue: { _ in
-            // TODO: There's no previous information tracked here, so revise this to look at
-            // some history marker of the last update and determine if this individual content
-            // has changed. Most likely, that will require (or notably benefit from) the exposure
-            // of the Diff api (https://github.com/automerge/automerge-swift/issues/148) that is not
-            // yet exposed as this is created.
-            self.sendObjectWillChange()
+            guard let objId = self.objId else {
+                return
+            }
+            Task {
+                let valueFromDoc = try doc.text(obj: objId)
+                if valueFromDoc.hashValue != self._hashOfCurrentValue {
+                    self.sendObjectWillChange()
+                }
+            }
         })
         #endif
     }
@@ -273,6 +278,7 @@ public final class AutomergeText: Codable {
         }
         let current = try doc.text(obj: objId)
         if current != newText {
+            _hashOfCurrentValue = newText.hashValue
             try doc.updateText(obj: objId, value: newText)
             sendObjectWillChange()
         }
@@ -292,6 +298,7 @@ public final class AutomergeText: Codable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         _unboundStorage = try container.decode(String.self, forKey: .value)
+        _hashOfCurrentValue = _unboundStorage.hashValue
     }
 }
 

--- a/Sources/Automerge/BoundTypes/Counter.swift
+++ b/Sources/Automerge/BoundTypes/Counter.swift
@@ -12,9 +12,9 @@ public final class Counter: Codable {
     var doc: Document?
     var objId: ObjId?
     var codingkey: AnyCodingKey?
+    var _hashOfCurrentValue: Int
     #if canImport(Combine)
     var observerHandle: AnyCancellable?
-    var _hashOfCurrentValue: Int
     #endif
     var _unboundStorage: Int
 

--- a/Tests/AutomergeTests/BoundTypeTests/BoundTypeChangeTests.swift
+++ b/Tests/AutomergeTests/BoundTypeTests/BoundTypeChangeTests.swift
@@ -4,7 +4,6 @@ import XCTest
 class BoundTypeChangeTests: XCTestCase {
     func testTextChangeNotification() async throws {
         let doc1 = Document()
-        try doc1.put(obj: ObjId.ROOT, key: "counter", value: .Counter(0))
         let text1 = try AutomergeText("hello", doc: doc1, path: "text1")
 
         let textChangeNotification =
@@ -17,6 +16,32 @@ class BoundTypeChangeTests: XCTestCase {
             }
         }
         XCTAssertNotNil(xx)
+        let txt1ObjId = try XCTUnwrap(text1.objId)
+        try doc1.updateText(obj: txt1ObjId, value: "Hello World!")
+
+        await fulfillment(of: [textChangeNotification], timeout: 1.0, enforceOrder: false)
+    }
+
+    func testLocalizedTextChangeNotification() async throws {
+        let doc1 = Document()
+        try doc1.put(obj: ObjId.ROOT, key: "counter", value: .Counter(0))
+        let counter = try Counter(0, doc: doc1, path: "counter")
+        let text1 = try AutomergeText("hello", doc: doc1, path: "text1")
+
+        let textChangeNotification =
+            expectation(description: "text1 should send an objectWillChange signal on an update to the document")
+        var alreadyFulfilled = false
+        let text_change = text1.objectWillChange.sink { _ in
+            if !alreadyFulfilled {
+                textChangeNotification.fulfill()
+                alreadyFulfilled = true
+            }
+        }
+        XCTAssertNotNil(text_change)
+        let counter_change = counter.objectWillChange.sink { _ in
+            XCTFail("No change notification should occur for counter while Text is updated")
+        }
+        XCTAssertNotNil(counter_change)
         let txt1ObjId = try XCTUnwrap(text1.objId)
         try doc1.updateText(obj: txt1ObjId, value: "Hello World!")
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -4,9 +4,7 @@ import XCTest
 final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
     func testSimpleKeyEncode() throws {
         let doc = Document()
-        // AutomergeText maintains a reference to the document, so those existing at the end
-        // will cause the weak reference used for tracking potential memory leaks to not be clear.
-        // trackForMemoryLeak(instance: doc)
+        trackForMemoryLeak(instance: doc)
 
         struct SimpleStruct: Codable, Equatable {
             let name: String
@@ -37,9 +35,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
 
     func testTargetedSingleValueDecode() throws {
         let doc = Document()
-        // AutomergeText maintains a reference to the document, so those existing at the end
-        // will cause the weak reference used for tracking potential memory leaks to not be clear.
-        // trackForMemoryLeak(instance: doc)
+        trackForMemoryLeak(instance: doc)
 
         struct SimpleStruct: Codable, Equatable {
             let name: String
@@ -96,9 +92,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
 
     func testTargetedDecodeOfCounter() throws {
         let doc = Document()
-        // Counter maintains a reference to the document, so those existing at the end
-        // will cause the weak reference used for tracking potential memory leaks to not be clear.
-        // trackForMemoryLeak(instance: doc)
+        trackForMemoryLeak(instance: doc)
 
         let exampleCounter = Counter(342)
         try doc.put(obj: ObjId.ROOT, key: "counter", value: .Counter(342))


### PR DESCRIPTION
I couldn't stand to leave it with at least a little more granular refinement to the change signals, and I wasn't yet ready to tackle the Rust and wiring through the low-level bits for the Diff api. So this is a "in the mean time" update to at least get it more properly correct in terms of change signals for bound types.

I also found my earlier miss in strong references to the Doc and resolved that for the bound types so that observation doesn't make an retain loop, which it previously did.

fixes #152, although a nicer version would be nice using the Diff APIs with computation of sending those signals at the Doc level to reduce work in non-simple-doc/few-instance scenarios.