### PR TITLE
pushing updates on CI to set up for Swift 5.9 minimum target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-test:
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       LOCAL_BUILD: true
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,7 @@ jobs:
       - run: rustup target add wasm32-wasi
       - uses: swiftwasm/setup-swiftwasm@v1
         with:
-          swift-version: "swift-wasm-5.9-SNAPSHOT-2024-04-26-a" 
-          # previously: wasm-5.8.0-RELEASE
+          swift-version: "wasm-5.9.1-RELEASE"
       - run: cargo build --manifest-path rust/Cargo.toml --target wasm32-wasi --release
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.78.0
           default: true
       - name: get xcode information
         run: |
@@ -35,12 +35,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.78.0
           default: true
       - run: rustup target add wasm32-wasi
       - uses: swiftwasm/setup-swiftwasm@v1
         with:
-          swift-version: "wasm-5.8.0-RELEASE"
+          swift-version: "swift-wasm-5.9-SNAPSHOT-2024-04-26-a" 
+          # previously: wasm-5.8.0-RELEASE
       - run: cargo build --manifest-path rust/Cargo.toml --target wasm32-wasi --release
       - uses: actions/upload-artifact@v4
         with:
@@ -55,7 +56,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.78.0
           default: true
           components: rustfmt
       - name: Clippy
@@ -68,7 +69,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.75.0
+          toolchain: 1.78.0
           default: true
           components: clippy
       - name: Clippy


### PR DESCRIPTION
I couldn't add commits to #174, so I opened this as a PR that we can try to merge prior to that and see if that helps...