### PR TITLE
add marker file that disables compatibility matrix for Swift on Linux at Swift Package Index

### DIFF
--- a/Sources/Automerge/_AutomergeLinux.swift
+++ b/Sources/Automerge/_AutomergeLinux.swift
@@ -1,0 +1,9 @@
+#if os(Linux)
+// Error on compilation on Linux - The XCFramework, on which this package depends, could be made
+// available for a variety of platforms, but there's not much of a smooth path to providing those
+// binary assets for Swift on Linux.
+//
+// This file exists so that the compatibility indicators on Swift Package Index don't infer that
+// this package is easily installed and used with Swift on Linux,
+#error("This explicit error is to indicate that this package doesn't support Linux as it stands")
+#endif

--- a/Tests/AutomergeTests/TestObservableDocument.swift
+++ b/Tests/AutomergeTests/TestObservableDocument.swift
@@ -35,6 +35,7 @@ class ObservableDocumentTestCase: XCTestCase {
         let collection = doc.objectWillChange.sink {
             stashedHeads = doc.heads()
         }
+        XCTAssertNotNil(collection)
         try doc.spliceText(obj: text, start: 0, delete: 0, value: "hello world!")
         XCTAssertNotEqual(doc.heads(), stashedHeads)
     }


### PR DESCRIPTION
- and it clears a lingering compilation warning in the tests