### PR TITLE
Swift6 mode

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -11,7 +11,7 @@ import Foundation
 import automergeFFI
 #endif
 
-fileprivate extension RustBuffer {
+private extension RustBuffer {
     // Allocate a new buffer, copying the contents of a `UInt8` array.
     init(bytes: [UInt8]) {
         let rbuf = bytes.withUnsafeBufferPointer { ptr in
@@ -21,7 +21,7 @@ fileprivate extension RustBuffer {
     }
 
     static func empty() -> RustBuffer {
-        RustBuffer(capacity: 0, len:0, data: nil)
+        RustBuffer(capacity: 0, len: 0, data: nil)
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
@@ -35,7 +35,7 @@ fileprivate extension RustBuffer {
     }
 }
 
-fileprivate extension ForeignBytes {
+private extension ForeignBytes {
     init(bufferPointer: UnsafeBufferPointer<UInt8>) {
         self.init(len: Int32(bufferPointer.count), data: bufferPointer.baseAddress)
     }
@@ -48,7 +48,7 @@ fileprivate extension ForeignBytes {
 // Helper classes/extensions that don't change.
 // Someday, this will be in a library of its own.
 
-fileprivate extension Data {
+private extension Data {
     init(rustBuffer: RustBuffer) {
         self.init(
             bytesNoCopy: rustBuffer.data!,
@@ -72,15 +72,15 @@ fileprivate extension Data {
 //
 // Instead, the read() method and these helper functions input a tuple of data
 
-fileprivate func createReader(data: Data) -> (data: Data, offset: Data.Index) {
+private func createReader(data: Data) -> (data: Data, offset: Data.Index) {
     (data: data, offset: 0)
 }
 
 // Reads an integer at the current offset, in big-endian order, and advances
 // the offset on success. Throws if reading the integer would move the
 // offset past the end of the buffer.
-fileprivate func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offset: Data.Index)) throws -> T {
-    let range = reader.offset..<reader.offset + MemoryLayout<T>.size
+private func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offset: Data.Index)) throws -> T {
+    let range = reader.offset ..< reader.offset + MemoryLayout<T>.size
     guard reader.data.count >= range.upperBound else {
         throw UniffiInternalError.bufferOverflow
     }
@@ -90,50 +90,50 @@ fileprivate func readInt<T: FixedWidthInteger>(_ reader: inout (data: Data, offs
         return value as! T
     }
     var value: T = 0
-    let _ = withUnsafeMutableBytes(of: &value, { reader.data.copyBytes(to: $0, from: range)})
+    let _ = withUnsafeMutableBytes(of: &value) { reader.data.copyBytes(to: $0, from: range) }
     reader.offset = range.upperBound
     return value.bigEndian
 }
 
 // Reads an arbitrary number of bytes, to be used to read
 // raw bytes, this is useful when lifting strings
-fileprivate func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: Int) throws -> Array<UInt8> {
-    let range = reader.offset..<(reader.offset+count)
+private func readBytes(_ reader: inout (data: Data, offset: Data.Index), count: Int) throws -> [UInt8] {
+    let range = reader.offset ..< (reader.offset + count)
     guard reader.data.count >= range.upperBound else {
         throw UniffiInternalError.bufferOverflow
     }
     var value = [UInt8](repeating: 0, count: count)
-    value.withUnsafeMutableBufferPointer({ buffer in
+    value.withUnsafeMutableBufferPointer { buffer in
         reader.data.copyBytes(to: buffer, from: range)
-    })
+    }
     reader.offset = range.upperBound
     return value
 }
 
 // Reads a float at the current offset.
-fileprivate func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
-    return Float(bitPattern: try readInt(&reader))
+private func readFloat(_ reader: inout (data: Data, offset: Data.Index)) throws -> Float {
+    try Float(bitPattern: readInt(&reader))
 }
 
 // Reads a float at the current offset.
-fileprivate func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
-    return Double(bitPattern: try readInt(&reader))
+private func readDouble(_ reader: inout (data: Data, offset: Data.Index)) throws -> Double {
+    try Double(bitPattern: readInt(&reader))
 }
 
 // Indicates if the offset has reached the end of the buffer.
-fileprivate func hasRemaining(_ reader: (data: Data, offset: Data.Index)) -> Bool {
-    return reader.offset < reader.data.count
+private func hasRemaining(_ reader: (data: Data, offset: Data.Index)) -> Bool {
+    reader.offset < reader.data.count
 }
 
 // Define writer functionality.  Normally this would be defined in a class or
 // struct, but we use standalone functions instead in order to make external
 // types work.  See the above discussion on Readers for details.
 
-fileprivate func createWriter() -> [UInt8] {
-    return []
+private func createWriter() -> [UInt8] {
+    []
 }
 
-fileprivate func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: Sequence, S.Element == UInt8 {
+private func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: Sequence, S.Element == UInt8 {
     writer.append(contentsOf: byteArr)
 }
 
@@ -141,22 +141,22 @@ fileprivate func writeBytes<S>(_ writer: inout [UInt8], _ byteArr: S) where S: S
 //
 // Warning: make sure what you are trying to write
 // is in the correct type!
-fileprivate func writeInt<T: FixedWidthInteger>(_ writer: inout [UInt8], _ value: T) {
+private func writeInt<T: FixedWidthInteger>(_ writer: inout [UInt8], _ value: T) {
     var value = value.bigEndian
     withUnsafeBytes(of: &value) { writer.append(contentsOf: $0) }
 }
 
-fileprivate func writeFloat(_ writer: inout [UInt8], _ value: Float) {
+private func writeFloat(_ writer: inout [UInt8], _ value: Float) {
     writeInt(&writer, value.bitPattern)
 }
 
-fileprivate func writeDouble(_ writer: inout [UInt8], _ value: Double) {
+private func writeDouble(_ writer: inout [UInt8], _ value: Double) {
     writeInt(&writer, value.bitPattern)
 }
 
 // Protocol for types that transfer other types across the FFI. This is
 // analogous to the Rust trait of the same name.
-fileprivate protocol FfiConverter {
+private protocol FfiConverter {
     associatedtype FfiType
     associatedtype SwiftType
 
@@ -167,32 +167,32 @@ fileprivate protocol FfiConverter {
 }
 
 // Types conforming to `Primitive` pass themselves directly over the FFI.
-fileprivate protocol FfiConverterPrimitive: FfiConverter where FfiType == SwiftType { }
+private protocol FfiConverterPrimitive: FfiConverter where FfiType == SwiftType {}
 
 extension FfiConverterPrimitive {
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public static func lift(_ value: FfiType) throws -> SwiftType {
-        return value
+        value
     }
 
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public static func lower(_ value: SwiftType) -> FfiType {
-        return value
+        value
     }
 }
 
 // Types conforming to `FfiConverterRustBuffer` lift and lower into a `RustBuffer`.
 // Used for complex types where it's hard to write a custom lift/lower.
-fileprivate protocol FfiConverterRustBuffer: FfiConverter where FfiType == RustBuffer {}
+private protocol FfiConverterRustBuffer: FfiConverter where FfiType == RustBuffer {}
 
 extension FfiConverterRustBuffer {
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public static func lift(_ buf: RustBuffer) throws -> SwiftType {
         var reader = createReader(data: Data(rustBuffer: buf))
         let value = try read(from: &reader)
@@ -203,18 +203,19 @@ extension FfiConverterRustBuffer {
         return value
     }
 
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public static func lower(_ value: SwiftType) -> RustBuffer {
-          var writer = createWriter()
-          write(value, into: &writer)
-          return RustBuffer(bytes: writer)
+        var writer = createWriter()
+        write(value, into: &writer)
+        return RustBuffer(bytes: writer)
     }
 }
+
 // An error type for FFI errors. These errors occur at the UniFFI level, not
 // the library level.
-fileprivate enum UniffiInternalError: LocalizedError {
+private enum UniffiInternalError: LocalizedError {
     case bufferOverflow
     case incompleteData
     case unexpectedOptionalTag
@@ -240,24 +241,24 @@ fileprivate enum UniffiInternalError: LocalizedError {
     }
 }
 
-fileprivate extension NSLock {
+private extension NSLock {
     func withLock<T>(f: () throws -> T) rethrows -> T {
-        self.lock()
+        lock()
         defer { self.unlock() }
         return try f()
     }
 }
 
-fileprivate let CALL_SUCCESS: Int8 = 0
-fileprivate let CALL_ERROR: Int8 = 1
-fileprivate let CALL_UNEXPECTED_ERROR: Int8 = 2
-fileprivate let CALL_CANCELLED: Int8 = 3
+private let CALL_SUCCESS: Int8 = 0
+private let CALL_ERROR: Int8 = 1
+private let CALL_UNEXPECTED_ERROR: Int8 = 2
+private let CALL_CANCELLED: Int8 = 3
 
-fileprivate extension RustCallStatus {
+private extension RustCallStatus {
     init() {
         self.init(
             code: CALL_SUCCESS,
-            errorBuf: RustBuffer.init(
+            errorBuf: RustBuffer(
                 capacity: 0,
                 len: 0,
                 data: nil
@@ -273,7 +274,8 @@ private func rustCall<T>(_ callback: (UnsafeMutablePointer<RustCallStatus>) -> T
 
 private func rustCallWithError<T, E: Swift.Error>(
     _ errorHandler: @escaping (RustBuffer) throws -> E,
-    _ callback: (UnsafeMutablePointer<RustCallStatus>) -> T) throws -> T {
+    _ callback: (UnsafeMutablePointer<RustCallStatus>) -> T
+) throws -> T {
     try makeRustCall(callback, errorHandler: errorHandler)
 }
 
@@ -282,7 +284,7 @@ private func makeRustCall<T, E: Swift.Error>(
     errorHandler: ((RustBuffer) throws -> E)?
 ) throws -> T {
     uniffiEnsureInitialized()
-    var callStatus = RustCallStatus.init()
+    var callStatus = RustCallStatus()
     let returnedVal = callback(&callStatus)
     try uniffiCheckCallStatus(callStatus: callStatus, errorHandler: errorHandler)
     return returnedVal
@@ -293,44 +295,44 @@ private func uniffiCheckCallStatus<E: Swift.Error>(
     errorHandler: ((RustBuffer) throws -> E)?
 ) throws {
     switch callStatus.code {
-        case CALL_SUCCESS:
-            return
+    case CALL_SUCCESS:
+        return
 
-        case CALL_ERROR:
-            if let errorHandler = errorHandler {
-                throw try errorHandler(callStatus.errorBuf)
-            } else {
-                callStatus.errorBuf.deallocate()
-                throw UniffiInternalError.unexpectedRustCallError
-            }
+    case CALL_ERROR:
+        if let errorHandler = errorHandler {
+            throw try errorHandler(callStatus.errorBuf)
+        } else {
+            callStatus.errorBuf.deallocate()
+            throw UniffiInternalError.unexpectedRustCallError
+        }
 
-        case CALL_UNEXPECTED_ERROR:
-            // When the rust code sees a panic, it tries to construct a RustBuffer
-            // with the message.  But if that code panics, then it just sends back
-            // an empty buffer.
-            if callStatus.errorBuf.len > 0 {
-                throw UniffiInternalError.rustPanic(try FfiConverterString.lift(callStatus.errorBuf))
-            } else {
-                callStatus.errorBuf.deallocate()
-                throw UniffiInternalError.rustPanic("Rust panic")
-            }
+    case CALL_UNEXPECTED_ERROR:
+        // When the rust code sees a panic, it tries to construct a RustBuffer
+        // with the message.  But if that code panics, then it just sends back
+        // an empty buffer.
+        if callStatus.errorBuf.len > 0 {
+            throw try UniffiInternalError.rustPanic(FfiConverterString.lift(callStatus.errorBuf))
+        } else {
+            callStatus.errorBuf.deallocate()
+            throw UniffiInternalError.rustPanic("Rust panic")
+        }
 
-        case CALL_CANCELLED:
-            fatalError("Cancellation not supported yet")
+    case CALL_CANCELLED:
+        fatalError("Cancellation not supported yet")
 
-        default:
-            throw UniffiInternalError.unexpectedRustCallStatusCode
+    default:
+        throw UniffiInternalError.unexpectedRustCallStatusCode
     }
 }
 
 private func uniffiTraitInterfaceCall<T>(
     callStatus: UnsafeMutablePointer<RustCallStatus>,
     makeCall: () throws -> T,
-    writeReturn: (T) -> ()
+    writeReturn: (T) -> Void
 ) {
     do {
         try writeReturn(makeCall())
-    } catch let error {
+    } catch {
         callStatus.pointee.code = CALL_UNEXPECTED_ERROR
         callStatus.pointee.errorBuf = FfiConverterString.lower(String(describing: error))
     }
@@ -339,7 +341,7 @@ private func uniffiTraitInterfaceCall<T>(
 private func uniffiTraitInterfaceCallWithError<T, E>(
     callStatus: UnsafeMutablePointer<RustCallStatus>,
     makeCall: () throws -> T,
-    writeReturn: (T) -> (),
+    writeReturn: (T) -> Void,
     lowerError: (E) -> RustBuffer
 ) {
     do {
@@ -352,7 +354,8 @@ private func uniffiTraitInterfaceCallWithError<T, E>(
         callStatus.pointee.errorBuf = FfiConverterString.lower(String(describing: error))
     }
 }
-fileprivate class UniffiHandleMap<T> {
+
+private class UniffiHandleMap<T> {
     private var map: [UInt64: T] = [:]
     private let lock = NSLock()
     private var currentHandle: UInt64 = 1
@@ -366,7 +369,7 @@ fileprivate class UniffiHandleMap<T> {
         }
     }
 
-     func get(handle: UInt64) throws -> T {
+    func get(handle: UInt64) throws -> T {
         try lock.withLock {
             guard let obj = map[handle] else {
                 throw UniffiInternalError.unexpectedStaleHandle
@@ -386,25 +389,21 @@ fileprivate class UniffiHandleMap<T> {
     }
 
     var count: Int {
-        get {
-            map.count
-        }
+        map.count
     }
 }
 
-
 // Public interface members begin here.
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterUInt8: FfiConverterPrimitive {
+private struct FfiConverterUInt8: FfiConverterPrimitive {
     typealias FfiType = UInt8
     typealias SwiftType = UInt8
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt8 {
-        return try lift(readInt(&buf))
+        try lift(readInt(&buf))
     }
 
     public static func write(_ value: UInt8, into buf: inout [UInt8]) {
@@ -415,12 +414,12 @@ fileprivate struct FfiConverterUInt8: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
+private struct FfiConverterUInt32: FfiConverterPrimitive {
     typealias FfiType = UInt32
     typealias SwiftType = UInt32
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt32 {
-        return try lift(readInt(&buf))
+        try lift(readInt(&buf))
     }
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -431,12 +430,12 @@ fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
+private struct FfiConverterUInt64: FfiConverterPrimitive {
     typealias FfiType = UInt64
     typealias SwiftType = UInt64
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt64 {
-        return try lift(readInt(&buf))
+        try lift(readInt(&buf))
     }
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -447,12 +446,12 @@ fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
+private struct FfiConverterInt64: FfiConverterPrimitive {
     typealias FfiType = Int64
     typealias SwiftType = Int64
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Int64 {
-        return try lift(readInt(&buf))
+        try lift(readInt(&buf))
     }
 
     public static func write(_ value: Int64, into buf: inout [UInt8]) {
@@ -463,12 +462,12 @@ fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
+private struct FfiConverterDouble: FfiConverterPrimitive {
     typealias FfiType = Double
     typealias SwiftType = Double
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Double {
-        return try lift(readDouble(&buf))
+        try lift(readDouble(&buf))
     }
 
     public static func write(_ value: Double, into buf: inout [UInt8]) {
@@ -479,20 +478,20 @@ fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterBool : FfiConverter {
+private struct FfiConverterBool: FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
 
     public static func lift(_ value: Int8) throws -> Bool {
-        return value != 0
+        value != 0
     }
 
     public static func lower(_ value: Bool) -> Int8 {
-        return value ? 1 : 0
+        value ? 1 : 0
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Bool {
-        return try lift(readInt(&buf))
+        try lift(readInt(&buf))
     }
 
     public static func write(_ value: Bool, into buf: inout [UInt8]) {
@@ -503,7 +502,7 @@ fileprivate struct FfiConverterBool : FfiConverter {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterString: FfiConverter {
+private struct FfiConverterString: FfiConverter {
     typealias SwiftType = String
     typealias FfiType = RustBuffer
 
@@ -519,7 +518,7 @@ fileprivate struct FfiConverterString: FfiConverter {
     }
 
     public static func lower(_ value: String) -> RustBuffer {
-        return value.utf8CString.withUnsafeBufferPointer { ptr in
+        value.utf8CString.withUnsafeBufferPointer { ptr in
             // The swift string gives us int8_t, we want uint8_t.
             ptr.withMemoryRebound(to: UInt8.self) { ptr in
                 // The swift string gives us a trailing null byte, we don't want it.
@@ -531,7 +530,7 @@ fileprivate struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        return try String(bytes: readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {
@@ -541,145 +540,141 @@ fileprivate struct FfiConverterString: FfiConverter {
     }
 }
 
+public protocol DocProtocol: AnyObject {
+    func actorId() -> ActorId
 
+    func applyEncodedChanges(changes: [UInt8]) throws
 
+    func applyEncodedChangesWithPatches(changes: [UInt8]) throws -> [Patch]
 
-public protocol DocProtocol : AnyObject {
-    
-    func actorId()  -> ActorId
-    
-    func applyEncodedChanges(changes: [UInt8]) throws 
-    
-    func applyEncodedChangesWithPatches(changes: [UInt8]) throws  -> [Patch]
-    
-    func changeByHash(hash: ChangeHash)  -> Change?
-    
-    func changes()  -> [ChangeHash]
-    
-    func commitWith(msg: String?, time: Int64) 
-    
-    func cursor(obj: ObjId, position: UInt64) throws  -> Cursor
-    
-    func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash]) throws  -> Cursor
-    
-    func cursorPosition(obj: ObjId, cursor: Cursor) throws  -> UInt64
-    
-    func cursorPositionAt(obj: ObjId, cursor: Cursor, heads: [ChangeHash]) throws  -> UInt64
-    
-    func deleteInList(obj: ObjId, index: UInt64) throws 
-    
-    func deleteInMap(obj: ObjId, key: String) throws 
-    
-    func difference(before: [ChangeHash], after: [ChangeHash])  -> [Patch]
-    
-    func encodeChangesSince(heads: [ChangeHash]) throws  -> [UInt8]
-    
-    func encodeNewChanges()  -> [UInt8]
-    
-    func fork()  -> Doc
-    
-    func forkAt(heads: [ChangeHash]) throws  -> Doc
-    
-    func generateSyncMessage(state: SyncState)  -> [UInt8]?
-    
-    func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws  -> [Value]
-    
-    func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws  -> [Value]
-    
-    func getAllInList(obj: ObjId, index: UInt64) throws  -> [Value]
-    
-    func getAllInMap(obj: ObjId, key: String) throws  -> [Value]
-    
-    func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws  -> Value?
-    
-    func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws  -> Value?
-    
-    func getInList(obj: ObjId, index: UInt64) throws  -> Value?
-    
-    func getInMap(obj: ObjId, key: String) throws  -> Value?
-    
-    func heads()  -> [ChangeHash]
-    
-    func incrementInList(obj: ObjId, index: UInt64, by: Int64) throws 
-    
-    func incrementInMap(obj: ObjId, key: String, by: Int64) throws 
-    
-    func insertInList(obj: ObjId, index: UInt64, value: ScalarValue) throws 
-    
-    func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws  -> ObjId
-    
-    func joinBlock(obj: ObjId, index: UInt32) throws 
-    
-    func length(obj: ObjId)  -> UInt64
-    
-    func lengthAt(obj: ObjId, heads: [ChangeHash])  -> UInt64
-    
-    func mapEntries(obj: ObjId) throws  -> [KeyValue]
-    
-    func mapEntriesAt(obj: ObjId, heads: [ChangeHash]) throws  -> [KeyValue]
-    
-    func mapKeys(obj: ObjId)  -> [String]
-    
-    func mapKeysAt(obj: ObjId, heads: [ChangeHash])  -> [String]
-    
-    func mark(obj: ObjId, start: UInt64, end: UInt64, expand: ExpandMark, name: String, value: ScalarValue) throws 
-    
-    func marks(obj: ObjId) throws  -> [Mark]
-    
-    func marksAt(obj: ObjId, heads: [ChangeHash]) throws  -> [Mark]
-    
-    func marksAtPosition(obj: ObjId, position: Position, heads: [ChangeHash]) throws  -> [Mark]
-    
-    func merge(other: Doc) throws 
-    
-    func mergeWithPatches(other: Doc) throws  -> [Patch]
-    
-    func objectType(obj: ObjId)  -> ObjType
-    
-    func path(obj: ObjId) throws  -> [PathElement]
-    
-    func putInList(obj: ObjId, index: UInt64, value: ScalarValue) throws 
-    
-    func putInMap(obj: ObjId, key: String, value: ScalarValue) throws 
-    
-    func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws  -> ObjId
-    
-    func putObjectInMap(obj: ObjId, key: String, objType: ObjType) throws  -> ObjId
-    
-    func receiveSyncMessage(state: SyncState, msg: [UInt8]) throws 
-    
-    func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws  -> [Patch]
-    
-    func save()  -> [UInt8]
-    
-    func setActor(actor: ActorId) 
-    
-    func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue]) throws 
-    
-    func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String) throws 
-    
-    func splitBlock(obj: ObjId, index: UInt32) throws  -> ObjId
-    
-    func text(obj: ObjId) throws  -> String
-    
-    func textAt(obj: ObjId, heads: [ChangeHash]) throws  -> String
-    
-    func updateText(obj: ObjId, chars: String) throws 
-    
-    func values(obj: ObjId) throws  -> [Value]
-    
-    func valuesAt(obj: ObjId, heads: [ChangeHash]) throws  -> [Value]
-    
+    func changeByHash(hash: ChangeHash) -> Change?
+
+    func changes() -> [ChangeHash]
+
+    func commitWith(msg: String?, time: Int64)
+
+    func cursor(obj: ObjId, position: UInt64) throws -> Cursor
+
+    func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash]) throws -> Cursor
+
+    func cursorPosition(obj: ObjId, cursor: Cursor) throws -> UInt64
+
+    func cursorPositionAt(obj: ObjId, cursor: Cursor, heads: [ChangeHash]) throws -> UInt64
+
+    func deleteInList(obj: ObjId, index: UInt64) throws
+
+    func deleteInMap(obj: ObjId, key: String) throws
+
+    func difference(before: [ChangeHash], after: [ChangeHash]) -> [Patch]
+
+    func encodeChangesSince(heads: [ChangeHash]) throws -> [UInt8]
+
+    func encodeNewChanges() -> [UInt8]
+
+    func fork() -> Doc
+
+    func forkAt(heads: [ChangeHash]) throws -> Doc
+
+    func generateSyncMessage(state: SyncState) -> [UInt8]?
+
+    func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> [Value]
+
+    func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> [Value]
+
+    func getAllInList(obj: ObjId, index: UInt64) throws -> [Value]
+
+    func getAllInMap(obj: ObjId, key: String) throws -> [Value]
+
+    func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> Value?
+
+    func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> Value?
+
+    func getInList(obj: ObjId, index: UInt64) throws -> Value?
+
+    func getInMap(obj: ObjId, key: String) throws -> Value?
+
+    func heads() -> [ChangeHash]
+
+    func incrementInList(obj: ObjId, index: UInt64, by: Int64) throws
+
+    func incrementInMap(obj: ObjId, key: String, by: Int64) throws
+
+    func insertInList(obj: ObjId, index: UInt64, value: ScalarValue) throws
+
+    func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId
+
+    func joinBlock(obj: ObjId, index: UInt32) throws
+
+    func length(obj: ObjId) -> UInt64
+
+    func lengthAt(obj: ObjId, heads: [ChangeHash]) -> UInt64
+
+    func mapEntries(obj: ObjId) throws -> [KeyValue]
+
+    func mapEntriesAt(obj: ObjId, heads: [ChangeHash]) throws -> [KeyValue]
+
+    func mapKeys(obj: ObjId) -> [String]
+
+    func mapKeysAt(obj: ObjId, heads: [ChangeHash]) -> [String]
+
+    func mark(obj: ObjId, start: UInt64, end: UInt64, expand: ExpandMark, name: String, value: ScalarValue) throws
+
+    func marks(obj: ObjId) throws -> [Mark]
+
+    func marksAt(obj: ObjId, heads: [ChangeHash]) throws -> [Mark]
+
+    func marksAtPosition(obj: ObjId, position: Position, heads: [ChangeHash]) throws -> [Mark]
+
+    func merge(other: Doc) throws
+
+    func mergeWithPatches(other: Doc) throws -> [Patch]
+
+    func objectType(obj: ObjId) -> ObjType
+
+    func path(obj: ObjId) throws -> [PathElement]
+
+    func putInList(obj: ObjId, index: UInt64, value: ScalarValue) throws
+
+    func putInMap(obj: ObjId, key: String, value: ScalarValue) throws
+
+    func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId
+
+    func putObjectInMap(obj: ObjId, key: String, objType: ObjType) throws -> ObjId
+
+    func receiveSyncMessage(state: SyncState, msg: [UInt8]) throws
+
+    func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws -> [Patch]
+
+    func save() -> [UInt8]
+
+    func setActor(actor: ActorId)
+
+    func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue]) throws
+
+    func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String) throws
+
+    func splitBlock(obj: ObjId, index: UInt32) throws -> ObjId
+
+    func text(obj: ObjId) throws -> String
+
+    func textAt(obj: ObjId, heads: [ChangeHash]) throws -> String
+
+    func updateText(obj: ObjId, chars: String) throws
+
+    func values(obj: ObjId) throws -> [Value]
+
+    func valuesAt(obj: ObjId, heads: [ChangeHash]) throws -> [Value]
 }
 
 open class Doc:
-    DocProtocol {
+    DocProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public struct NoPointer {
         public init() {}
     }
@@ -687,36 +682,40 @@ open class Doc:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
     // This constructor can be used to instantiate a fake object.
-    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that
+    // may be implemented for classes extending [FFIObject].
     //
     // - Warning:
-    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-#if swift(>=5.8)
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there
+    //     isn't a backing [Pointer] the FFI lower functions will crash.
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    #endif
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
-        return try! rustCall { uniffi_uniffi_automerge_fn_clone_doc(self.pointer, $0) }
+        try! rustCall { uniffi_uniffi_automerge_fn_clone_doc(self.pointer, $0) }
     }
-public convenience init() {
-    let pointer =
-        try! rustCall() {
-    uniffi_uniffi_automerge_fn_constructor_doc_new($0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+
+    public convenience init() {
+        let pointer =
+            try! rustCall {
+                uniffi_uniffi_automerge_fn_constructor_doc_new(
+                    $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -726,577 +725,711 @@ public convenience init() {
         try! rustCall { uniffi_uniffi_automerge_fn_free_doc(pointer, $0) }
     }
 
-    
-public static func load(bytes: [UInt8])throws  -> Doc {
-    return try  FfiConverterTypeDoc.lift(try rustCallWithError(FfiConverterTypeLoadError.lift) {
-    uniffi_uniffi_automerge_fn_constructor_doc_load(
-        FfiConverterSequenceUInt8.lower(bytes),$0
-    )
-})
-}
-    
-public static func newWithActor(actor: ActorId) -> Doc {
-    return try!  FfiConverterTypeDoc.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_constructor_doc_new_with_actor(
-        FfiConverterTypeActorId.lower(actor),$0
-    )
-})
-}
-    
+    public static func load(bytes: [UInt8]) throws -> Doc {
+        try FfiConverterTypeDoc.lift(rustCallWithError(FfiConverterTypeLoadError.lift) {
+            uniffi_uniffi_automerge_fn_constructor_doc_load(
+                FfiConverterSequenceUInt8.lower(bytes), $0
+            )
+        })
+    }
 
-    
-open func actorId() -> ActorId {
-    return try!  FfiConverterTypeActorId.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_actor_id(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func applyEncodedChanges(changes: [UInt8])throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes(self.uniffiClonePointer(),
-        FfiConverterSequenceUInt8.lower(changes),$0
-    )
-}
-}
-    
-open func applyEncodedChangesWithPatches(changes: [UInt8])throws  -> [Patch] {
-    return try  FfiConverterSequenceTypePatch.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(self.uniffiClonePointer(),
-        FfiConverterSequenceUInt8.lower(changes),$0
-    )
-})
-}
-    
-open func changeByHash(hash: ChangeHash) -> Change? {
-    return try!  FfiConverterOptionTypeChange.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_change_by_hash(self.uniffiClonePointer(),
-        FfiConverterTypeChangeHash.lower(hash),$0
-    )
-})
-}
-    
-open func changes() -> [ChangeHash] {
-    return try!  FfiConverterSequenceTypeChangeHash.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_changes(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func commitWith(msg: String?, time: Int64) {try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_commit_with(self.uniffiClonePointer(),
-        FfiConverterOptionString.lower(msg),
-        FfiConverterInt64.lower(time),$0
-    )
-}
-}
-    
-open func cursor(obj: ObjId, position: UInt64)throws  -> Cursor {
-    return try  FfiConverterTypeCursor.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_cursor(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(position),$0
-    )
-})
-}
-    
-open func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash])throws  -> Cursor {
-    return try  FfiConverterTypeCursor.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_cursor_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(position),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func cursorPosition(obj: ObjId, cursor: Cursor)throws  -> UInt64 {
-    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_cursor_position(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterTypeCursor.lower(cursor),$0
-    )
-})
-}
-    
-open func cursorPositionAt(obj: ObjId, cursor: Cursor, heads: [ChangeHash])throws  -> UInt64 {
-    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_cursor_position_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterTypeCursor.lower(cursor),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func deleteInList(obj: ObjId, index: UInt64)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_delete_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),$0
-    )
-}
-}
-    
-open func deleteInMap(obj: ObjId, key: String)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_delete_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),$0
-    )
-}
-}
-    
-open func difference(before: [ChangeHash], after: [ChangeHash]) -> [Patch] {
-    return try!  FfiConverterSequenceTypePatch.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_difference(self.uniffiClonePointer(),
-        FfiConverterSequenceTypeChangeHash.lower(before),
-        FfiConverterSequenceTypeChangeHash.lower(after),$0
-    )
-})
-}
-    
-open func encodeChangesSince(heads: [ChangeHash])throws  -> [UInt8] {
-    return try  FfiConverterSequenceUInt8.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_encode_changes_since(self.uniffiClonePointer(),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func encodeNewChanges() -> [UInt8] {
-    return try!  FfiConverterSequenceUInt8.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_encode_new_changes(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func fork() -> Doc {
-    return try!  FfiConverterTypeDoc.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_fork(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func forkAt(heads: [ChangeHash])throws  -> Doc {
-    return try  FfiConverterTypeDoc.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_fork_at(self.uniffiClonePointer(),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func generateSyncMessage(state: SyncState) -> [UInt8]? {
-    return try!  FfiConverterOptionSequenceUInt8.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_generate_sync_message(self.uniffiClonePointer(),
-        FfiConverterTypeSyncState.lower(state),$0
-    )
-})
-}
-    
-open func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash])throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_all_at_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash])throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_all_at_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func getAllInList(obj: ObjId, index: UInt64)throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_all_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),$0
-    )
-})
-}
-    
-open func getAllInMap(obj: ObjId, key: String)throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_all_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),$0
-    )
-})
-}
-    
-open func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash])throws  -> Value? {
-    return try  FfiConverterOptionTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_at_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash])throws  -> Value? {
-    return try  FfiConverterOptionTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_at_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func getInList(obj: ObjId, index: UInt64)throws  -> Value? {
-    return try  FfiConverterOptionTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),$0
-    )
-})
-}
-    
-open func getInMap(obj: ObjId, key: String)throws  -> Value? {
-    return try  FfiConverterOptionTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_get_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),$0
-    )
-})
-}
-    
-open func heads() -> [ChangeHash] {
-    return try!  FfiConverterSequenceTypeChangeHash.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_heads(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func incrementInList(obj: ObjId, index: UInt64, by: Int64)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_increment_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterInt64.lower(by),$0
-    )
-}
-}
-    
-open func incrementInMap(obj: ObjId, key: String, by: Int64)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_increment_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),
-        FfiConverterInt64.lower(by),$0
-    )
-}
-}
-    
-open func insertInList(obj: ObjId, index: UInt64, value: ScalarValue)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_insert_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterTypeScalarValue.lower(value),$0
-    )
-}
-}
-    
-open func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType)throws  -> ObjId {
-    return try  FfiConverterTypeObjId.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_insert_object_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterTypeObjType.lower(objType),$0
-    )
-})
-}
-    
-open func joinBlock(obj: ObjId, index: UInt32)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_join_block(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt32.lower(index),$0
-    )
-}
-}
-    
-open func length(obj: ObjId) -> UInt64 {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_length(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func lengthAt(obj: ObjId, heads: [ChangeHash]) -> UInt64 {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_length_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func mapEntries(obj: ObjId)throws  -> [KeyValue] {
-    return try  FfiConverterSequenceTypeKeyValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_map_entries(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func mapEntriesAt(obj: ObjId, heads: [ChangeHash])throws  -> [KeyValue] {
-    return try  FfiConverterSequenceTypeKeyValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_map_entries_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func mapKeys(obj: ObjId) -> [String] {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_map_keys(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func mapKeysAt(obj: ObjId, heads: [ChangeHash]) -> [String] {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_map_keys_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func mark(obj: ObjId, start: UInt64, end: UInt64, expand: ExpandMark, name: String, value: ScalarValue)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_mark(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(start),
-        FfiConverterUInt64.lower(end),
-        FfiConverterTypeExpandMark.lower(expand),
-        FfiConverterString.lower(name),
-        FfiConverterTypeScalarValue.lower(value),$0
-    )
-}
-}
-    
-open func marks(obj: ObjId)throws  -> [Mark] {
-    return try  FfiConverterSequenceTypeMark.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_marks(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func marksAt(obj: ObjId, heads: [ChangeHash])throws  -> [Mark] {
-    return try  FfiConverterSequenceTypeMark.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_marks_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func marksAtPosition(obj: ObjId, position: Position, heads: [ChangeHash])throws  -> [Mark] {
-    return try  FfiConverterSequenceTypeMark.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_marks_at_position(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterTypePosition.lower(position),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func merge(other: Doc)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_merge(self.uniffiClonePointer(),
-        FfiConverterTypeDoc.lower(other),$0
-    )
-}
-}
-    
-open func mergeWithPatches(other: Doc)throws  -> [Patch] {
-    return try  FfiConverterSequenceTypePatch.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_merge_with_patches(self.uniffiClonePointer(),
-        FfiConverterTypeDoc.lower(other),$0
-    )
-})
-}
-    
-open func objectType(obj: ObjId) -> ObjType {
-    return try!  FfiConverterTypeObjType.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_object_type(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func path(obj: ObjId)throws  -> [PathElement] {
-    return try  FfiConverterSequenceTypePathElement.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_path(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func putInList(obj: ObjId, index: UInt64, value: ScalarValue)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_put_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterTypeScalarValue.lower(value),$0
-    )
-}
-}
-    
-open func putInMap(obj: ObjId, key: String, value: ScalarValue)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_put_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),
-        FfiConverterTypeScalarValue.lower(value),$0
-    )
-}
-}
-    
-open func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType)throws  -> ObjId {
-    return try  FfiConverterTypeObjId.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_put_object_in_list(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(index),
-        FfiConverterTypeObjType.lower(objType),$0
-    )
-})
-}
-    
-open func putObjectInMap(obj: ObjId, key: String, objType: ObjType)throws  -> ObjId {
-    return try  FfiConverterTypeObjId.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_put_object_in_map(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(key),
-        FfiConverterTypeObjType.lower(objType),$0
-    )
-})
-}
-    
-open func receiveSyncMessage(state: SyncState, msg: [UInt8])throws  {try rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_receive_sync_message(self.uniffiClonePointer(),
-        FfiConverterTypeSyncState.lower(state),
-        FfiConverterSequenceUInt8.lower(msg),$0
-    )
-}
-}
-    
-open func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8])throws  -> [Patch] {
-    return try  FfiConverterSequenceTypePatch.lift(try rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(self.uniffiClonePointer(),
-        FfiConverterTypeSyncState.lower(state),
-        FfiConverterSequenceUInt8.lower(msg),$0
-    )
-})
-}
-    
-open func save() -> [UInt8] {
-    return try!  FfiConverterSequenceUInt8.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_save(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func setActor(actor: ActorId) {try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_doc_set_actor(self.uniffiClonePointer(),
-        FfiConverterTypeActorId.lower(actor),$0
-    )
-}
-}
-    
-open func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue])throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_splice(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(start),
-        FfiConverterInt64.lower(delete),
-        FfiConverterSequenceTypeScalarValue.lower(values),$0
-    )
-}
-}
-    
-open func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_splice_text(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt64.lower(start),
-        FfiConverterInt64.lower(delete),
-        FfiConverterString.lower(chars),$0
-    )
-}
-}
-    
-open func splitBlock(obj: ObjId, index: UInt32)throws  -> ObjId {
-    return try  FfiConverterTypeObjId.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_split_block(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterUInt32.lower(index),$0
-    )
-})
-}
-    
-open func text(obj: ObjId)throws  -> String {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_text(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func textAt(obj: ObjId, heads: [ChangeHash])throws  -> String {
-    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_text_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
-open func updateText(obj: ObjId, chars: String)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_update_text(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterString.lower(chars),$0
-    )
-}
-}
-    
-open func values(obj: ObjId)throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_values(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),$0
-    )
-})
-}
-    
-open func valuesAt(obj: ObjId, heads: [ChangeHash])throws  -> [Value] {
-    return try  FfiConverterSequenceTypeValue.lift(try rustCallWithError(FfiConverterTypeDocError.lift) {
-    uniffi_uniffi_automerge_fn_method_doc_values_at(self.uniffiClonePointer(),
-        FfiConverterTypeObjId.lower(obj),
-        FfiConverterSequenceTypeChangeHash.lower(heads),$0
-    )
-})
-}
-    
+    public static func newWithActor(actor: ActorId) -> Doc {
+        try! FfiConverterTypeDoc.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_constructor_doc_new_with_actor(
+                FfiConverterTypeActorId.lower(actor), $0
+            )
+        })
+    }
 
