### PR TITLE
Allow `uniffi_automerge` to be consumed as a crate dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 name = "uniffi_automerge"
 
 [[bin]]


### PR DESCRIPTION
Currently two static libraries generated by a Rust toolchain cannot be linked together in a single binary due to symbol conflicts (see https://github.com/rust-lang/rust/issues/104707). This is a problem for WebAssembly targets, where dynamic linking is not stable yet. To link multiple Rust-originated static libraries together, we need to produce a single static library from an umbrella crate that re-exports everything from its dependencies.

This change allows `uniffi_automerge` to be consumed as a crate dependency by the umbrella crate.