### PR TITLE
Encode `nil` values into the document

### DIFF
--- a/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
+++ b/Sources/Automerge/Codable/Encoding/AutomergeSingleValueEncodingContainer.swift
@@ -55,7 +55,10 @@ struct AutomergeSingleValueEncodingContainer: SingleValueEncodingContainer {
         #endif
     }
 
-    mutating func encodeNil() throws {}
+    mutating func encodeNil() throws {
+        try scalarValueEncode(value: ScalarValue.Null)
+        impl.singleValueWritten = true
+    }
 
     mutating func encode(_ value: Bool) throws {
         try scalarValueEncode(value: value)

--- a/Sources/Automerge/ScalarValueRepresentable.swift
+++ b/Sources/Automerge/ScalarValueRepresentable.swift
@@ -34,6 +34,21 @@ public protocol ScalarValueRepresentable {
     func toScalarValue() -> ScalarValue
 }
 
+// MARK: ScalarValue Conversions
+
+/// A failure to convert an Automerge scalar value to or from an Automerge scalar value.
+public enum ScalarValueConversionError: LocalizedError {}
+
+extension ScalarValue: ScalarValueRepresentable {
+    public static func fromScalarValue(_ val: ScalarValue) -> Result<ScalarValue, ScalarValueConversionError> {
+        .success(val)
+    }
+
+    public func toScalarValue() -> ScalarValue {
+        self
+    }
+}
+
 // MARK: Boolean Conversions
 
 /// A failure to convert an Automerge scalar value to or from a Boolean representation.

--- a/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeSingleValueEncoderImplTests.swift
@@ -32,6 +32,20 @@ final class AutomergeSingleValueEncoderImplTests: XCTestCase {
         cautiousSingleValueContainer = cautious.singleValueContainer()
     }
 
+    func testSimpleKeyEncode_Null() throws {
+        try singleValueContainer.encodeNil()
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Null))
+        try cautiousSingleValueContainer.encodeNil()
+        XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Null))
+    }
+
+    func testSimpleKeyEncode_Null_CautiousFailure() throws {
+        try doc.put(obj: ObjId.ROOT, key: "value", value: .F64(4.0))
+        XCTAssertThrowsError(
+            try cautiousSingleValueContainer.encodeNil()
+        )
+    }
+
     func testSimpleKeyEncode_Bool() throws {
         try singleValueContainer.encode(true)
         XCTAssertEqual(try doc.get(obj: ObjId.ROOT, key: "value"), .Scalar(.Boolean(true)))

--- a/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeUnkeyedEncoderDecoderTests.swift
@@ -276,4 +276,18 @@ final class AutomergeUnkeyedEncoderDecoderTests: XCTestCase {
         XCTAssertEqual(decodedStruct.list.count, 1)
         XCTAssertEqual(decodedStruct.list, [URL(string: "url.com")!])
     }
+
+    func testListOfNullEncodeDecode() throws {
+        struct WrapperStruct: Codable, Equatable {
+            let list: [Int?]
+        }
+
+        let topLevel = WrapperStruct(list: [nil])
+
+        try encoder.encode(topLevel)
+
+        let decodedStruct = try decoder.decode(WrapperStruct.self)
+        XCTAssertEqual(decodedStruct.list.count, 1)
+        XCTAssertEqual(decodedStruct.list, [nil])
+    }
 }


### PR DESCRIPTION
The encoder was omitting some `nil` values, making them `undefined` in the JavaScript library, instead of `null`.

Given the following code:

```swift
struct Item: Codable {
    var completedAt: Date?

    func encode(to encoder: any Encoder) throws {
        var container = encoder.container(keyedBy: CodingKeys.self)
        try container.encode(completedAt, forKey: .completedAt)
    }
}

let item = Item(completedAt: nil)
let doc = Document()
let encoder = AutomergeEncoder(doc: doc)
try encoder.encode(item)
let completedAt = try doc.get(obj: .ROOT, key: "completedAt")
print(completedAt)
```

Results in `completedAt` being `nil`, instead of `ScalarValue.Null`. This means the encoder wasn't writing the null value into the `Document`.

---

This PR changes the encoder so it writes `nil`s into the `Document`, with tests to check it.

As an implementation detail, now `ScalarValue` conforms to `ScalarValueRepresentable`.