+    open func actorId() -> ActorId {
+        try! FfiConverterTypeActorId.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_actor_id(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func applyEncodedChanges(changes: [UInt8]) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes(
+            self.uniffiClonePointer(),
+            FfiConverterSequenceUInt8.lower(changes),
+            $0
+        )
+    }
+    }
+
+    open func applyEncodedChangesWithPatches(changes: [UInt8]) throws -> [Patch] {
+        try FfiConverterSequenceTypePatch.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_apply_encoded_changes_with_patches(
+                self.uniffiClonePointer(),
+                FfiConverterSequenceUInt8.lower(changes),
+                $0
+            )
+        })
+    }
+
+    open func changeByHash(hash: ChangeHash) -> Change? {
+        try! FfiConverterOptionTypeChange.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_change_by_hash(
+                self.uniffiClonePointer(),
+                FfiConverterTypeChangeHash.lower(hash),
+                $0
+            )
+        })
+    }
+
+    open func changes() -> [ChangeHash] {
+        try! FfiConverterSequenceTypeChangeHash.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_changes(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func commitWith(msg: String?, time: Int64) { try! rustCall {
+        uniffi_uniffi_automerge_fn_method_doc_commit_with(
+            self.uniffiClonePointer(),
+            FfiConverterOptionString.lower(msg),
+            FfiConverterInt64.lower(time),
+            $0
+        )
+    }
+    }
+
+    open func cursor(obj: ObjId, position: UInt64) throws -> Cursor {
+        try FfiConverterTypeCursor.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_cursor(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(position),
+                $0
+            )
+        })
+    }
+
+    open func cursorAt(obj: ObjId, position: UInt64, heads: [ChangeHash]) throws -> Cursor {
+        try FfiConverterTypeCursor.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_cursor_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(position),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func cursorPosition(obj: ObjId, cursor: Cursor) throws -> UInt64 {
+        try FfiConverterUInt64.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_cursor_position(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterTypeCursor.lower(cursor),
+                $0
+            )
+        })
+    }
+
+    open func cursorPositionAt(obj: ObjId, cursor: Cursor, heads: [ChangeHash]) throws -> UInt64 {
+        try FfiConverterUInt64.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_cursor_position_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterTypeCursor.lower(cursor),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func deleteInList(obj: ObjId, index: UInt64) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_delete_in_list(
+            self.uniffiClonePointer(),
+            FfiConverterTypeObjId.lower(obj),
+            FfiConverterUInt64.lower(index),
+            $0
+        )
+    }
+    }
+
+    open func deleteInMap(obj: ObjId, key: String) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_delete_in_map(
+            self.uniffiClonePointer(),
+            FfiConverterTypeObjId.lower(obj),
+            FfiConverterString.lower(key),
+            $0
+        )
+    }
+    }
+
+    open func difference(before: [ChangeHash], after: [ChangeHash]) -> [Patch] {
+        try! FfiConverterSequenceTypePatch.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_difference(
+                self.uniffiClonePointer(),
+                FfiConverterSequenceTypeChangeHash.lower(before),
+                FfiConverterSequenceTypeChangeHash.lower(after),
+                $0
+            )
+        })
+    }
+
+    open func encodeChangesSince(heads: [ChangeHash]) throws -> [UInt8] {
+        try FfiConverterSequenceUInt8.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_encode_changes_since(
+                self.uniffiClonePointer(),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func encodeNewChanges() -> [UInt8] {
+        try! FfiConverterSequenceUInt8.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_encode_new_changes(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func fork() -> Doc {
+        try! FfiConverterTypeDoc.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_fork(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func forkAt(heads: [ChangeHash]) throws -> Doc {
+        try FfiConverterTypeDoc.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_fork_at(
+                self.uniffiClonePointer(),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func generateSyncMessage(state: SyncState) -> [UInt8]? {
+        try! FfiConverterOptionSequenceUInt8.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_generate_sync_message(
+                self.uniffiClonePointer(),
+                FfiConverterTypeSyncState.lower(state),
+                $0
+            )
+        })
+    }
+
+    open func getAllAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_all_at_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func getAllAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_all_at_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func getAllInList(obj: ObjId, index: UInt64) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_all_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                $0
+            )
+        })
+    }
+
+    open func getAllInMap(obj: ObjId, key: String) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_all_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                $0
+            )
+        })
+    }
+
+    open func getAtInList(obj: ObjId, index: UInt64, heads: [ChangeHash]) throws -> Value? {
+        try FfiConverterOptionTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_at_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func getAtInMap(obj: ObjId, key: String, heads: [ChangeHash]) throws -> Value? {
+        try FfiConverterOptionTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_at_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func getInList(obj: ObjId, index: UInt64) throws -> Value? {
+        try FfiConverterOptionTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                $0
+            )
+        })
+    }
+
+    open func getInMap(obj: ObjId, key: String) throws -> Value? {
+        try FfiConverterOptionTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_get_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                $0
+            )
+        })
+    }
+
+    open func heads() -> [ChangeHash] {
+        try! FfiConverterSequenceTypeChangeHash.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_heads(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func incrementInList(obj: ObjId, index: UInt64, by: Int64) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_increment_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterInt64.lower(by),
+                $0
+            )
+        }
+    }
+
+    open func incrementInMap(obj: ObjId, key: String, by: Int64) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_increment_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                FfiConverterInt64.lower(by),
+                $0
+            )
+        }
+    }
+
+    open func insertInList(obj: ObjId, index: UInt64, value: ScalarValue) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_insert_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterTypeScalarValue.lower(value),
+                $0
+            )
+        }
+    }
+
+    open func insertObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
+        try FfiConverterTypeObjId.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_insert_object_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterTypeObjType.lower(objType),
+                $0
+            )
+        })
+    }
+
+    open func joinBlock(obj: ObjId, index: UInt32) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_join_block(
+            self.uniffiClonePointer(),
+            FfiConverterTypeObjId.lower(obj),
+            FfiConverterUInt32.lower(index),
+            $0
+        )
+    }
+    }
+
+    open func length(obj: ObjId) -> UInt64 {
+        try! FfiConverterUInt64.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_length(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func lengthAt(obj: ObjId, heads: [ChangeHash]) -> UInt64 {
+        try! FfiConverterUInt64.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_length_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func mapEntries(obj: ObjId) throws -> [KeyValue] {
+        try FfiConverterSequenceTypeKeyValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_map_entries(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func mapEntriesAt(obj: ObjId, heads: [ChangeHash]) throws -> [KeyValue] {
+        try FfiConverterSequenceTypeKeyValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_map_entries_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func mapKeys(obj: ObjId) -> [String] {
+        try! FfiConverterSequenceString.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_map_keys(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func mapKeysAt(obj: ObjId, heads: [ChangeHash]) -> [String] {
+        try! FfiConverterSequenceString.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_map_keys_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func mark(
+        obj: ObjId,
+        start: UInt64,
+        end: UInt64,
+        expand: ExpandMark,
+        name: String,
+        value: ScalarValue
+    ) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_mark(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(start),
+                FfiConverterUInt64.lower(end),
+                FfiConverterTypeExpandMark.lower(expand),
+                FfiConverterString.lower(name),
+                FfiConverterTypeScalarValue.lower(value),
+                $0
+            )
+        }
+    }
+
+    open func marks(obj: ObjId) throws -> [Mark] {
+        try FfiConverterSequenceTypeMark.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_marks(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func marksAt(obj: ObjId, heads: [ChangeHash]) throws -> [Mark] {
+        try FfiConverterSequenceTypeMark.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_marks_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func marksAtPosition(obj: ObjId, position: Position, heads: [ChangeHash]) throws -> [Mark] {
+        try FfiConverterSequenceTypeMark.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_marks_at_position(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterTypePosition.lower(position),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func merge(other: Doc) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_merge(
+            self.uniffiClonePointer(),
+            FfiConverterTypeDoc.lower(other),
+            $0
+        )
+    }
+    }
+
+    open func mergeWithPatches(other: Doc) throws -> [Patch] {
+        try FfiConverterSequenceTypePatch.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_merge_with_patches(
+                self.uniffiClonePointer(),
+                FfiConverterTypeDoc.lower(other),
+                $0
+            )
+        })
+    }
+
+    open func objectType(obj: ObjId) -> ObjType {
+        try! FfiConverterTypeObjType.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_object_type(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func path(obj: ObjId) throws -> [PathElement] {
+        try FfiConverterSequenceTypePathElement.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_path(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func putInList(obj: ObjId, index: UInt64, value: ScalarValue) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_put_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterTypeScalarValue.lower(value),
+                $0
+            )
+        }
+    }
+
+    open func putInMap(obj: ObjId, key: String, value: ScalarValue) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_put_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                FfiConverterTypeScalarValue.lower(value),
+                $0
+            )
+        }
+    }
+
+    open func putObjectInList(obj: ObjId, index: UInt64, objType: ObjType) throws -> ObjId {
+        try FfiConverterTypeObjId.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_put_object_in_list(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(index),
+                FfiConverterTypeObjType.lower(objType),
+                $0
+            )
+        })
+    }
+
+    open func putObjectInMap(obj: ObjId, key: String, objType: ObjType) throws -> ObjId {
+        try FfiConverterTypeObjId.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_put_object_in_map(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterString.lower(key),
+                FfiConverterTypeObjType.lower(objType),
+                $0
+            )
+        })
+    }
+
+    open func receiveSyncMessage(state: SyncState, msg: [UInt8]) throws {
+        try rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_receive_sync_message(
+                self.uniffiClonePointer(),
+                FfiConverterTypeSyncState.lower(state),
+                FfiConverterSequenceUInt8.lower(msg),
+                $0
+            )
+        }
+    }
+
+    open func receiveSyncMessageWithPatches(state: SyncState, msg: [UInt8]) throws -> [Patch] {
+        try FfiConverterSequenceTypePatch.lift(rustCallWithError(FfiConverterTypeReceiveSyncError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_receive_sync_message_with_patches(
+                self.uniffiClonePointer(),
+                FfiConverterTypeSyncState.lower(state),
+                FfiConverterSequenceUInt8.lower(msg),
+                $0
+            )
+        })
+    }
+
+    open func save() -> [UInt8] {
+        try! FfiConverterSequenceUInt8.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_doc_save(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
+
+    open func setActor(actor: ActorId) { try! rustCall {
+        uniffi_uniffi_automerge_fn_method_doc_set_actor(
+            self.uniffiClonePointer(),
+            FfiConverterTypeActorId.lower(actor),
+            $0
+        )
+    }
+    }
+
+    open func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue]) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_splice(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(start),
+                FfiConverterInt64.lower(delete),
+                FfiConverterSequenceTypeScalarValue.lower(values),
+                $0
+            )
+        }
+    }
+
+    open func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String) throws {
+        try rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_splice_text(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt64.lower(start),
+                FfiConverterInt64.lower(delete),
+                FfiConverterString.lower(chars),
+                $0
+            )
+        }
+    }
+
+    open func splitBlock(obj: ObjId, index: UInt32) throws -> ObjId {
+        try FfiConverterTypeObjId.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_split_block(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterUInt32.lower(index),
+                $0
+            )
+        })
+    }
+
+    open func text(obj: ObjId) throws -> String {
+        try FfiConverterString.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_text(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func textAt(obj: ObjId, heads: [ChangeHash]) throws -> String {
+        try FfiConverterString.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_text_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
+
+    open func updateText(obj: ObjId, chars: String) throws { try rustCallWithError(FfiConverterTypeDocError.lift) {
+        uniffi_uniffi_automerge_fn_method_doc_update_text(
+            self.uniffiClonePointer(),
+            FfiConverterTypeObjId.lower(obj),
+            FfiConverterString.lower(chars),
+            $0
+        )
+    }
+    }
+
+    open func values(obj: ObjId) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_values(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                $0
+            )
+        })
+    }
+
+    open func valuesAt(obj: ObjId, heads: [ChangeHash]) throws -> [Value] {
+        try FfiConverterSequenceTypeValue.lift(rustCallWithError(FfiConverterTypeDocError.lift) {
+            uniffi_uniffi_automerge_fn_method_doc_values_at(
+                self.uniffiClonePointer(),
+                FfiConverterTypeObjId.lower(obj),
+                FfiConverterSequenceTypeChangeHash.lower(heads),
+                $0
+            )
+        })
+    }
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeDoc: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = Doc
 
     public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Doc {
-        return Doc(unsafeFromRawPointer: pointer)
+        Doc(unsafeFromRawPointer: pointer)
     }
 
     public static func lower(_ value: Doc) -> UnsafeMutableRawPointer {
-        return value.uniffiClonePointer()
+        value.uniffiClonePointer()
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Doc {
@@ -1304,7 +1437,7 @@ public struct FfiConverterTypeDoc: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1317,44 +1450,37 @@ public struct FfiConverterTypeDoc: FfiConverter {
     }
 }
 
-
-
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeDoc_lift(_ pointer: UnsafeMutableRawPointer) throws -> Doc {
-    return try FfiConverterTypeDoc.lift(pointer)
+    try FfiConverterTypeDoc.lift(pointer)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeDoc_lower(_ value: Doc) -> UnsafeMutableRawPointer {
-    return FfiConverterTypeDoc.lower(value)
+    FfiConverterTypeDoc.lower(value)
 }
 
+public protocol SyncStateProtocol: AnyObject {
+    func encode() -> [UInt8]
 
+    func reset()
 
-
-public protocol SyncStateProtocol : AnyObject {
-    
-    func encode()  -> [UInt8]
-    
-    func reset() 
-    
-    func theirHeads()  -> [ChangeHash]?
-    
+    func theirHeads() -> [ChangeHash]?
 }
 
 open class SyncState:
-    SyncStateProtocol {
+    SyncStateProtocol
+{
     fileprivate let pointer: UnsafeMutableRawPointer!
 
     /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public struct NoPointer {
         public init() {}
     }
@@ -1362,36 +1488,40 @@ open class SyncState:
     // TODO: We'd like this to be `private` but for Swifty reasons,
     // we can't implement `FfiConverter` without making this `required` and we can't
     // make it `required` without making it `public`.
-    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+    public required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
 
     // This constructor can be used to instantiate a fake object.
-    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that
+    // may be implemented for classes extending [FFIObject].
     //
     // - Warning:
-    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
-#if swift(>=5.8)
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there
+    //     isn't a backing [Pointer] the FFI lower functions will crash.
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
-    public init(noPointer: NoPointer) {
-        self.pointer = nil
+    #endif
+    public init(noPointer _: NoPointer) {
+        pointer = nil
     }
 
-#if swift(>=5.8)
+    #if swift(>=5.8)
     @_documentation(visibility: private)
-#endif
+    #endif
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
-        return try! rustCall { uniffi_uniffi_automerge_fn_clone_syncstate(self.pointer, $0) }
+        try! rustCall { uniffi_uniffi_automerge_fn_clone_syncstate(self.pointer, $0) }
     }
-public convenience init() {
-    let pointer =
-        try! rustCall() {
-    uniffi_uniffi_automerge_fn_constructor_syncstate_new($0
-    )
-}
-    self.init(unsafeFromRawPointer: pointer)
-}
+
+    public convenience init() {
+        let pointer =
+            try! rustCall {
+                uniffi_uniffi_automerge_fn_constructor_syncstate_new(
+                    $0
+                )
+            }
+        self.init(unsafeFromRawPointer: pointer)
+    }
 
     deinit {
         guard let pointer = pointer else {
@@ -1401,54 +1531,54 @@ public convenience init() {
         try! rustCall { uniffi_uniffi_automerge_fn_free_syncstate(pointer, $0) }
     }
 
-    
-public static func decode(bytes: [UInt8])throws  -> SyncState {
-    return try  FfiConverterTypeSyncState.lift(try rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
-    uniffi_uniffi_automerge_fn_constructor_syncstate_decode(
-        FfiConverterSequenceUInt8.lower(bytes),$0
-    )
-})
-}
-    
+    public static func decode(bytes: [UInt8]) throws -> SyncState {
+        try FfiConverterTypeSyncState.lift(rustCallWithError(FfiConverterTypeDecodeSyncStateError.lift) {
+            uniffi_uniffi_automerge_fn_constructor_syncstate_decode(
+                FfiConverterSequenceUInt8.lower(bytes), $0
+            )
+        })
+    }
 
-    
-open func encode() -> [UInt8] {
-    return try!  FfiConverterSequenceUInt8.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_syncstate_encode(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
-open func reset() {try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_syncstate_reset(self.uniffiClonePointer(),$0
-    )
-}
-}
-    
-open func theirHeads() -> [ChangeHash]? {
-    return try!  FfiConverterOptionSequenceTypeChangeHash.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_method_syncstate_their_heads(self.uniffiClonePointer(),$0
-    )
-})
-}
-    
+    open func encode() -> [UInt8] {
+        try! FfiConverterSequenceUInt8.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_syncstate_encode(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
 
+    open func reset() { try! rustCall {
+        uniffi_uniffi_automerge_fn_method_syncstate_reset(
+            self.uniffiClonePointer(),
+            $0
+        )
+    }
+    }
+
+    open func theirHeads() -> [ChangeHash]? {
+        try! FfiConverterOptionSequenceTypeChangeHash.lift(try! rustCall {
+            uniffi_uniffi_automerge_fn_method_syncstate_their_heads(
+                self.uniffiClonePointer(),
+                $0
+            )
+        })
+    }
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeSyncState: FfiConverter {
-
     typealias FfiType = UnsafeMutableRawPointer
     typealias SwiftType = SyncState
 
     public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> SyncState {
-        return SyncState(unsafeFromRawPointer: pointer)
+        SyncState(unsafeFromRawPointer: pointer)
     }
 
     public static func lower(_ value: SyncState) -> UnsafeMutableRawPointer {
-        return value.uniffiClonePointer()
+        value.uniffiClonePointer()
     }
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SyncState {
@@ -1456,7 +1586,7 @@ public struct FfiConverterTypeSyncState: FfiConverter {
         // The Rust code won't compile if a pointer won't fit in a UInt64.
         // We have to go via `UInt` because that's the thing that's the size of a pointer.
         let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
-        if (ptr == nil) {
+        if ptr == nil {
             throw UniffiInternalError.unexpectedNullPointer
         }
         return try lift(ptr!)
@@ -1469,23 +1599,19 @@ public struct FfiConverterTypeSyncState: FfiConverter {
     }
 }
 
-
-
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeSyncState_lift(_ pointer: UnsafeMutableRawPointer) throws -> SyncState {
-    return try FfiConverterTypeSyncState.lift(pointer)
+    try FfiConverterTypeSyncState.lift(pointer)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeSyncState_lower(_ value: SyncState) -> UnsafeMutableRawPointer {
-    return FfiConverterTypeSyncState.lower(value)
+    FfiConverterTypeSyncState.lower(value)
 }
-
 
 public struct Change {
     public var actorId: ActorId
@@ -1497,7 +1623,14 @@ public struct Change {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(actorId: ActorId, message: String?, deps: [ChangeHash], timestamp: Int64, bytes: [UInt8], hash: ChangeHash) {
+    public init(
+        actorId: ActorId,
+        message: String?,
+        deps: [ChangeHash],
+        timestamp: Int64,
+        bytes: [UInt8],
+        hash: ChangeHash
+    ) {
         self.actorId = actorId
         self.message = message
         self.deps = deps
@@ -1507,10 +1640,8 @@ public struct Change {
     }
 }
 
-
-
 extension Change: Equatable, Hashable {
-    public static func ==(lhs: Change, rhs: Change) -> Bool {
+    public static func == (lhs: Change, rhs: Change) -> Bool {
         if lhs.actorId != rhs.actorId {
             return false
         }
@@ -1542,20 +1673,18 @@ extension Change: Equatable, Hashable {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeChange: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Change {
-        return
-            try Change(
-                actorId: FfiConverterTypeActorId.read(from: &buf), 
-                message: FfiConverterOptionString.read(from: &buf), 
-                deps: FfiConverterSequenceTypeChangeHash.read(from: &buf), 
-                timestamp: FfiConverterInt64.read(from: &buf), 
-                bytes: FfiConverterSequenceUInt8.read(from: &buf), 
-                hash: FfiConverterTypeChangeHash.read(from: &buf)
+        try Change(
+            actorId: FfiConverterTypeActorId.read(from: &buf),
+            message: FfiConverterOptionString.read(from: &buf),
+            deps: FfiConverterSequenceTypeChangeHash.read(from: &buf),
+            timestamp: FfiConverterInt64.read(from: &buf),
+            bytes: FfiConverterSequenceUInt8.read(from: &buf),
+            hash: FfiConverterTypeChangeHash.read(from: &buf)
         )
     }
 
@@ -1569,21 +1698,19 @@ public struct FfiConverterTypeChange: FfiConverterRustBuffer {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeChange_lift(_ buf: RustBuffer) throws -> Change {
-    return try FfiConverterTypeChange.lift(buf)
+    try FfiConverterTypeChange.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeChange_lower(_ value: Change) -> RustBuffer {
-    return FfiConverterTypeChange.lower(value)
+    FfiConverterTypeChange.lower(value)
 }
-
 
 public struct KeyValue {
     public var key: String
@@ -1597,10 +1724,8 @@ public struct KeyValue {
     }
 }
 
-
-
 extension KeyValue: Equatable, Hashable {
-    public static func ==(lhs: KeyValue, rhs: KeyValue) -> Bool {
+    public static func == (lhs: KeyValue, rhs: KeyValue) -> Bool {
         if lhs.key != rhs.key {
             return false
         }
@@ -1616,16 +1741,14 @@ extension KeyValue: Equatable, Hashable {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeKeyValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> KeyValue {
-        return
-            try KeyValue(
-                key: FfiConverterString.read(from: &buf), 
-                value: FfiConverterTypeValue.read(from: &buf)
+        try KeyValue(
+            key: FfiConverterString.read(from: &buf),
+            value: FfiConverterTypeValue.read(from: &buf)
         )
     }
 
@@ -1635,21 +1758,19 @@ public struct FfiConverterTypeKeyValue: FfiConverterRustBuffer {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeKeyValue_lift(_ buf: RustBuffer) throws -> KeyValue {
-    return try FfiConverterTypeKeyValue.lift(buf)
+    try FfiConverterTypeKeyValue.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeKeyValue_lower(_ value: KeyValue) -> RustBuffer {
-    return FfiConverterTypeKeyValue.lower(value)
+    FfiConverterTypeKeyValue.lower(value)
 }
-
 
 public struct Mark {
     public var start: UInt64
@@ -1667,10 +1788,8 @@ public struct Mark {
     }
 }
 
-
-
 extension Mark: Equatable, Hashable {
-    public static func ==(lhs: Mark, rhs: Mark) -> Bool {
+    public static func == (lhs: Mark, rhs: Mark) -> Bool {
         if lhs.start != rhs.start {
             return false
         }
@@ -1694,18 +1813,16 @@ extension Mark: Equatable, Hashable {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypeMark: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Mark {
-        return
-            try Mark(
-                start: FfiConverterUInt64.read(from: &buf), 
-                end: FfiConverterUInt64.read(from: &buf), 
-                name: FfiConverterString.read(from: &buf), 
-                value: FfiConverterTypeScalarValue.read(from: &buf)
+        try Mark(
+            start: FfiConverterUInt64.read(from: &buf),
+            end: FfiConverterUInt64.read(from: &buf),
+            name: FfiConverterString.read(from: &buf),
+            value: FfiConverterTypeScalarValue.read(from: &buf)
         )
     }
 
@@ -1717,21 +1834,19 @@ public struct FfiConverterTypeMark: FfiConverterRustBuffer {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeMark_lift(_ buf: RustBuffer) throws -> Mark {
-    return try FfiConverterTypeMark.lift(buf)
+    try FfiConverterTypeMark.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeMark_lower(_ value: Mark) -> RustBuffer {
-    return FfiConverterTypeMark.lower(value)
+    FfiConverterTypeMark.lower(value)
 }
-
 
 public struct Patch {
     public var path: [PathElement]
@@ -1745,10 +1860,8 @@ public struct Patch {
     }
 }
 
-
-
 extension Patch: Equatable, Hashable {
-    public static func ==(lhs: Patch, rhs: Patch) -> Bool {
+    public static func == (lhs: Patch, rhs: Patch) -> Bool {
         if lhs.path != rhs.path {
             return false
         }
@@ -1764,16 +1877,14 @@ extension Patch: Equatable, Hashable {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypePatch: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Patch {
-        return
-            try Patch(
-                path: FfiConverterSequenceTypePathElement.read(from: &buf), 
-                action: FfiConverterTypePatchAction.read(from: &buf)
+        try Patch(
+            path: FfiConverterSequenceTypePathElement.read(from: &buf),
+            action: FfiConverterTypePatchAction.read(from: &buf)
         )
     }
 
@@ -1783,21 +1894,19 @@ public struct FfiConverterTypePatch: FfiConverterRustBuffer {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePatch_lift(_ buf: RustBuffer) throws -> Patch {
-    return try FfiConverterTypePatch.lift(buf)
+    try FfiConverterTypePatch.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePatch_lower(_ value: Patch) -> RustBuffer {
-    return FfiConverterTypePatch.lower(value)
+    FfiConverterTypePatch.lower(value)
 }
-
 
 public struct PathElement {
     public var prop: Prop
@@ -1811,10 +1920,8 @@ public struct PathElement {
     }
 }
 
-
-
 extension PathElement: Equatable, Hashable {
-    public static func ==(lhs: PathElement, rhs: PathElement) -> Bool {
+    public static func == (lhs: PathElement, rhs: PathElement) -> Bool {
         if lhs.prop != rhs.prop {
             return false
         }
@@ -1830,16 +1937,14 @@ extension PathElement: Equatable, Hashable {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public struct FfiConverterTypePathElement: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PathElement {
-        return
-            try PathElement(
-                prop: FfiConverterTypeProp.read(from: &buf), 
-                obj: FfiConverterTypeObjId.read(from: &buf)
+        try PathElement(
+            prop: FfiConverterTypeProp.read(from: &buf),
+            obj: FfiConverterTypeObjId.read(from: &buf)
         )
     }
 
@@ -1849,30 +1954,23 @@ public struct FfiConverterTypePathElement: FfiConverterRustBuffer {
     }
 }
 
-
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePathElement_lift(_ buf: RustBuffer) throws -> PathElement {
-    return try FfiConverterTypePathElement.lift(buf)
+    try FfiConverterTypePathElement.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePathElement_lower(_ value: PathElement) -> RustBuffer {
-    return FfiConverterTypePathElement.lower(value)
+    FfiConverterTypePathElement.lower(value)
 }
-
 
 public enum DecodeSyncStateError {
-
-    
-    
     case Internal(message: String)
-    
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1883,14 +1981,9 @@ public struct FfiConverterTypeDecodeSyncStateError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DecodeSyncStateError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
-        
-
-        
-        case 1: return .Internal(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
+            )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -1898,18 +1991,11 @@ public struct FfiConverterTypeDecodeSyncStateError: FfiConverterRustBuffer {
 
     public static func write(_ value: DecodeSyncStateError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        case .Internal(_ /* message is ignored*/):
+        case .Internal(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(1))
-
-        
         }
     }
 }
-
 
 extension DecodeSyncStateError: Equatable, Hashable {}
 
@@ -1919,17 +2005,11 @@ extension DecodeSyncStateError: Foundation.LocalizedError {
     }
 }
 
-
 public enum DocError {
-
-    
-    
     case WrongObjectType(message: String)
-    
-    case Internal(message: String)
-    
-}
 
+    case Internal(message: String)
+}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -1940,18 +2020,13 @@ public struct FfiConverterTypeDocError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> DocError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
+        case 1: return try .WrongObjectType(
+                message: FfiConverterString.read(from: &buf)
+            )
 
-        
-
-        
-        case 1: return .WrongObjectType(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
-        case 2: return .Internal(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
+        case 2: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
+            )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -1959,20 +2034,13 @@ public struct FfiConverterTypeDocError: FfiConverterRustBuffer {
 
     public static func write(_ value: DocError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        case .WrongObjectType(_ /* message is ignored*/):
+        case .WrongObjectType(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(1))
-        case .Internal(_ /* message is ignored*/):
+        case .Internal(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(2))
-
-        
         }
     }
 }
-
 
 extension DocError: Equatable, Hashable {}
 
@@ -1986,13 +2054,11 @@ extension DocError: Foundation.LocalizedError {
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum ExpandMark {
-    
     case before
     case after
     case none
     case both
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2003,72 +2069,54 @@ public struct FfiConverterTypeExpandMark: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ExpandMark {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .before
-        
+
         case 2: return .after
-        
+
         case 3: return .none
-        
+
         case 4: return .both
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ExpandMark, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .before:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .after:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .none:
             writeInt(&buf, Int32(3))
-        
-        
+
         case .both:
             writeInt(&buf, Int32(4))
-        
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeExpandMark_lift(_ buf: RustBuffer) throws -> ExpandMark {
-    return try FfiConverterTypeExpandMark.lift(buf)
+    try FfiConverterTypeExpandMark.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeExpandMark_lower(_ value: ExpandMark) -> RustBuffer {
-    return FfiConverterTypeExpandMark.lower(value)
+    FfiConverterTypeExpandMark.lower(value)
 }
-
-
 
 extension ExpandMark: Equatable, Hashable {}
 
-
-
-
 public enum LoadError {
-
-    
-    
     case Internal(message: String)
-    
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2079,14 +2127,9 @@ public struct FfiConverterTypeLoadError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LoadError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
-        
-
-        
-        case 1: return .Internal(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
+            )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2094,18 +2137,11 @@ public struct FfiConverterTypeLoadError: FfiConverterRustBuffer {
 
     public static func write(_ value: LoadError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        case .Internal(_ /* message is ignored*/):
+        case .Internal(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(1))
-
-        
         }
     }
 }
-
 
 extension LoadError: Equatable, Hashable {}
 
@@ -2119,12 +2155,10 @@ extension LoadError: Foundation.LocalizedError {
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum ObjType {
-    
     case map
     case list
     case text
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2135,80 +2169,89 @@ public struct FfiConverterTypeObjType: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ObjType {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
         case 1: return .map
-        
+
         case 2: return .list
-        
+
         case 3: return .text
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ObjType, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case .map:
             writeInt(&buf, Int32(1))
-        
-        
+
         case .list:
             writeInt(&buf, Int32(2))
-        
-        
+
         case .text:
             writeInt(&buf, Int32(3))
-        
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeObjType_lift(_ buf: RustBuffer) throws -> ObjType {
-    return try FfiConverterTypeObjType.lift(buf)
+    try FfiConverterTypeObjType.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeObjType_lower(_ value: ObjType) -> RustBuffer {
-    return FfiConverterTypeObjType.lower(value)
+    FfiConverterTypeObjType.lower(value)
 }
 
-
-
 extension ObjType: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum PatchAction {
-    
-    case put(obj: ObjId, prop: Prop, value: Value
+    case put(
+        obj: ObjId,
+        prop: Prop,
+        value: Value
     )
-    case insert(obj: ObjId, index: UInt64, values: [Value]
+    case insert(
+        obj: ObjId,
+        index: UInt64,
+        values: [Value]
     )
-    case spliceText(obj: ObjId, index: UInt64, value: String, marks: [String: Value]
+    case spliceText(
+        obj: ObjId,
+        index: UInt64,
+        value: String,
+        marks: [String: Value]
     )
-    case increment(obj: ObjId, prop: Prop, value: Int64
+    case increment(
+        obj: ObjId,
+        prop: Prop,
+        value: Int64
     )
-    case conflict(obj: ObjId, prop: Prop
+    case conflict(
+        obj: ObjId,
+        prop: Prop
     )
-    case deleteMap(obj: ObjId, key: String
+    case deleteMap(
+        obj: ObjId,
+        key: String
     )
-    case deleteSeq(obj: ObjId, index: UInt64, length: UInt64
+    case deleteSeq(
+        obj: ObjId,
+        index: UInt64,
+        length: UInt64
     )
-    case marks(obj: ObjId, marks: [Mark]
+    case marks(
+        obj: ObjId,
+        marks: [Mark]
     )
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2219,128 +2262,134 @@ public struct FfiConverterTypePatchAction: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PatchAction {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .put(obj: try FfiConverterTypeObjId.read(from: &buf), prop: try FfiConverterTypeProp.read(from: &buf), value: try FfiConverterTypeValue.read(from: &buf)
-        )
-        
-        case 2: return .insert(obj: try FfiConverterTypeObjId.read(from: &buf), index: try FfiConverterUInt64.read(from: &buf), values: try FfiConverterSequenceTypeValue.read(from: &buf)
-        )
-        
-        case 3: return .spliceText(obj: try FfiConverterTypeObjId.read(from: &buf), index: try FfiConverterUInt64.read(from: &buf), value: try FfiConverterString.read(from: &buf), marks: try FfiConverterDictionaryStringTypeValue.read(from: &buf)
-        )
-        
-        case 4: return .increment(obj: try FfiConverterTypeObjId.read(from: &buf), prop: try FfiConverterTypeProp.read(from: &buf), value: try FfiConverterInt64.read(from: &buf)
-        )
-        
-        case 5: return .conflict(obj: try FfiConverterTypeObjId.read(from: &buf), prop: try FfiConverterTypeProp.read(from: &buf)
-        )
-        
-        case 6: return .deleteMap(obj: try FfiConverterTypeObjId.read(from: &buf), key: try FfiConverterString.read(from: &buf)
-        )
-        
-        case 7: return .deleteSeq(obj: try FfiConverterTypeObjId.read(from: &buf), index: try FfiConverterUInt64.read(from: &buf), length: try FfiConverterUInt64.read(from: &buf)
-        )
-        
-        case 8: return .marks(obj: try FfiConverterTypeObjId.read(from: &buf), marks: try FfiConverterSequenceTypeMark.read(from: &buf)
-        )
-        
+        case 1: return try .put(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterTypeValue.read(from: &buf)
+            )
+
+        case 2: return try .insert(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                values: FfiConverterSequenceTypeValue.read(from: &buf)
+            )
+
+        case 3: return try .spliceText(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                value: FfiConverterString.read(from: &buf),
+                marks: FfiConverterDictionaryStringTypeValue.read(from: &buf)
+            )
+
+        case 4: return try .increment(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf),
+                value: FfiConverterInt64.read(from: &buf)
+            )
+
+        case 5: return try .conflict(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                prop: FfiConverterTypeProp.read(from: &buf)
+            )
+
+        case 6: return try .deleteMap(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                key: FfiConverterString.read(from: &buf)
+            )
+
+        case 7: return try .deleteSeq(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                index: FfiConverterUInt64.read(from: &buf),
+                length: FfiConverterUInt64.read(from: &buf)
+            )
+
+        case 8: return try .marks(
+                obj: FfiConverterTypeObjId.read(from: &buf),
+                marks: FfiConverterSequenceTypeMark.read(from: &buf)
+            )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: PatchAction, into buf: inout [UInt8]) {
         switch value {
-        
-        
-        case let .put(obj,prop,value):
+        case let .put(obj, prop, value):
             writeInt(&buf, Int32(1))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterTypeProp.write(prop, into: &buf)
             FfiConverterTypeValue.write(value, into: &buf)
-            
-        
-        case let .insert(obj,index,values):
+
+        case let .insert(obj, index, values):
             writeInt(&buf, Int32(2))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterUInt64.write(index, into: &buf)
             FfiConverterSequenceTypeValue.write(values, into: &buf)
-            
-        
-        case let .spliceText(obj,index,value,marks):
+
+        case let .spliceText(obj, index, value, marks):
             writeInt(&buf, Int32(3))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterUInt64.write(index, into: &buf)
             FfiConverterString.write(value, into: &buf)
             FfiConverterDictionaryStringTypeValue.write(marks, into: &buf)
-            
-        
-        case let .increment(obj,prop,value):
+
+        case let .increment(obj, prop, value):
             writeInt(&buf, Int32(4))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterTypeProp.write(prop, into: &buf)
             FfiConverterInt64.write(value, into: &buf)
-            
-        
-        case let .conflict(obj,prop):
+
+        case let .conflict(obj, prop):
             writeInt(&buf, Int32(5))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterTypeProp.write(prop, into: &buf)
-            
-        
-        case let .deleteMap(obj,key):
+
+        case let .deleteMap(obj, key):
             writeInt(&buf, Int32(6))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterString.write(key, into: &buf)
-            
-        
-        case let .deleteSeq(obj,index,length):
+
+        case let .deleteSeq(obj, index, length):
             writeInt(&buf, Int32(7))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterUInt64.write(index, into: &buf)
             FfiConverterUInt64.write(length, into: &buf)
-            
-        
-        case let .marks(obj,marks):
+
+        case let .marks(obj, marks):
             writeInt(&buf, Int32(8))
             FfiConverterTypeObjId.write(obj, into: &buf)
             FfiConverterSequenceTypeMark.write(marks, into: &buf)
-            
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePatchAction_lift(_ buf: RustBuffer) throws -> PatchAction {
-    return try FfiConverterTypePatchAction.lift(buf)
+    try FfiConverterTypePatchAction.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePatchAction_lower(_ value: PatchAction) -> RustBuffer {
-    return FfiConverterTypePatchAction.lower(value)
+    FfiConverterTypePatchAction.lower(value)
 }
 
-
-
 extension PatchAction: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum Position {
-    
-    case cursor(position: Cursor
+    case cursor(
+        position: Cursor
     )
-    case index(position: UInt64
+    case index(
+        position: UInt64
     )
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2351,66 +2400,58 @@ public struct FfiConverterTypePosition: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Position {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .cursor(position: try FfiConverterTypeCursor.read(from: &buf)
-        )
-        
-        case 2: return .index(position: try FfiConverterUInt64.read(from: &buf)
-        )
-        
+        case 1: return try .cursor(
+                position: FfiConverterTypeCursor.read(from: &buf)
+            )
+
+        case 2: return try .index(
+                position: FfiConverterUInt64.read(from: &buf)
+            )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: Position, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case let .cursor(position):
             writeInt(&buf, Int32(1))
             FfiConverterTypeCursor.write(position, into: &buf)
-            
-        
+
         case let .index(position):
             writeInt(&buf, Int32(2))
             FfiConverterUInt64.write(position, into: &buf)
-            
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePosition_lift(_ buf: RustBuffer) throws -> Position {
-    return try FfiConverterTypePosition.lift(buf)
+    try FfiConverterTypePosition.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypePosition_lower(_ value: Position) -> RustBuffer {
-    return FfiConverterTypePosition.lower(value)
+    FfiConverterTypePosition.lower(value)
 }
 
-
-
 extension Position: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum Prop {
-    
-    case key(value: String
+    case key(
+        value: String
     )
-    case index(value: UInt64
+    case index(
+        value: UInt64
     )
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2421,66 +2462,52 @@ public struct FfiConverterTypeProp: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Prop {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .key(value: try FfiConverterString.read(from: &buf)
-        )
-        
-        case 2: return .index(value: try FfiConverterUInt64.read(from: &buf)
-        )
-        
+        case 1: return try .key(
+                value: FfiConverterString.read(from: &buf)
+            )
+
+        case 2: return try .index(
+                value: FfiConverterUInt64.read(from: &buf)
+            )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: Prop, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case let .key(value):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(value, into: &buf)
-            
-        
+
         case let .index(value):
             writeInt(&buf, Int32(2))
             FfiConverterUInt64.write(value, into: &buf)
-            
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeProp_lift(_ buf: RustBuffer) throws -> Prop {
-    return try FfiConverterTypeProp.lift(buf)
+    try FfiConverterTypeProp.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeProp_lower(_ value: Prop) -> RustBuffer {
-    return FfiConverterTypeProp.lower(value)
+    FfiConverterTypeProp.lower(value)
 }
-
-
 
 extension Prop: Equatable, Hashable {}
 
-
-
-
 public enum ReceiveSyncError {
-
-    
-    
     case Internal(message: String)
-    
-    case InvalidMessage(message: String)
-    
-}
 
+    case InvalidMessage(message: String)
+}
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2491,18 +2518,13 @@ public struct FfiConverterTypeReceiveSyncError: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReceiveSyncError {
         let variant: Int32 = try readInt(&buf)
         switch variant {
+        case 1: return try .Internal(
+                message: FfiConverterString.read(from: &buf)
+            )
 
-        
-
-        
-        case 1: return .Internal(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
-        case 2: return .InvalidMessage(
-            message: try FfiConverterString.read(from: &buf)
-        )
-        
+        case 2: return try .InvalidMessage(
+                message: FfiConverterString.read(from: &buf)
+            )
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2510,20 +2532,13 @@ public struct FfiConverterTypeReceiveSyncError: FfiConverterRustBuffer {
 
     public static func write(_ value: ReceiveSyncError, into buf: inout [UInt8]) {
         switch value {
-
-        
-
-        
-        case .Internal(_ /* message is ignored*/):
+        case .Internal(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(1))
-        case .InvalidMessage(_ /* message is ignored*/):
+        case .InvalidMessage(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(2))
-
-        
         }
     }
 }
-
 
 extension ReceiveSyncError: Equatable, Hashable {}
 
@@ -2537,28 +2552,36 @@ extension ReceiveSyncError: Foundation.LocalizedError {
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum ScalarValue {
-    
-    case bytes(value: [UInt8]
+    case bytes(
+        value: [UInt8]
     )
-    case string(value: String
+    case string(
+        value: String
     )
-    case uint(value: UInt64
+    case uint(
+        value: UInt64
     )
-    case int(value: Int64
+    case int(
+        value: Int64
     )
-    case f64(value: Double
+    case f64(
+        value: Double
     )
-    case counter(value: Int64
+    case counter(
+        value: Int64
     )
-    case timestamp(value: Int64
+    case timestamp(
+        value: Int64
     )
-    case boolean(value: Bool
+    case boolean(
+        value: Bool
     )
-    case unknown(typeCode: UInt8, data: [UInt8]
+    case unknown(
+        typeCode: UInt8,
+        data: [UInt8]
     )
     case null
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2569,129 +2592,122 @@ public struct FfiConverterTypeScalarValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ScalarValue {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .bytes(value: try FfiConverterSequenceUInt8.read(from: &buf)
-        )
-        
-        case 2: return .string(value: try FfiConverterString.read(from: &buf)
-        )
-        
-        case 3: return .uint(value: try FfiConverterUInt64.read(from: &buf)
-        )
-        
-        case 4: return .int(value: try FfiConverterInt64.read(from: &buf)
-        )
-        
-        case 5: return .f64(value: try FfiConverterDouble.read(from: &buf)
-        )
-        
-        case 6: return .counter(value: try FfiConverterInt64.read(from: &buf)
-        )
-        
-        case 7: return .timestamp(value: try FfiConverterInt64.read(from: &buf)
-        )
-        
-        case 8: return .boolean(value: try FfiConverterBool.read(from: &buf)
-        )
-        
-        case 9: return .unknown(typeCode: try FfiConverterUInt8.read(from: &buf), data: try FfiConverterSequenceUInt8.read(from: &buf)
-        )
-        
+        case 1: return try .bytes(
+                value: FfiConverterSequenceUInt8.read(from: &buf)
+            )
+
+        case 2: return try .string(
+                value: FfiConverterString.read(from: &buf)
+            )
+
+        case 3: return try .uint(
+                value: FfiConverterUInt64.read(from: &buf)
+            )
+
+        case 4: return try .int(
+                value: FfiConverterInt64.read(from: &buf)
+            )
+
+        case 5: return try .f64(
+                value: FfiConverterDouble.read(from: &buf)
+            )
+
+        case 6: return try .counter(
+                value: FfiConverterInt64.read(from: &buf)
+            )
+
+        case 7: return try .timestamp(
+                value: FfiConverterInt64.read(from: &buf)
+            )
+
+        case 8: return try .boolean(
+                value: FfiConverterBool.read(from: &buf)
+            )
+
+        case 9: return try .unknown(
+                typeCode: FfiConverterUInt8.read(from: &buf),
+                data: FfiConverterSequenceUInt8.read(from: &buf)
+            )
+
         case 10: return .null
-        
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ScalarValue, into buf: inout [UInt8]) {
         switch value {
-        
-        
         case let .bytes(value):
             writeInt(&buf, Int32(1))
             FfiConverterSequenceUInt8.write(value, into: &buf)
-            
-        
+
         case let .string(value):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(value, into: &buf)
-            
-        
+
         case let .uint(value):
             writeInt(&buf, Int32(3))
             FfiConverterUInt64.write(value, into: &buf)
-            
-        
+
         case let .int(value):
             writeInt(&buf, Int32(4))
             FfiConverterInt64.write(value, into: &buf)
-            
-        
+
         case let .f64(value):
             writeInt(&buf, Int32(5))
             FfiConverterDouble.write(value, into: &buf)
-            
-        
+
         case let .counter(value):
             writeInt(&buf, Int32(6))
             FfiConverterInt64.write(value, into: &buf)
-            
-        
+
         case let .timestamp(value):
             writeInt(&buf, Int32(7))
             FfiConverterInt64.write(value, into: &buf)
-            
-        
+
         case let .boolean(value):
             writeInt(&buf, Int32(8))
             FfiConverterBool.write(value, into: &buf)
-            
-        
-        case let .unknown(typeCode,data):
+
+        case let .unknown(typeCode, data):
             writeInt(&buf, Int32(9))
             FfiConverterUInt8.write(typeCode, into: &buf)
             FfiConverterSequenceUInt8.write(data, into: &buf)
-            
-        
+
         case .null:
             writeInt(&buf, Int32(10))
-        
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeScalarValue_lift(_ buf: RustBuffer) throws -> ScalarValue {
-    return try FfiConverterTypeScalarValue.lift(buf)
+    try FfiConverterTypeScalarValue.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeScalarValue_lower(_ value: ScalarValue) -> RustBuffer {
-    return FfiConverterTypeScalarValue.lower(value)
+    FfiConverterTypeScalarValue.lower(value)
 }
 
-
-
 extension ScalarValue: Equatable, Hashable {}
-
-
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum Value {
-    
-    case object(typ: ObjType, id: ObjId
+    case object(
+        typ: ObjType,
+        id: ObjId
     )
-    case scalar(value: ScalarValue
+    case scalar(
+        value: ScalarValue
     )
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
@@ -2702,60 +2718,53 @@ public struct FfiConverterTypeValue: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Value {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-        
-        case 1: return .object(typ: try FfiConverterTypeObjType.read(from: &buf), id: try FfiConverterTypeObjId.read(from: &buf)
-        )
-        
-        case 2: return .scalar(value: try FfiConverterTypeScalarValue.read(from: &buf)
-        )
-        
+        case 1: return try .object(
+                typ: FfiConverterTypeObjType.read(from: &buf),
+                id: FfiConverterTypeObjId.read(from: &buf)
+            )
+
+        case 2: return try .scalar(
+                value: FfiConverterTypeScalarValue.read(from: &buf)
+            )
+
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: Value, into buf: inout [UInt8]) {
         switch value {
-        
-        
-        case let .object(typ,id):
+        case let .object(typ, id):
             writeInt(&buf, Int32(1))
             FfiConverterTypeObjType.write(typ, into: &buf)
             FfiConverterTypeObjId.write(id, into: &buf)
-            
-        
+
         case let .scalar(value):
             writeInt(&buf, Int32(2))
             FfiConverterTypeScalarValue.write(value, into: &buf)
-            
         }
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeValue_lift(_ buf: RustBuffer) throws -> Value {
-    return try FfiConverterTypeValue.lift(buf)
+    try FfiConverterTypeValue.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeValue_lower(_ value: Value) -> RustBuffer {
-    return FfiConverterTypeValue.lower(value)
+    FfiConverterTypeValue.lower(value)
 }
 
-
-
 extension Value: Equatable, Hashable {}
-
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
+private struct FfiConverterOptionString: FfiConverterRustBuffer {
     typealias SwiftType = String?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -2779,7 +2788,7 @@ fileprivate struct FfiConverterOptionString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionTypeChange: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeChange: FfiConverterRustBuffer {
     typealias SwiftType = Change?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -2803,7 +2812,7 @@ fileprivate struct FfiConverterOptionTypeChange: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionTypeValue: FfiConverterRustBuffer {
+private struct FfiConverterOptionTypeValue: FfiConverterRustBuffer {
     typealias SwiftType = Value?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -2827,7 +2836,7 @@ fileprivate struct FfiConverterOptionTypeValue: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionSequenceUInt8: FfiConverterRustBuffer {
+private struct FfiConverterOptionSequenceUInt8: FfiConverterRustBuffer {
     typealias SwiftType = [UInt8]?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -2851,7 +2860,7 @@ fileprivate struct FfiConverterOptionSequenceUInt8: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterOptionSequenceTypeChangeHash: FfiConverterRustBuffer {
+private struct FfiConverterOptionSequenceTypeChangeHash: FfiConverterRustBuffer {
     typealias SwiftType = [ChangeHash]?
 
     public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
@@ -2875,7 +2884,7 @@ fileprivate struct FfiConverterOptionSequenceTypeChangeHash: FfiConverterRustBuf
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
+private struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
     typealias SwiftType = [UInt8]
 
     public static func write(_ value: [UInt8], into buf: inout [UInt8]) {
@@ -2891,7 +2900,7 @@ fileprivate struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
         var seq = [UInt8]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterUInt8.read(from: &buf))
+            try seq.append(FfiConverterUInt8.read(from: &buf))
         }
         return seq
     }
@@ -2900,7 +2909,7 @@ fileprivate struct FfiConverterSequenceUInt8: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
+private struct FfiConverterSequenceString: FfiConverterRustBuffer {
     typealias SwiftType = [String]
 
     public static func write(_ value: [String], into buf: inout [UInt8]) {
@@ -2916,7 +2925,7 @@ fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
         var seq = [String]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterString.read(from: &buf))
+            try seq.append(FfiConverterString.read(from: &buf))
         }
         return seq
     }
@@ -2925,7 +2934,7 @@ fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
     typealias SwiftType = [KeyValue]
 
     public static func write(_ value: [KeyValue], into buf: inout [UInt8]) {
@@ -2941,7 +2950,7 @@ fileprivate struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
         var seq = [KeyValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeKeyValue.read(from: &buf))
+            try seq.append(FfiConverterTypeKeyValue.read(from: &buf))
         }
         return seq
     }
@@ -2950,7 +2959,7 @@ fileprivate struct FfiConverterSequenceTypeKeyValue: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
     typealias SwiftType = [Mark]
 
     public static func write(_ value: [Mark], into buf: inout [UInt8]) {
@@ -2966,7 +2975,7 @@ fileprivate struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
         var seq = [Mark]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeMark.read(from: &buf))
+            try seq.append(FfiConverterTypeMark.read(from: &buf))
         }
         return seq
     }
@@ -2975,7 +2984,7 @@ fileprivate struct FfiConverterSequenceTypeMark: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
     typealias SwiftType = [Patch]
 
     public static func write(_ value: [Patch], into buf: inout [UInt8]) {
@@ -2991,7 +3000,7 @@ fileprivate struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
         var seq = [Patch]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePatch.read(from: &buf))
+            try seq.append(FfiConverterTypePatch.read(from: &buf))
         }
         return seq
     }
@@ -3000,7 +3009,7 @@ fileprivate struct FfiConverterSequenceTypePatch: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
     typealias SwiftType = [PathElement]
 
     public static func write(_ value: [PathElement], into buf: inout [UInt8]) {
@@ -3016,7 +3025,7 @@ fileprivate struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
         var seq = [PathElement]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypePathElement.read(from: &buf))
+            try seq.append(FfiConverterTypePathElement.read(from: &buf))
         }
         return seq
     }
@@ -3025,7 +3034,7 @@ fileprivate struct FfiConverterSequenceTypePathElement: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
     typealias SwiftType = [ScalarValue]
 
     public static func write(_ value: [ScalarValue], into buf: inout [UInt8]) {
@@ -3041,7 +3050,7 @@ fileprivate struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
         var seq = [ScalarValue]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeScalarValue.read(from: &buf))
+            try seq.append(FfiConverterTypeScalarValue.read(from: &buf))
         }
         return seq
     }
@@ -3050,7 +3059,7 @@ fileprivate struct FfiConverterSequenceTypeScalarValue: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
     typealias SwiftType = [Value]
 
     public static func write(_ value: [Value], into buf: inout [UInt8]) {
@@ -3066,7 +3075,7 @@ fileprivate struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
         var seq = [Value]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeValue.read(from: &buf))
+            try seq.append(FfiConverterTypeValue.read(from: &buf))
         }
         return seq
     }
@@ -3075,7 +3084,7 @@ fileprivate struct FfiConverterSequenceTypeValue: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
+private struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
     typealias SwiftType = [ChangeHash]
 
     public static func write(_ value: [ChangeHash], into buf: inout [UInt8]) {
@@ -3091,7 +3100,7 @@ fileprivate struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
         var seq = [ChangeHash]()
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
-            seq.append(try FfiConverterTypeChangeHash.read(from: &buf))
+            try seq.append(FfiConverterTypeChangeHash.read(from: &buf))
         }
         return seq
     }
@@ -3100,7 +3109,7 @@ fileprivate struct FfiConverterSequenceTypeChangeHash: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-fileprivate struct FfiConverterDictionaryStringTypeValue: FfiConverterRustBuffer {
+private struct FfiConverterDictionaryStringTypeValue: FfiConverterRustBuffer {
     public static func write(_ value: [String: Value], into buf: inout [UInt8]) {
         let len = Int32(value.count)
         writeInt(&buf, len)
@@ -3114,7 +3123,7 @@ fileprivate struct FfiConverterDictionaryStringTypeValue: FfiConverterRustBuffer
         let len: Int32 = try readInt(&buf)
         var dict = [String: Value]()
         dict.reserveCapacity(Int(len))
-        for _ in 0..<len {
+        for _ in 0 ..< len {
             let key = try FfiConverterString.read(from: &buf)
             let value = try FfiConverterTypeValue.read(from: &buf)
             dict[key] = value
@@ -3122,7 +3131,6 @@ fileprivate struct FfiConverterDictionaryStringTypeValue: FfiConverterRustBuffer
         return dict
     }
 }
-
 
 /**
  * Typealias from the type name used in the UDL file to the builtin type.  This
@@ -3135,38 +3143,35 @@ public typealias ActorId = [UInt8]
 #endif
 public struct FfiConverterTypeActorId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ActorId {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
+        try FfiConverterSequenceUInt8.read(from: &buf)
     }
 
     public static func write(_ value: ActorId, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
+        FfiConverterSequenceUInt8.write(value, into: &buf)
     }
 
     public static func lift(_ value: RustBuffer) throws -> ActorId {
-        return try FfiConverterSequenceUInt8.lift(value)
+        try FfiConverterSequenceUInt8.lift(value)
     }
 
     public static func lower(_ value: ActorId) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
+        FfiConverterSequenceUInt8.lower(value)
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeActorId_lift(_ value: RustBuffer) throws -> ActorId {
-    return try FfiConverterTypeActorId.lift(value)
+    try FfiConverterTypeActorId.lift(value)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeActorId_lower(_ value: ActorId) -> RustBuffer {
-    return FfiConverterTypeActorId.lower(value)
+    FfiConverterTypeActorId.lower(value)
 }
-
-
 
 /**
  * Typealias from the type name used in the UDL file to the builtin type.  This
@@ -3179,38 +3184,35 @@ public typealias ChangeHash = [UInt8]
 #endif
 public struct FfiConverterTypeChangeHash: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChangeHash {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
+        try FfiConverterSequenceUInt8.read(from: &buf)
     }
 
     public static func write(_ value: ChangeHash, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
+        FfiConverterSequenceUInt8.write(value, into: &buf)
     }
 
     public static func lift(_ value: RustBuffer) throws -> ChangeHash {
-        return try FfiConverterSequenceUInt8.lift(value)
+        try FfiConverterSequenceUInt8.lift(value)
     }
 
     public static func lower(_ value: ChangeHash) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
+        FfiConverterSequenceUInt8.lower(value)
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeChangeHash_lift(_ value: RustBuffer) throws -> ChangeHash {
-    return try FfiConverterTypeChangeHash.lift(value)
+    try FfiConverterTypeChangeHash.lift(value)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeChangeHash_lower(_ value: ChangeHash) -> RustBuffer {
-    return FfiConverterTypeChangeHash.lower(value)
+    FfiConverterTypeChangeHash.lower(value)
 }
-
-
 
 /**
  * Typealias from the type name used in the UDL file to the builtin type.  This
@@ -3223,38 +3225,35 @@ public typealias Cursor = [UInt8]
 #endif
 public struct FfiConverterTypeCursor: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Cursor {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
+        try FfiConverterSequenceUInt8.read(from: &buf)
     }
 
     public static func write(_ value: Cursor, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
+        FfiConverterSequenceUInt8.write(value, into: &buf)
     }
 
     public static func lift(_ value: RustBuffer) throws -> Cursor {
-        return try FfiConverterSequenceUInt8.lift(value)
+        try FfiConverterSequenceUInt8.lift(value)
     }
 
     public static func lower(_ value: Cursor) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
+        FfiConverterSequenceUInt8.lower(value)
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeCursor_lift(_ value: RustBuffer) throws -> Cursor {
-    return try FfiConverterTypeCursor.lift(value)
+    try FfiConverterTypeCursor.lift(value)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeCursor_lower(_ value: Cursor) -> RustBuffer {
-    return FfiConverterTypeCursor.lower(value)
+    FfiConverterTypeCursor.lower(value)
 }
-
-
 
 /**
  * Typealias from the type name used in the UDL file to the builtin type.  This
@@ -3267,42 +3266,42 @@ public typealias ObjId = [UInt8]
 #endif
 public struct FfiConverterTypeObjId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ObjId {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
+        try FfiConverterSequenceUInt8.read(from: &buf)
     }
 
     public static func write(_ value: ObjId, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
+        FfiConverterSequenceUInt8.write(value, into: &buf)
     }
 
     public static func lift(_ value: RustBuffer) throws -> ObjId {
-        return try FfiConverterSequenceUInt8.lift(value)
+        try FfiConverterSequenceUInt8.lift(value)
     }
 
     public static func lower(_ value: ObjId) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
+        FfiConverterSequenceUInt8.lower(value)
     }
 }
-
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeObjId_lift(_ value: RustBuffer) throws -> ObjId {
-    return try FfiConverterTypeObjId.lift(value)
+    try FfiConverterTypeObjId.lift(value)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
 public func FfiConverterTypeObjId_lower(_ value: ObjId) -> RustBuffer {
-    return FfiConverterTypeObjId.lower(value)
+    FfiConverterTypeObjId.lower(value)
 }
 
 public func root() -> ObjId {
-    return try!  FfiConverterTypeObjId.lift(try! rustCall() {
-    uniffi_uniffi_automerge_fn_func_root($0
-    )
-})
+    try! FfiConverterTypeObjId.lift(try! rustCall {
+        uniffi_uniffi_automerge_fn_func_root(
+            $0
+        )
+    })
 }
 
 private enum InitializationResult {
@@ -3310,6 +3309,7 @@ private enum InitializationResult {
     case contractVersionMismatch
     case apiChecksumMismatch
 }
+
 // Use a global variable to perform the versioning checks. Swift ensures that
 // the code inside is only computed once.
 private var initializationResult: InitializationResult = {
@@ -3320,217 +3320,217 @@ private var initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_func_root() != 19647) {
+    if uniffi_uniffi_automerge_checksum_func_root() != 19647 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_actor_id() != 10869) {
+    if uniffi_uniffi_automerge_checksum_method_doc_actor_id() != 10869 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes() != 57114) {
+    if uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes() != 57114 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes_with_patches() != 63928) {
+    if uniffi_uniffi_automerge_checksum_method_doc_apply_encoded_changes_with_patches() != 63928 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_change_by_hash() != 44577) {
+    if uniffi_uniffi_automerge_checksum_method_doc_change_by_hash() != 44577 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_changes() != 1878) {
+    if uniffi_uniffi_automerge_checksum_method_doc_changes() != 1878 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_commit_with() != 65319) {
+    if uniffi_uniffi_automerge_checksum_method_doc_commit_with() != 65319 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_cursor() != 18441) {
+    if uniffi_uniffi_automerge_checksum_method_doc_cursor() != 18441 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_cursor_at() != 39363) {
+    if uniffi_uniffi_automerge_checksum_method_doc_cursor_at() != 39363 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_cursor_position() != 5760) {
+    if uniffi_uniffi_automerge_checksum_method_doc_cursor_position() != 5760 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_cursor_position_at() != 35233) {
+    if uniffi_uniffi_automerge_checksum_method_doc_cursor_position_at() != 35233 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_delete_in_list() != 36066) {
+    if uniffi_uniffi_automerge_checksum_method_doc_delete_in_list() != 36066 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_delete_in_map() != 1721) {
+    if uniffi_uniffi_automerge_checksum_method_doc_delete_in_map() != 1721 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_difference() != 13614) {
+    if uniffi_uniffi_automerge_checksum_method_doc_difference() != 13614 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_encode_changes_since() != 49806) {
+    if uniffi_uniffi_automerge_checksum_method_doc_encode_changes_since() != 49806 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_encode_new_changes() != 56722) {
+    if uniffi_uniffi_automerge_checksum_method_doc_encode_new_changes() != 56722 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_fork() != 38250) {
+    if uniffi_uniffi_automerge_checksum_method_doc_fork() != 38250 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_fork_at() != 49724) {
+    if uniffi_uniffi_automerge_checksum_method_doc_fork_at() != 49724 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_generate_sync_message() != 33156) {
+    if uniffi_uniffi_automerge_checksum_method_doc_generate_sync_message() != 33156 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_all_at_in_list() != 42311) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_all_at_in_list() != 42311 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_all_at_in_map() != 29778) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_all_at_in_map() != 29778 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_all_in_list() != 3346) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_all_in_list() != 3346 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_all_in_map() != 46751) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_all_in_map() != 46751 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_at_in_list() != 29393) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_at_in_list() != 29393 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_at_in_map() != 41003) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_at_in_map() != 41003 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_in_list() != 55210) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_in_list() != 55210 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_get_in_map() != 27911) {
+    if uniffi_uniffi_automerge_checksum_method_doc_get_in_map() != 27911 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_heads() != 44667) {
+    if uniffi_uniffi_automerge_checksum_method_doc_heads() != 44667 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_increment_in_list() != 6803) {
+    if uniffi_uniffi_automerge_checksum_method_doc_increment_in_list() != 6803 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_increment_in_map() != 24542) {
+    if uniffi_uniffi_automerge_checksum_method_doc_increment_in_map() != 24542 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_insert_in_list() != 26167) {
+    if uniffi_uniffi_automerge_checksum_method_doc_insert_in_list() != 26167 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_insert_object_in_list() != 30538) {
+    if uniffi_uniffi_automerge_checksum_method_doc_insert_object_in_list() != 30538 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_join_block() != 37348) {
+    if uniffi_uniffi_automerge_checksum_method_doc_join_block() != 37348 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_length() != 30352) {
+    if uniffi_uniffi_automerge_checksum_method_doc_length() != 30352 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_length_at() != 64377) {
+    if uniffi_uniffi_automerge_checksum_method_doc_length_at() != 64377 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_map_entries() != 3918) {
+    if uniffi_uniffi_automerge_checksum_method_doc_map_entries() != 3918 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_map_entries_at() != 35589) {
+    if uniffi_uniffi_automerge_checksum_method_doc_map_entries_at() != 35589 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_map_keys() != 45893) {
+    if uniffi_uniffi_automerge_checksum_method_doc_map_keys() != 45893 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_map_keys_at() != 36273) {
+    if uniffi_uniffi_automerge_checksum_method_doc_map_keys_at() != 36273 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_mark() != 5875) {
+    if uniffi_uniffi_automerge_checksum_method_doc_mark() != 5875 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_marks() != 58967) {
+    if uniffi_uniffi_automerge_checksum_method_doc_marks() != 58967 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_marks_at() != 57491) {
+    if uniffi_uniffi_automerge_checksum_method_doc_marks_at() != 57491 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_marks_at_position() != 19243) {
+    if uniffi_uniffi_automerge_checksum_method_doc_marks_at_position() != 19243 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_merge() != 8598) {
+    if uniffi_uniffi_automerge_checksum_method_doc_merge() != 8598 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_merge_with_patches() != 63992) {
+    if uniffi_uniffi_automerge_checksum_method_doc_merge_with_patches() != 63992 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_object_type() != 15479) {
+    if uniffi_uniffi_automerge_checksum_method_doc_object_type() != 15479 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_path() != 29434) {
+    if uniffi_uniffi_automerge_checksum_method_doc_path() != 29434 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_put_in_list() != 39558) {
+    if uniffi_uniffi_automerge_checksum_method_doc_put_in_list() != 39558 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_put_in_map() != 3891) {
+    if uniffi_uniffi_automerge_checksum_method_doc_put_in_map() != 3891 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_put_object_in_list() != 29333) {
+    if uniffi_uniffi_automerge_checksum_method_doc_put_object_in_list() != 29333 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_put_object_in_map() != 50970) {
+    if uniffi_uniffi_automerge_checksum_method_doc_put_object_in_map() != 50970 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message() != 17509) {
+    if uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message() != 17509 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message_with_patches() != 42532) {
+    if uniffi_uniffi_automerge_checksum_method_doc_receive_sync_message_with_patches() != 42532 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_save() != 20308) {
+    if uniffi_uniffi_automerge_checksum_method_doc_save() != 20308 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_set_actor() != 64337) {
+    if uniffi_uniffi_automerge_checksum_method_doc_set_actor() != 64337 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_splice() != 29894) {
+    if uniffi_uniffi_automerge_checksum_method_doc_splice() != 29894 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_splice_text() != 20602) {
+    if uniffi_uniffi_automerge_checksum_method_doc_splice_text() != 20602 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_split_block() != 10956) {
+    if uniffi_uniffi_automerge_checksum_method_doc_split_block() != 10956 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_text() != 64716) {
+    if uniffi_uniffi_automerge_checksum_method_doc_text() != 64716 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_text_at() != 45714) {
+    if uniffi_uniffi_automerge_checksum_method_doc_text_at() != 45714 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_update_text() != 26364) {
+    if uniffi_uniffi_automerge_checksum_method_doc_update_text() != 26364 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_values() != 48159) {
+    if uniffi_uniffi_automerge_checksum_method_doc_values() != 48159 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_values_at() != 16206) {
+    if uniffi_uniffi_automerge_checksum_method_doc_values_at() != 16206 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_syncstate_encode() != 34911) {
+    if uniffi_uniffi_automerge_checksum_method_syncstate_encode() != 34911 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_syncstate_reset() != 57480) {
+    if uniffi_uniffi_automerge_checksum_method_syncstate_reset() != 57480 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_syncstate_their_heads() != 39870) {
+    if uniffi_uniffi_automerge_checksum_method_syncstate_their_heads() != 39870 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_constructor_doc_load() != 20048) {
+    if uniffi_uniffi_automerge_checksum_constructor_doc_load() != 20048 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_constructor_doc_new() != 9447) {
+    if uniffi_uniffi_automerge_checksum_constructor_doc_new() != 9447 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_constructor_doc_new_with_actor() != 21001) {
+    if uniffi_uniffi_automerge_checksum_constructor_doc_new_with_actor() != 21001 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_constructor_syncstate_decode() != 17966) {
+    if uniffi_uniffi_automerge_checksum_constructor_syncstate_decode() != 17966 {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_constructor_syncstate_new() != 37569) {
+    if uniffi_uniffi_automerge_checksum_constructor_syncstate_new() != 37569 {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -3312,7 +3312,7 @@ private enum InitializationResult {
 
 // Use a global variable to perform the versioning checks. Swift ensures that
 // the code inside is only computed once.
-private var initializationResult: InitializationResult = {
+private let initializationResult: InitializationResult = {
     // Get the bindings contract version from our ComponentInterface
     let bindings_contract_version = 26
     // Get the scaffolding contract version by calling the into the dylib

--- a/CollectionBenchmarks/Sources/CollectionBenchmarks/main.swift
+++ b/CollectionBenchmarks/Sources/CollectionBenchmarks/main.swift
@@ -1,6 +1,6 @@
+import Automerge
 import CollectionsBenchmark
 import Foundation
-import Automerge
 import Loro
 
 // NOTE(heckj): collections-benchmark implementations can be a bit hard to understand
@@ -124,7 +124,7 @@ benchmark.addSimple(
         _ = try! text.splice(pos: stringLength, len: 0, s: strChar)
         stringLength = text.lenUnicode()
     }
-    
+
     let resultingString = text.toString()
     // precondition(stringLength == input.count) // NOT VALID - difference in UTF-8 codepoints and how strings represent
     // lengths

--- a/Package.swift
+++ b/Package.swift
@@ -57,8 +57,8 @@ if ProcessInfo.processInfo.environment["LOCAL_BUILD"] != nil {
 } else {
     FFIbinaryTarget = .binaryTarget(
         name: "automergeFFI",
-        url: "https://github.com/automerge/automerge-swift/releases/download/0.5.17/automergeFFI.xcframework.zip",
-        checksum: "fb2a6fc45b427c87f39d11cf749c6f59052579996eae3b4881df69b1c25cbd5f"
+        url: "https://github.com/automerge/automerge-swift/releases/download/0.5.19/automergeFFI.xcframework.zip",
+        checksum: "93ec4afb778d36d057a360d57af114e2d6e1f5c70c0df4c3c930c8c03aabae2d"
     )
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -102,5 +102,6 @@ let package = Package(
             dependencies: ["Automerge", "AutomergeUtilities"],
             exclude: ["Fixtures"]
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.version("6"), .v5]
 )

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -27,9 +27,9 @@ public final class Document: @unchecked Sendable {
         try work()
     }
     #endif
-    
+
     #if canImport(Combine)
-    private let objectDidChangeSubject: PassthroughSubject<(), Never> = .init()
+    private let objectDidChangeSubject: PassthroughSubject<Void, Never> = .init()
 
     /// A publisher that emits after the document has changed.
     ///
@@ -48,9 +48,7 @@ public final class Document: @unchecked Sendable {
     ///         processChanges(changes)
     ///     }
     /// }.store(in: &cancellables)
-    public lazy var objectDidChange: AnyPublisher<(), Never> = {
-        objectDidChangeSubject.eraseToAnyPublisher()
-    }()
+    public lazy var objectDidChange: AnyPublisher<Void, Never> = objectDidChangeSubject.eraseToAnyPublisher()
     #endif
 
     var reportingLogLevel: LogVerbosity

--- a/Sources/Automerge/Errors.swift
+++ b/Sources/Automerge/Errors.swift
@@ -29,17 +29,6 @@ public struct DocError: LocalizedError {
     }
 }
 
-//extension FfiDocError: LocalizedError {
-//    public var errorDescription: String? {
-//        switch self {
-//        case let .WrongObjectType(message: msg):
-//            return "WrongObjectType: \(msg)"
-//        case let .Internal(message: msg):
-//            return "AutomergeCore Internal Error: \(msg)"
-//        }
-//    }
-//}
-
 /// An error that indicates the synchronisation state could not be decoded.
 ///
 /// The error is specific to the Rust language binding infrastructure.

--- a/Sources/Automerge/Errors.swift
+++ b/Sources/Automerge/Errors.swift
@@ -29,16 +29,16 @@ public struct DocError: LocalizedError {
     }
 }
 
-extension FfiDocError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .WrongObjectType(message: msg):
-            return "WrongObjectType: \(msg)"
-        case let .Internal(message: msg):
-            return "AutomergeCore Internal Error: \(msg)"
-        }
-    }
-}
+//extension FfiDocError: LocalizedError {
+//    public var errorDescription: String? {
+//        switch self {
+//        case let .WrongObjectType(message: msg):
+//            return "WrongObjectType: \(msg)"
+//        case let .Internal(message: msg):
+//            return "AutomergeCore Internal Error: \(msg)"
+//        }
+//    }
+//}
 
 /// An error that indicates the synchronisation state could not be decoded.
 ///

--- a/Tests/AutomergeTests/BoundTypeTests/TestCounter.swift
+++ b/Tests/AutomergeTests/BoundTypeTests/TestCounter.swift
@@ -39,24 +39,42 @@ class CounterTestCase: XCTestCase {
         _ = doc2.save()
 
         let counter1 = try doc1.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter1 == Value.Scalar(.Counter(3)), "Test failure illustrating put doesn't merge the same as increment [\(counter1!) != \(Value.Scalar(.Counter(3)))]")
+        assertNonFatal(
+            counter1 == Value.Scalar(.Counter(3)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter1!) != \(Value.Scalar(.Counter(3)))]"
+        )
         let counter2 = try doc2.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter2 == Value.Scalar(.Counter(-1)), "Test failure illustrating put doesn't merge the same as increment [\(counter2!) != \(Value.Scalar(.Counter(-1)))]")
+        assertNonFatal(
+            counter2 == Value.Scalar(.Counter(-1)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter2!) != \(Value.Scalar(.Counter(-1)))]"
+        )
 
         try doc1.merge(other: doc2)
 
         let counter3 = try doc1.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter3 == Value.Scalar(.Counter(2)), "Test failure illustrating put doesn't merge the same as increment [\(counter3!) != \(Value.Scalar(.Counter(2)))]")
+        assertNonFatal(
+            counter3 == Value.Scalar(.Counter(2)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter3!) != \(Value.Scalar(.Counter(2)))]"
+        )
         let counter4 = try doc2.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter4 == Value.Scalar(.Counter(-1)), "Test failure illustrating put doesn't merge the same as increment [\(counter4!) != \(Value.Scalar(.Counter(-1)))]")
-        
+        assertNonFatal(
+            counter4 == Value.Scalar(.Counter(-1)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter4!) != \(Value.Scalar(.Counter(-1)))]"
+        )
+
         try doc2.merge(other: doc1)
 
         let counter5 = try doc1.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter5 == Value.Scalar(.Counter(2)), "Test failure illustrating put doesn't merge the same as increment [\(counter5!) != \(Value.Scalar(.Counter(2)))]")
+        assertNonFatal(
+            counter5 == Value.Scalar(.Counter(2)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter5!) != \(Value.Scalar(.Counter(2)))]"
+        )
 
         let counter6 = try doc2.get(obj: ObjId.ROOT, key: "counter")
-        assertNonFatal(counter6 == Value.Scalar(.Counter(2)), "Test failure illustrating put doesn't merge the same as increment [\(counter6!) != \(Value.Scalar(.Counter(2)))]")
+        assertNonFatal(
+            counter6 == Value.Scalar(.Counter(2)),
+            "Test failure illustrating put doesn't merge the same as increment [\(counter6!) != \(Value.Scalar(.Counter(2)))]"
+        )
     }
 }
 
@@ -66,4 +84,3 @@ private extension XCTestCase {
         print("\(message) at \(file):\(line)")
     }
 }
-

--- a/Tests/AutomergeTests/CheckForMemoryLeaksTests.swift
+++ b/Tests/AutomergeTests/CheckForMemoryLeaksTests.swift
@@ -1,0 +1,59 @@
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Automerge
+import XCTest
+
+class MemoryLeakTests: XCTestCase {
+    @MainActor func testMemoryLeakOnSyncTwoDocs() {
+        let doc1 = Document()
+        trackForMemoryLeak(instance: doc1)
+        let syncState1 = SyncState()
+
+        let doc2 = Document()
+        trackForMemoryLeak(instance: doc2)
+        let syncState2 = SyncState()
+
+        try! doc1.put(obj: ObjId.ROOT, key: "key1", value: .String("value1"))
+        try! doc2.put(obj: ObjId.ROOT, key: "key2", value: .String("value2"))
+
+        sync(doc1, syncState1, doc2, syncState2)
+
+        for doc in [doc1, doc2] {
+            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key1")!, .Scalar(.String("value1")))
+            XCTAssertEqual(try! doc.get(obj: ObjId.ROOT, key: "key2")!, .Scalar(.String("value2")))
+        }
+
+        XCTAssertNotNil(syncState1.theirHeads)
+    }
+
+    @MainActor func testEncodeDoesntLeak() throws {
+        let doc = Document()
+        trackForMemoryLeak(instance: doc)
+
+        struct SimpleStruct: Codable, Equatable {
+            let name: String
+            let notes: AutomergeText
+        }
+
+        let automergeEncoder = AutomergeEncoder(doc: doc)
+        let automergeDecoder = AutomergeDecoder(doc: doc)
+
+        let sample = SimpleStruct(
+            name: "henry",
+            notes: AutomergeText("Something wicked this way comes.")
+        )
+
+        let pathToTry: [AnyCodingKey] = [
+            AnyCodingKey("example"),
+            AnyCodingKey(0),
+        ]
+        try automergeEncoder.encode(sample, at: pathToTry)
+
+        XCTAssertNotNil(try doc.get(obj: ObjId.ROOT, key: "example"))
+        let foo = try doc.lookupPath(path: ".example.[0]")
+        XCTAssertNotNil(foo)
+
+        let decodedStruct = try automergeDecoder.decode(SimpleStruct.self, from: pathToTry)
+        XCTAssertEqual(decodedStruct, sample)
+    }
+}
+#endif

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -2,7 +2,7 @@ import Automerge
 import XCTest
 
 final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
-    func testSimpleKeyEncode() throws {
+    @MainActor func testSimpleKeyEncode() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -33,7 +33,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedStruct, sample)
     }
 
-    func testTargetedSingleValueDecode() throws {
+    @MainActor func testTargetedSingleValueDecode() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -66,7 +66,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decoded2.value, "Something wicked this way comes.")
     }
 
-    func testTargetedDecodeOfData() throws {
+    @MainActor func testTargetedDecodeOfData() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -78,7 +78,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedData, exampleData)
     }
 
-    func testTargetedDecodeOfDate() throws {
+    @MainActor func testTargetedDecodeOfDate() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -90,7 +90,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedDate, earlyDate)
     }
 
-    func testTargetedDecodeOfCounter() throws {
+    @MainActor func testTargetedDecodeOfCounter() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -102,7 +102,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedCounter, exampleCounter)
     }
 
-    func testTargetedDecodeOfInts() throws {
+    @MainActor func testTargetedDecodeOfInts() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -117,7 +117,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(Int32.self, from: [AnyCodingKey("int")]), 34)
     }
 
-    func testTargetedDecodeOfUInts() throws {
+    @MainActor func testTargetedDecodeOfUInts() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -132,7 +132,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(UInt32.self, from: [AnyCodingKey("int")]), 34)
     }
 
-    func testTargetedDecodeOfFloats() throws {
+    @MainActor func testTargetedDecodeOfFloats() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 
@@ -144,7 +144,7 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(Float.self, from: [AnyCodingKey("double")]), 3.4, accuracy: 0.1)
     }
 
-    func testTargetedDecodeOfOptionalInt() throws {
+    @MainActor func testTargetedDecodeOfOptionalInt() throws {
         let doc = Document()
         trackForMemoryLeak(instance: doc)
 

--- a/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
+++ b/Tests/AutomergeTests/CodableTests/AutomergeTargettedEncodeDecodeTests.swift
@@ -2,9 +2,8 @@ import Automerge
 import XCTest
 
 final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
-    @MainActor func testSimpleKeyEncode() throws {
+    func testSimpleKeyEncode() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         struct SimpleStruct: Codable, Equatable {
             let name: String
@@ -33,9 +32,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedStruct, sample)
     }
 
-    @MainActor func testTargetedSingleValueDecode() throws {
+    func testTargetedSingleValueDecode() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         struct SimpleStruct: Codable, Equatable {
             let name: String
@@ -66,9 +64,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decoded2.value, "Something wicked this way comes.")
     }
 
-    @MainActor func testTargetedDecodeOfData() throws {
+    func testTargetedDecodeOfData() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         let exampleData = Data("Hello".utf8)
         try doc.put(obj: ObjId.ROOT, key: "data", value: .Bytes(exampleData))
@@ -78,9 +75,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedData, exampleData)
     }
 
-    @MainActor func testTargetedDecodeOfDate() throws {
+    func testTargetedDecodeOfDate() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         let earlyDate = Date(timeIntervalSince1970: 0)
         try doc.put(obj: ObjId.ROOT, key: "date", value: .Timestamp(earlyDate))
@@ -90,9 +86,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedDate, earlyDate)
     }
 
-    @MainActor func testTargetedDecodeOfCounter() throws {
+    func testTargetedDecodeOfCounter() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         let exampleCounter = Counter(342)
         try doc.put(obj: ObjId.ROOT, key: "counter", value: .Counter(342))
@@ -102,9 +97,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(decodedCounter, exampleCounter)
     }
 
-    @MainActor func testTargetedDecodeOfInts() throws {
+    func testTargetedDecodeOfInts() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
 
@@ -117,9 +111,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(Int32.self, from: [AnyCodingKey("int")]), 34)
     }
 
-    @MainActor func testTargetedDecodeOfUInts() throws {
+    func testTargetedDecodeOfUInts() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         try doc.put(obj: ObjId.ROOT, key: "int", value: .Uint(34))
 
@@ -132,9 +125,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(UInt32.self, from: [AnyCodingKey("int")]), 34)
     }
 
-    @MainActor func testTargetedDecodeOfFloats() throws {
+    func testTargetedDecodeOfFloats() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         try doc.put(obj: ObjId.ROOT, key: "double", value: .F64(3.4))
 
@@ -144,9 +136,8 @@ final class AutomergeTargettedEncodeDecodeTests: XCTestCase {
         XCTAssertEqual(try automergeDecoder.decode(Float.self, from: [AnyCodingKey("double")]), 3.4, accuracy: 0.1)
     }
 
-    @MainActor func testTargetedDecodeOfOptionalInt() throws {
+    func testTargetedDecodeOfOptionalInt() throws {
         let doc = Document()
-        trackForMemoryLeak(instance: doc)
 
         try doc.put(obj: ObjId.ROOT, key: "int", value: .Int(34))
 

--- a/Tests/AutomergeTests/CodableTests/Samples.swift
+++ b/Tests/AutomergeTests/CodableTests/Samples.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public enum Samples {
-    public static var layered = ExampleModel(title: "Samples", notes: generateSampleNotes())
+    public static let layered = ExampleModel(title: "Samples", notes: generateSampleNotes())
 }
 
-public struct GeoLocation: Hashable, Codable {
+public struct GeoLocation: Hashable, Codable, Sendable {
     var latitude: Double
     var longitude: Double
     var altitude: Double?
@@ -20,7 +20,7 @@ public struct GeoLocation: Hashable, Codable {
     }
 }
 
-public struct Note: Hashable, Codable {
+public struct Note: Hashable, Codable, Sendable {
     var timestamp: Date
     var description: String
     var location: GeoLocation
@@ -34,7 +34,7 @@ public struct Note: Hashable, Codable {
     }
 }
 
-public struct ExampleModel: Codable, Equatable {
+public struct ExampleModel: Codable, Equatable, Sendable {
     var title: String
     var notes: [Note]
 

--- a/Tests/AutomergeTests/TestSync.swift
+++ b/Tests/AutomergeTests/TestSync.swift
@@ -2,7 +2,7 @@ import Automerge
 import XCTest
 
 class SyncTests: XCTestCase {
-    @MainActor func testSyncTwoDocs() {
+    func testSyncTwoDocs() {
         let doc1 = Document()
         let syncState1 = SyncState()
 

--- a/Tests/AutomergeTests/TestSync.swift
+++ b/Tests/AutomergeTests/TestSync.swift
@@ -2,7 +2,7 @@ import Automerge
 import XCTest
 
 class SyncTests: XCTestCase {
-    func testSyncTwoDocs() {
+    @MainActor func testSyncTwoDocs() {
         let doc1 = Document()
         trackForMemoryLeak(instance: doc1)
         let syncState1 = SyncState()

--- a/Tests/AutomergeTests/TestSync.swift
+++ b/Tests/AutomergeTests/TestSync.swift
@@ -4,11 +4,9 @@ import XCTest
 class SyncTests: XCTestCase {
     @MainActor func testSyncTwoDocs() {
         let doc1 = Document()
-        trackForMemoryLeak(instance: doc1)
         let syncState1 = SyncState()
 
         let doc2 = Document()
-        trackForMemoryLeak(instance: doc2)
         let syncState2 = SyncState()
 
         try! doc1.put(obj: ObjId.ROOT, key: "key1", value: .String("value1"))

--- a/Tests/AutomergeTests/TestWasmIntegrity.swift
+++ b/Tests/AutomergeTests/TestWasmIntegrity.swift
@@ -2,7 +2,6 @@ import Automerge
 import XCTest
 
 class WasmIntegriy: XCTestCase {
-
     func testTextValueEncodingBetweenPlatforms() throws {
         let doc = Document()
         let textId = try doc.putObject(obj: .ROOT, key: "text", ty: .Text)

--- a/Tests/AutomergeTests/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/AutomergeTests/XCTestCase+MemoryLeakTracking.swift
@@ -1,8 +1,7 @@
 import XCTest
 
 extension XCTestCase {
-    @MainActor
-    func trackForMemoryLeak(
+    @MainActor func trackForMemoryLeak(
         instance: AnyObject,
         file: StaticString = #filePath,
         line: UInt = #line

--- a/Tests/AutomergeTests/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/AutomergeTests/XCTestCase+MemoryLeakTracking.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 extension XCTestCase {
+    @MainActor
     func trackForMemoryLeak(
         instance: AnyObject,
         file: StaticString = #filePath,


### PR DESCRIPTION
# HOLD MERGE

Hold the merge until a new version of UniFFI is released to resolve the code generation issue. The PR I submitted to fix the issue we're seeing has been accepted, but further PRs are underway for a more complete UniFFI solution to generating safe Swift6 code.

(We could merge this as is, but then anyone regenerating the code with UniFFI would need to manually update that same `var` to a `let`, which doesn't make sense)

Work in progress to enable full compilation for Automerge-swift under Swift 6 language mode.

Most of this is good and ready to go, but there's a manual change I needed to make in `AutomergeUniffi/automerge.swift`, which is generated by UniFFI, that needs to be resolved before we can easily make this claim. 