### PR TITLE
0.5.10 core library update

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -642,11 +642,12 @@ open class Doc:
     }
 
     public convenience init() {
-        let pointer = try! rustCall {
-            uniffi_uniffi_automerge_fn_constructor_doc_new(
-                $0
-            )
-        }
+        let pointer =
+            try! rustCall {
+                uniffi_uniffi_automerge_fn_constructor_doc_new(
+                    $0
+                )
+            }
         self.init(unsafeFromRawPointer: pointer)
     }
 
@@ -1385,11 +1386,12 @@ open class SyncState:
     }
 
     public convenience init() {
-        let pointer = try! rustCall {
-            uniffi_uniffi_automerge_fn_constructor_syncstate_new(
-                $0
-            )
-        }
+        let pointer =
+            try! rustCall {
+                uniffi_uniffi_automerge_fn_constructor_syncstate_new(
+                    $0
+                )
+            }
         self.init(unsafeFromRawPointer: pointer)
     }
 
@@ -1998,8 +2000,7 @@ public enum PatchAction {
     case insert(
         obj: ObjId,
         index: UInt64,
-        values: [Value],
-        marks: [String: Value]
+        values: [Value]
     )
     case spliceText(
         obj: ObjId,
@@ -2046,8 +2047,7 @@ public struct FfiConverterTypePatchAction: FfiConverterRustBuffer {
         case 2: return try .insert(
                 obj: FfiConverterTypeObjId.read(from: &buf),
                 index: FfiConverterUInt64.read(from: &buf),
-                values: FfiConverterSequenceTypeValue.read(from: &buf),
-                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
+                values: FfiConverterSequenceTypeValue.read(from: &buf)
             )
 
         case 3: return try .spliceText(
@@ -2096,12 +2096,11 @@ public struct FfiConverterTypePatchAction: FfiConverterRustBuffer {
             FfiConverterTypeProp.write(prop, into: &buf)
             FfiConverterTypeValue.write(value, into: &buf)
 
-        case let .insert(obj, index, values, marks):
+        case let .insert(obj, index, values):
             writeInt(&buf, Int32(2))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterUInt64.write(index, into: &buf)
             FfiConverterSequenceTypeValue.write(values, into: &buf)
-            FfiConverterDictionaryStringTypeValue.write(marks, into: &buf)
 
         case let .spliceText(obj, index, value, marks):
             writeInt(&buf, Int32(3))

--- a/Sources/Automerge/Patch.swift
+++ b/Sources/Automerge/Patch.swift
@@ -50,10 +50,8 @@ public enum PatchAction: Equatable {
     ///
     /// The property included within the `Put` can be either an index to a sequence, or a key into a map.
     case Put(ObjId, Prop, Value)
-    /// Insert a collection of values at the index you provide for the identified object with the given marks
-    ///
-    /// `marks` will only  be set for text objects.
-    case Insert(obj: ObjId, index: UInt64, values: [Value], marks: [String: Value])
+    /// Insert a collection of values at the index you provide for the identified object.
+    case Insert(obj: ObjId, index: UInt64, values: [Value])
     /// Splices characters into and/or removes characters from the identified object at a given position within it.
     ///
     /// > Note: The unsigned 64bit integer is the index to a UTF-8 code point, and not a grapheme cluster index.
@@ -77,12 +75,11 @@ public enum PatchAction: Equatable {
         switch ffi {
         case let .put(obj, prop, value):
             return .Put(ObjId(bytes: obj), Prop.fromFfi(prop), Value.fromFfi(value: value))
-        case let .insert(obj, index, values, marks):
+        case let .insert(obj, index, values):
             return .Insert(
                 obj: ObjId(bytes: obj),
                 index: index,
-                values: values.map { Value.fromFfi(value: $0) },
-                marks: marks.mapValues(Value.fromFfi)
+                values: values.map { Value.fromFfi(value: $0) }
             )
         case let .spliceText(obj, index, value, marks):
             return .SpliceText(

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "automerge"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b5e6ed2097a1e55cce3128d64c909cdb42c800d4880411c7382f3dfa2c808d"
+checksum = "ed6e1f2c0a7de41582d18829f837c3b2a3b98f32402a4b67541ab4e2183fc40e"
 dependencies = [
  "flate2",
  "fxhash",
@@ -697,9 +697,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "uniffi"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37a4fc8954608e2d53e6ea0093ac16c3ce540f9a0cd27ab658caa0282537c54"
+checksum = "a5566fae48a5cb017005bf9cd622af5236b2a203a13fb548afde3506d3c68277"
 dependencies = [
  "anyhow",
  "uniffi_build",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868c9efaec99e71c60bb22cbd8c89a62e68506a828898c90a6106bde0f298964"
+checksum = "4a77bb514bcd4bf27c9bd404d7c3f2a6a8131b957eba9c22cfeb7751c4278e09"
 dependencies = [
  "anyhow",
  "askama",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb32968ec02e5093df86e4fa8df7759a4cf64d2bde86238b0407c8ec97d80f"
+checksum = "45cba427aeb7b3a8b54830c4c915079a7a3c62608dd03dddba1d867a8a023eb4"
 dependencies = [
  "anyhow",
  "camino",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7f91c2de378a5993a6d0367d9c6e178bbc98309919ee42fccc0142a5adbb25"
+checksum = "ae7e5a6c33b1dec3f255f57ec0b6af0f0b2bb3021868be1d5eec7a38e2905ebc"
 dependencies = [
  "quote",
  "syn 2.0.22",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9665ccbf2eaf7e58ca93587d3ba0ef7ead824c4d9b825b54170d1edcd9a2"
+checksum = "0ea3eb5474d50fc149b7e4d86b9c5bd4a61dcc167f0683902bf18ae7bbb3deef"
 dependencies = [
  "anyhow",
  "bytes",
@@ -779,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c0cd00841fbcfaac392c1121fc59231c35a8257b68d67dba21322d10ef97d3"
+checksum = "18331d35003f46f0d04047fbe4227291815b83a937a8c32bc057f990962182c4"
 dependencies = [
  "bincode",
  "camino",
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70be6fa1fd9b2d3a1138f068da3d1c40394c33c9c880f8b477bd3a2043283893"
+checksum = "f7224422c4cfd181c7ca9fca2154abca4d21db962f926f270f996edd38b0c4b8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28ac70a40b629dec58c8519771637abbe2a1bc09fb0a3019568632917ea9182"
+checksum = "f8ce878d0bdfc288b58797044eaaedf748526c56eef3575380bb4d4b19d69eee"
 dependencies = [
  "anyhow",
  "camino",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4823fb2c22e735d437eb4e497f276ea415364da9a3823adcfb8366be7dbd714d"
+checksum = "8c43c9ed40a8d20a5c3eae2d23031092db6b96dc8e571beb449ba9757484cea0"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,10 +13,10 @@ path = "uniffi-bindgen.rs"
 required-features = ["uniffi/cli"]
 
 [dependencies]
-automerge = "0.5.9"
+automerge = "0.5.10"
 thiserror = "1.0.38"
-uniffi = "0.27.0"
+uniffi = "0.27.1"
 
 [build-dependencies]
-uniffi = {version = "0.27.0", features = ["build"] }
+uniffi = {version = "0.27.1", features = ["build"] }
 

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -120,7 +120,7 @@ dictionary Patch {
 [Enum]
 interface PatchAction {
     Put( ObjId obj, Prop prop, Value value);
-    Insert( ObjId obj, u64 index, sequence<Value> values, record<string, Value> marks);
+    Insert( ObjId obj, u64 index, sequence<Value> values);
     SpliceText( ObjId obj, u64 index, string value, record<string, Value> marks);
     Increment( ObjId obj, Prop prop, i64 value);
     Conflict( ObjId obj, Prop prop);

--- a/rust/src/patches.rs
+++ b/rust/src/patches.rs
@@ -80,10 +80,7 @@ impl PatchAction {
                 },
                 value: value.into(),
             },
-            am::PatchAction::Insert {
-                index,
-                values,
-            } => PatchAction::Insert {
+            am::PatchAction::Insert { index, values } => PatchAction::Insert {
                 obj: obj.into(),
                 index: index as u64,
                 values: values

--- a/rust/src/patches.rs
+++ b/rust/src/patches.rs
@@ -34,7 +34,6 @@ pub enum PatchAction {
         obj: ObjId,
         index: u64,
         values: Vec<Value>,
-        marks: HashMap<String, Value>,
     },
     SpliceText {
         obj: ObjId,
@@ -84,7 +83,6 @@ impl PatchAction {
             am::PatchAction::Insert {
                 index,
                 values,
-                marks,
             } => PatchAction::Insert {
                 obj: obj.into(),
                 index: index as u64,
@@ -92,7 +90,6 @@ impl PatchAction {
                     .into_iter()
                     .map(|(v, id, _conflict)| Value::from((v.clone(), id.clone())))
                     .collect(),
-                marks: convert_marks(marks),
             },
             am::PatchAction::SpliceText {
                 index,


### PR DESCRIPTION
- update to core library version 0.5.10
- PatchAction::Insert no longer accepts marks with the 0.5.10 API
  - remove from UDL
  - remove from Rust code making library overlay
  - remove from Swift API