### PR TITLE
point to v1.89.0 of the rust toolchain to resolve edition2024 build failure in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,6 @@ on:
     branches: [main]
 
 jobs:
-
   automerge-dependencies:
     runs-on: macos-14
     env:
@@ -30,7 +29,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.85.0
+          toolchain: 1.89.0
           default: true
       - name: Select Xcode 15.4
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
@@ -124,7 +123,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.85.0
+          toolchain: 1.89.0
           default: true
           components: rustfmt
       - name: Clippy
@@ -137,7 +136,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.85.0
+          toolchain: 1.89.0
           default: true
           components: clippy
       - name: Clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           default: true
       - name: Select Xcode 15.4
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
@@ -124,7 +124,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           default: true
           components: rustfmt
       - name: Clippy
@@ -137,7 +137,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.81.0
+          toolchain: 1.85.0
           default: true
           components: clippy
       - name: Clippy


### PR DESCRIPTION
## Fix: Update Rust toolchain to 1.85.0

A [CI build associated with another PR](https://github.com/automerge/automerge-swift/actions/runs/22075292710/job/63844355266) was failing the `clippy` job due to a transitive dependency (`crypto-common v0.2.0-rc.5`) requiring Cargo's `edition2024` feature, which was not stabilized until Rust 1.85.0.

```
error: failed to parse manifest at `crypto-common-0.2.0-rc.5/Cargo.toml`
Caused by:
  feature `edition2024` is required
  The package requires the Cargo feature called `edition2024`, but that feature
  is not stabilized in this version of Cargo (1.81.0)
```

Per the [Rust docs](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024), `edition2024` requires Rust 1.85.0+.

Furthermore, we actually need to bump to 1.89.0 due to an additional error (when attempting to run with 1.85.0):

```
error: rustc 1.85.0 is not supported by the following packages:
  automerge@0.7.2 requires rustc 1.89.0
  smol_str@0.3.4 requires rustc 1.89
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.85.0
```

### Changes

Updated the pinned Rust toolchain from `1.81.0` to `1.89.0` in all three CI jobs (`automerge-dependencies`, `rustfmt`, `clippy`).
