### PR TITLE
Expose heads raw state representation

### DIFF
--- a/Sources/Automerge/ChangeHash.swift
+++ b/Sources/Automerge/ChangeHash.swift
@@ -18,7 +18,7 @@ public extension Set<ChangeHash> {
     /// and retrieval of document states.
     func raw() -> Data {
         let rawBytes = map(\.bytes).sorted { lhs, rhs in
-            lhs.hashValue > rhs.hashValue
+            lhs.debugDescription > rhs.debugDescription
         }
         return Data(rawBytes.joined())
     }
@@ -28,7 +28,7 @@ public extension Data {
 
     /// Returns the related set of changes of a state representation within an Automerge document.
     func heads() -> Set<ChangeHash>? {
-        let rawBytes = Array(self)
+        let rawBytes: [UInt8] = Array(self)
         guard rawBytes.count % 32 == 0 else { return nil }
         let totalHashes = rawBytes.count / 32
         let heads = (0..<totalHashes).map { index in

--- a/Sources/Automerge/ChangeHash.swift
+++ b/Sources/Automerge/ChangeHash.swift
@@ -26,7 +26,7 @@ public extension Set<ChangeHash> {
 
 public extension Data {
 
-    /// Returns the related set of changes of a state representation within an Automerge document.
+    /// Interprets the data to return the data as a set of change hashes that represent a state within an Automerge document. If the data is not a multiple of 32 bytes, returns nil.
     func heads() -> Set<ChangeHash>? {
         let rawBytes: [UInt8] = Array(self)
         guard rawBytes.count % 32 == 0 else { return nil }

--- a/Sources/Automerge/ChangeHash.swift
+++ b/Sources/Automerge/ChangeHash.swift
@@ -9,3 +9,15 @@ public struct ChangeHash: Equatable, Hashable, CustomDebugStringConvertible, Sen
         bytes.map { String(format: "%02hhx", $0) }.joined()
     }
 }
+
+public extension Set<ChangeHash> {
+
+    /// Transforms each `ChangeHash` in the set into its byte array (`[UInt8]`). This raw byte representation
+    /// captures the state of the document at a specific point in its history, allowing for efficient storage
+    /// and retrieval of document states.
+    func raw() -> [[UInt8]] {
+        map(\.bytes).sorted { lhs, rhs in
+            lhs[0] > rhs[0]
+        }
+    }
+}

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -1035,6 +1035,17 @@ public final class Document: @unchecked Sendable {
         }
     }
 
+    /// Returns the related set of changes of a state representation within an Automerge document.
+    public func heads(raw: [[UInt8]]) -> Set<ChangeHash>? {
+        var output: Set<ChangeHash> = []
+        for bytes in raw {
+            guard let changeHash = change(hash: ChangeHash(bytes: bytes))?.hash
+            else { return nil }
+            output.insert(changeHash)
+        }
+        return output
+    }
+
     /// Generates patches between two points in the document history.
     ///
     /// Use:

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -1035,17 +1035,6 @@ public final class Document: @unchecked Sendable {
         }
     }
 
-    /// Returns the related set of changes of a state representation within an Automerge document.
-    public func heads(raw: [[UInt8]]) -> Set<ChangeHash>? {
-        var output: Set<ChangeHash> = []
-        for bytes in raw {
-            guard let changeHash = change(hash: ChangeHash(bytes: bytes))?.hash
-            else { return nil }
-            output.insert(changeHash)
-        }
-        return output
-    }
-
     /// Generates patches between two points in the document history.
     ///
     /// Use:

--- a/Tests/AutomergeTests/TestChanges.swift
+++ b/Tests/AutomergeTests/TestChanges.swift
@@ -94,28 +94,27 @@ class ChangeSetTests: XCTestCase {
         try doc.merge(other: doc1)
 
         let heads = doc.heads()
-        let restored = doc.heads(raw: heads.raw())
+        let restored = doc.heads().raw().heads()
 
         XCTAssertEqual(heads, restored)
     }
 
-    func testChangeHash_WhenRawIsManipulated_DocumentDoesNotAccept() throws {
+    func testChangeHash_SameHeads_ResultSameRawData() throws {
         let doc = Document()
         let textId = try! doc.putObject(obj: ObjId.ROOT, key: "text", ty: .Text)
         let doc1 = doc.fork()
-        try doc.spliceText(obj: textId, start: 0, delete: 0, value: "Hello")
-        try doc1.spliceText(obj: textId, start: 0, delete: 0, value: " World!")
+        let doc2 = doc.fork()
+        let doc3 = doc.fork()
+        try doc.spliceText(obj: textId, start: 0, delete: 0, value: "[0]")
+        try doc1.spliceText(obj: textId, start: 0, delete: 0, value: "[1]")
+        try doc2.spliceText(obj: textId, start: 0, delete: 0, value: "[2]")
+        try doc3.spliceText(obj: textId, start: 0, delete: 0, value: "[3]")
         try doc.merge(other: doc1)
+        try doc.merge(other: doc2)
+        try doc.merge(other: doc3)
 
-        let headsRaw = doc.heads().raw().map { raw in
-            var raw = raw
-            raw[0] = 0
-            raw[7] = 0
-            raw[14] = 0
-            return raw
-        }
-        let restored = doc.heads(raw: headsRaw)
+        let rawHashes = (0..<100).map { _ in doc.heads().raw().hashValue }
 
-        XCTAssertNil(restored)
+        XCTAssertEqual(Set(rawHashes).count, 1)
     }
 }

--- a/Tests/AutomergeTests/TestChanges.swift
+++ b/Tests/AutomergeTests/TestChanges.swift
@@ -113,7 +113,7 @@ class ChangeSetTests: XCTestCase {
         try doc.merge(other: doc2)
         try doc.merge(other: doc3)
 
-        let rawHashes = (0..<100).map { _ in doc.heads().raw().hashValue }
+        let rawHashes = (0..<500).map { _ in doc.heads().raw() }
 
         XCTAssertEqual(Set(rawHashes).count, 1)
     }


### PR DESCRIPTION
### Motivation
Sometimes we want to persist in our domain a state representation based on `Set<ChangeHash>` (aka heads) without coupling to the Automerge library. In this way, we can restore this state by moving back to the Automerge domain. It is usually quite interesting to implement an undo manager based on "commits".

Introducing a `raw()` method to retrieve the raw representation of `heads` without any Automerge dependency; and also the go-back action into `Set<ChangeHash>`.

side-note: as we use an opaque type to encode the raw version of a group of change hashes, I am just checking it contains packages of 32 bytes to retrieve the associated change hash - after retrieving it, in case of not valid ChangeHash document will throw exceptions.
