### PR TITLE
with the latest version of UniFFI, errors that it generates are alrea…

### DIFF
--- a/Sources/Automerge/Errors.swift
+++ b/Sources/Automerge/Errors.swift
@@ -29,17 +29,6 @@ public struct DocError: LocalizedError {
     }
 }
 
-extension FfiDocError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .WrongObjectType(message: msg):
-            return "WrongObjectType: \(msg)"
-        case let .Internal(message: msg):
-            return "AutomergeCore Internal Error: \(msg)"
-        }
-    }
-}
-
 /// An error that indicates the synchronisation state could not be decoded.
 ///
 /// The error is specific to the Rust language binding infrastructure.


### PR DESCRIPTION
…dy LocalizedErrors and don't need conformance in addition